### PR TITLE
feat(pp8): Treasury integration, exports, Help Center and DEV login

### DIFF
--- a/e2e/pp8/treasury-catalogue-integration-mocks.ts
+++ b/e2e/pp8/treasury-catalogue-integration-mocks.ts
@@ -1,0 +1,197 @@
+import { Page } from '@playwright/test';
+
+export const CATALOGUE_ENTERPRISE_ID = 'enterprise-catalogue-test';
+
+const auxiliaryAccounts = {
+  auxiliaryAccounts: [
+    {
+      id: 1101,
+      code: '11100501',
+      description: 'Banco operativo',
+      nature: 'Debito',
+      financialStatus: 'Estado de Situacion Financiero',
+      classification: 'Activo Corriente',
+      parent: null,
+      children: [],
+      crossing: false,
+      costCenter: false,
+      status: true,
+    },
+    {
+      id: 2205,
+      code: '22050101',
+      description: 'CxP Proveedores',
+      nature: 'Credito',
+      financialStatus: 'Estado de Situacion Financiero',
+      classification: 'Pasivo Corriente',
+      parent: null,
+      children: [],
+      crossing: false,
+      costCenter: false,
+      status: true,
+    },
+    {
+      id: 5199,
+      code: '51999901',
+      description: 'Gasto inactivo',
+      nature: 'Debito',
+      financialStatus: 'Estado de Resultados',
+      classification: 'Gastos Operacionales',
+      parent: null,
+      children: [],
+      crossing: false,
+      costCenter: false,
+      status: false,
+    },
+  ],
+  totalCount: 3,
+  idEnterprise: CATALOGUE_ENTERPRISE_ID,
+};
+
+const paymentMethods = {
+  content: [
+    {
+      id: 8,
+      name: 'Transferencia activa',
+      accountingAccount: '11100501 - Banco operativo',
+      accountingAccountId: 1101,
+      status: true,
+      requiresBankAccount: true,
+    },
+    {
+      id: 9,
+      name: 'Metodo cuenta inactiva',
+      accountingAccount: '51999901 - Gasto inactivo',
+      accountingAccountId: 5199,
+      status: true,
+      requiresBankAccount: false,
+    },
+  ],
+};
+
+function fakeJwt(): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + 7200,
+      sub: 'playwright-catalogue',
+      authorization: {
+        permissions: [
+          { rsname: 'PM', scopes: ['C', 'U', 'R', 'L'] },
+          { rsname: 'AC', scopes: ['C', 'U', 'R', 'L', 'I', 'ET'] },
+        ],
+      },
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.playwright-signature`;
+}
+
+export async function bootstrapCatalogueTreasuryMocks(page: Page): Promise<void> {
+  const token = fakeJwt();
+
+  await page.addInitScript(
+    ({ enterpriseId, jwt }) => {
+      localStorage.setItem('token', jwt);
+      localStorage.setItem(
+        'entData',
+        JSON.stringify({
+          id: enterpriseId,
+          name: 'PP8 Catalogue Test',
+          nit: '900000002',
+          logo: '',
+          inventoryConfigType: 'WEIGHTED_AVERAGE',
+        }),
+      );
+    },
+    { enterpriseId: CATALOGUE_ENTERPRISE_ID, jwt: token },
+  );
+
+  await page.route('**/api/keycloak/getCurrentUser', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'playwright-catalogue-user',
+        username: 'playwright.catalogue',
+        email: 'playwright.catalogue@test.local',
+        roles: ['Administrador'],
+      }),
+    });
+  });
+
+  await page.route('**/api/payments/**', async (route) => {
+    if (route.request().url().includes('/expiring')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, code: 'NO_CONTENT', data: [] }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: [] }) });
+  });
+
+  await page.route('**/api/accountCatalogue/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('/auxiliary/')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(auxiliaryAccounts) });
+    }
+    if (url.includes('payment-methods/findAllActive')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(paymentMethods) });
+    }
+    if (url.includes('bank-accounts')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          content: [{ id: 501, accountNumber: '123456789', bank: { name: 'Banco Test' }, status: true }],
+        }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.route('**/api/treasury/**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname.endsWith('/payables/pending')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 101,
+            sourceInvoiceId: 50,
+            reference: 'FC-CAT-1',
+            enterpriseId: CATALOGUE_ENTERPRISE_ID,
+            supplierId: 77,
+            originalAmount: 50000,
+            paidAmount: 0,
+            pendingAmount: 50000,
+            reservedAmount: 0,
+            availableAmount: 50000,
+            issueDate: '2026-08-01',
+            originalDueDate: '2026-08-30',
+            dueDate: '2026-08-30',
+            payableAccountId: 2205,
+            payableAccountCode: '22050101',
+            active: true,
+            version: 0,
+          },
+        ]),
+      });
+    }
+    if (url.pathname.endsWith('/payment-vouchers')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: [], totalElements: 0, totalPages: 0, number: 0, size: 20 }),
+      });
+    }
+    if (url.pathname.endsWith('/payment-schedules')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+    if (url.pathname.endsWith('/payable-write-offs')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+}

--- a/e2e/pp8/treasury-catalogue-integration.spec.ts
+++ b/e2e/pp8/treasury-catalogue-integration.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { bootstrapCatalogueTreasuryMocks } from './treasury-catalogue-integration-mocks';
+
+test.beforeEach(async ({ page }) => {
+  await bootstrapCatalogueTreasuryMocks(page);
+});
+
+test('Tesorería oculta cuentas inactivas en baja de CxP y métodos con cuenta contable inactiva', async ({ page }) => {
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'FC-CAT-1' }).first()).toBeVisible({ timeout: 15_000 });
+
+  await page.locator('#counterpartAccount').click({ force: true });
+  await expect(page.getByRole('option', { name: /51999901/ })).toHaveCount(0);
+  await expect(page.getByRole('option', { name: /22050101/ })).toHaveCount(1);
+  await page.keyboard.press('Escape');
+
+  await page.locator('#paymentMethod').click({ force: true });
+  await expect(page.getByRole('option', { name: /Metodo cuenta inactiva/i })).toHaveCount(0);
+  await expect(page.getByRole('option', { name: /Transferencia activa/i })).toHaveCount(1);
+  await page.keyboard.press('Escape');
+});
+
+test('Crear método de pago solo lista cuentas auxiliares activas', async ({ page }) => {
+  await page.goto('/#/gen-masters/payment-methods/create');
+  await expect(page.getByRole('heading', { name: /Crear/i })).toBeVisible({ timeout: 15_000 });
+
+  await page.locator('.p-select').first().click({ force: true });
+  await expect(page.getByRole('option', { name: /51999901/ })).toHaveCount(0);
+  await expect(page.getByRole('option', { name: /11100501/ })).toHaveCount(1);
+  await expect(page.getByRole('option', { name: /22050101/ })).toHaveCount(1);
+});
+
+test('Método con requiere cuenta bancaria muestra selector bancario al pagar', async ({ page }) => {
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.locator('td', { hasText: 'FC-CAT-1' }).first()).toBeVisible({ timeout: 15_000 });
+
+  await expect(page.locator('#bankAccount')).toHaveCount(0);
+
+  await page.locator('#paymentMethod').click({ force: true });
+  await page.getByRole('option', { name: /Transferencia activa/i }).click();
+
+  await expect(page.locator('#bankAccount')).toBeVisible();
+});

--- a/e2e/pp8/treasury-export-mocks.ts
+++ b/e2e/pp8/treasury-export-mocks.ts
@@ -1,0 +1,291 @@
+import { Page } from '@playwright/test';
+
+export const EXPORT_ENTERPRISE_ID = 'enterprise-export-test';
+
+const payables = [
+  {
+    id: 101,
+    sourceInvoiceId: 50,
+    reference: 'FC-9001',
+    enterpriseId: EXPORT_ENTERPRISE_ID,
+    supplierId: 77,
+    originalAmount: 100000,
+    paidAmount: 0,
+    pendingAmount: 100000,
+    reservedAmount: 0,
+    availableAmount: 100000,
+    issueDate: '2026-08-01',
+    originalDueDate: '2026-08-30',
+    dueDate: '2026-08-30',
+    payableAccountId: 2205,
+    payableAccountCode: '2205',
+    active: true,
+    version: 0,
+  },
+];
+
+const vouchersPage = {
+  content: [
+    {
+      id: 501,
+      voucherNumber: 'CE-9001',
+      enterpriseId: EXPORT_ENTERPRISE_ID,
+      issueDate: '2026-08-10',
+      status: 'POSTED',
+      paymentMethodId: 8,
+      total: 40000,
+      observations: 'Pago Playwright',
+      accountingEntryId: 999,
+      version: 1,
+      details: [
+        {
+          id: 1,
+          supplierId: 77,
+          invoiceId: 101,
+          invoiceReference: 'FC-9001',
+          payableAccountId: 2205,
+          payableAccountCode: '2205',
+          previousBalance: 100000,
+          amountPaid: 40000,
+          remainingBalance: 60000,
+        },
+      ],
+    },
+  ],
+  totalElements: 1,
+  totalPages: 1,
+  number: 0,
+  size: 20,
+};
+
+const statement = {
+  supplierId: 77,
+  invoiced: 100000,
+  paid: 40000,
+  pending: 60000,
+  invoices: [
+    {
+      issueDate: '2026-08-01',
+      dueDate: '2026-08-30',
+      reference: 'FC-9001',
+      originalAmount: 100000,
+      pendingAmount: 60000,
+    },
+  ],
+  vouchers: [
+    {
+      issueDate: '2026-08-10',
+      voucherNumber: 'CE-9001',
+      observations: 'Pago Playwright',
+      details: [
+        {
+          supplierId: 77,
+          invoiceReference: 'FC-9001',
+          amountPaid: 40000,
+          remainingBalance: 60000,
+        },
+      ],
+    },
+  ],
+};
+
+const agingLines = [
+  {
+    supplierId: 77,
+    invoiceId: 101,
+    reference: 'FC-9001',
+    accountCode: '2205',
+    dueDate: '2026-08-30',
+    daysOverdue: 0,
+    current: 60000,
+    days1to30: 0,
+    days31to60: 0,
+    days61to90: 0,
+    days91Plus: 0,
+  },
+];
+
+function fakeJwt(): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 7200, sub: 'playwright-export' }),
+  ).toString('base64url');
+  return `${header}.${payload}.playwright-signature`;
+}
+
+export async function bootstrapTreasuryExportMocks(page: Page): Promise<void> {
+  const token = fakeJwt();
+
+  await page.addInitScript(() => {
+    (window as any).__pp8ExportBlobs = [] as number[];
+    const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    URL.createObjectURL = (obj: Blob | MediaSource) => {
+      if (obj instanceof Blob) {
+        (window as any).__pp8ExportBlobs.push(obj.size);
+      }
+      return originalCreateObjectURL(obj);
+    };
+
+    const style = document.createElement('style');
+    style.textContent = `
+      .p-toast, p-toast, .p-toast-message, [role="alert"], .p-message, p-message {
+        pointer-events: none !important;
+      }
+    `;
+    (document.head || document.documentElement).appendChild(style);
+  });
+
+  await page.addInitScript(
+    ({ enterpriseId, jwt }) => {
+      localStorage.setItem('token', jwt);
+      localStorage.setItem(
+        'entData',
+        JSON.stringify({
+          id: enterpriseId,
+          name: 'PP8 Export Test',
+          nit: '900000001',
+          logo: '',
+          inventoryConfigType: 'WEIGHTED_AVERAGE',
+        }),
+      );
+    },
+    { enterpriseId: EXPORT_ENTERPRISE_ID, jwt: token },
+  );
+
+  await page.route('**/api/keycloak/getCurrentUser', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'playwright-export-user',
+        username: 'playwright.export',
+        email: 'playwright.export@test.local',
+        roles: ['Administrador', 'Estudiante', 'Profesor'],
+      }),
+    });
+  });
+
+  await page.route('**/api/payments/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('/expiring')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, code: 'NO_CONTENT', data: [] }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: [] }) });
+  });
+
+  await page.route('**/api/treasury/**', async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname.endsWith('/payables/pending')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(payables) });
+    }
+    if (url.pathname.endsWith('/payment-vouchers')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(vouchersPage) });
+    }
+    if (url.pathname.includes('/payment-vouchers/')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(vouchersPage.content[0]) });
+    }
+    if (url.pathname.endsWith('/payment-schedules')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 601,
+            enterpriseId: EXPORT_ENTERPRISE_ID,
+            executionDate: '2026-08-15',
+            status: 'SCHEDULED',
+            paymentMethodId: 8,
+            total: 25000,
+            retryCount: 0,
+            voucherId: null,
+            details: [],
+          },
+        ]),
+      });
+    }
+    if (url.pathname.endsWith('/payable-write-offs')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 701, status: 'DRAFT', total: 10000, reason: 'Ajuste Playwright' },
+        ]),
+      });
+    }
+    if (url.pathname.endsWith('/reports/statement')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(statement) });
+    }
+    if (url.pathname.endsWith('/reports/aging')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(agingLines) });
+    }
+
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.route('**/api/thirds/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        content: [{ thId: 77, socialReason: 'Proveedor Playwright SA', names: '', lastNames: '' }],
+        totalElements: 1,
+      }),
+    });
+  });
+
+  await page.route('**/api/accountCatalogue/**', async (route) => {
+    const url = route.request().url();
+    if (url.includes('payment-methods')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          content: [{ id: 8, name: 'Transferencia', requiresBankAccount: false, status: true }],
+        }),
+      });
+    }
+    if (url.includes('bank-accounts')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: [] }),
+      });
+    }
+    if (url.includes('/auxiliary/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          auxiliaryAccounts: [
+            {
+              id: 2205,
+              code: '2205',
+              description: 'CxP Proveedores',
+              nature: 'Credito',
+              financialStatus: 'Pasivo',
+              classification: 'Auxiliar',
+              parent: null,
+              children: [],
+              crossing: false,
+              costCenter: false,
+              status: true,
+            },
+          ],
+        }),
+      });
+    }
+    if (url.includes('bankAccounts') || url.includes('bank-accounts')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: [] }),
+      });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+}

--- a/e2e/pp8/treasury-exports.spec.ts
+++ b/e2e/pp8/treasury-exports.spec.ts
@@ -1,0 +1,115 @@
+import { expect, Page, test } from '@playwright/test';
+import { bootstrapTreasuryExportMocks } from './treasury-export-mocks';
+
+test.describe.configure({ mode: 'serial' });
+
+async function clickExportAndVerify(page: Page, buttonName: string, ext: string): Promise<void> {
+  const button = page.getByRole('button', { name: buttonName });
+  await expect(button).toBeEnabled({ timeout: 60_000 });
+
+  if (/pdf/i.test(ext)) {
+    await page.locator('[role="alert"] button, .p-toast-close-button, button[aria-label="Close"]').first().click({ force: true, timeout: 2_000 }).catch(() => undefined);
+  }
+
+  const beforeBlobCount = await page.evaluate(() => ((window as any).__pp8ExportBlobs || []).length);
+
+  await page.evaluate((label) => {
+    const button = Array.from(document.querySelectorAll('button')).find((item) =>
+      item.textContent?.includes(label),
+    ) as HTMLButtonElement | undefined;
+    if (!button) {
+      throw new Error(`Botón no encontrado: ${label}`);
+    }
+    button.click();
+  }, buttonName);
+
+  await expect
+    .poll(async () => {
+      const blobs = await page.evaluate(() => (window as any).__pp8ExportBlobs || []);
+      if (blobs.length > beforeBlobCount) {
+        return blobs[blobs.length - 1] > 100 ? 'blob' : null;
+      }
+
+      const toastText = await page
+        .locator('.p-toast-detail, .p-toast-message-text, .p-toast-summary')
+        .allTextContents();
+      const hasSuccessToast = toastText.some(
+        (text) => new RegExp(ext, 'i').test(text) && !/Error|No se pudo/i.test(text),
+      );
+      return hasSuccessToast ? 'toast' : null;
+    }, { timeout: 30_000 })
+    .not.toBeNull();
+
+  await expect(page.locator('.p-toast-detail, .p-toast-message-text').filter({ hasText: /Error|No se pudo/i })).toHaveCount(0);
+  await expect(
+    page.locator('.p-toast-detail, .p-toast-message-text, .p-toast-summary').filter({ hasText: new RegExp(ext, 'i') }).first(),
+  ).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  page.on('pageerror', (error) => console.error('PAGE ERROR:', error.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') console.error('BROWSER LOG ERROR:', msg.text());
+  });
+  await bootstrapTreasuryExportMocks(page);
+});
+
+test('1. Operaciones de Tesorería exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'FC-9001' }).first()).toBeVisible({ timeout: 15_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});
+
+test('2. Programación de pagos exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/purchase-bills');
+  await expect(page.getByRole('heading', { name: /Programaci[oó]n Pagos de Factura/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'FC-9001' }).first()).toBeVisible({ timeout: 15_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});
+
+test('3. Comprobantes de egreso exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/expense-receipts');
+  await expect(page.getByRole('heading', { name: /Comprobantes de Egreso/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'CE-9001' }).first()).toBeVisible({ timeout: 15_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});
+
+test('4. Vencimiento por edades exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/reports/aging-report');
+  await expect(page.getByRole('heading', { name: /Vencimiento por edades/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'FC-9001' }).first()).toBeVisible({ timeout: 20_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});
+
+test('5. Reportes de proveedores (lista) exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/reports/vendors');
+  await expect(page.getByRole('heading', { name: /Reportes de Proveedores/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'Proveedor Playwright SA' }).first()).toBeVisible({ timeout: 20_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});
+
+test('6. Estado de cuenta por proveedor (detalle) exporta CSV y PDF', async ({ page }) => {
+  await page.goto('/#/financial/treasury/reports/vendor-report/77?name=Proveedor%20Playwright%20SA');
+  await expect(page.getByRole('heading', { name: /Estado de cuenta/i })).toBeVisible();
+  await expect(page.locator('td', { hasText: 'FC-9001' }).first()).toBeVisible({ timeout: 20_000 });
+
+  await clickExportAndVerify(page, 'Exportar CSV', 'csv');
+  await page.waitForTimeout(1200);
+  await clickExportAndVerify(page, 'Exportar PDF', 'pdf');
+});

--- a/playwright.pp8.config.ts
+++ b/playwright.pp8.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   retries: 0,
-  timeout: 120_000,
+  timeout: 300_000,
   expect: { timeout: 20_000 },
   reporter: [['list']],
   use: {

--- a/src/app/Core/auth/login/login.component.spec.ts
+++ b/src/app/Core/auth/login/login.component.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../services/auth.service';
+import { environment } from '../../../../environments/environment';
+
+describe('LoginComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: { login: () => ({ subscribe: () => undefined }) } },
+      ],
+    });
+  });
+
+  it('keeps password empty by default', () => {
+    const component = TestBed.createComponent(LoginComponent).componentInstance;
+    expect(component.loginForm.get('password')?.value).toBe('');
+  });
+
+  it('uses environment default username when configured', () => {
+    const component = TestBed.createComponent(LoginComponent).componentInstance;
+    expect(component.loginForm.get('username')?.value).toBe(environment.defaultLoginUsername ?? '');
+  });
+});

--- a/src/app/Core/auth/login/login.component.ts
+++ b/src/app/Core/auth/login/login.component.ts
@@ -1,47 +1,41 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AuthService } from '../services/auth.service';
 import { RouterModule } from '@angular/router';
 import { Router } from '@angular/router';
 import { Login } from '../models/login';
 import { ButtonModule } from 'primeng/button';
 import { PublicFooterComponent } from '../../../PublicSite/public-footer/public-footer.component';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-login',
-  imports: [ReactiveFormsModule,CommonModule, RouterModule, ButtonModule, PublicFooterComponent],
+  imports: [ReactiveFormsModule, CommonModule, RouterModule, ButtonModule, PublicFooterComponent],
   templateUrl: './login.component.html',
-  styleUrl: './login.component.css'
+  styleUrl: './login.component.css',
 })
 export class LoginComponent {
-  loginFail: boolean = false;
-  invalidForm: boolean = false;
+  loginFail = false;
+  invalidForm = false;
 
   authService: AuthService = inject(AuthService);
 
-  constructor(public router: Router,) {
-
-  }
+  constructor(public router: Router) {}
 
   loginForm = new FormGroup({
-    //! Valores por defecto servidor en desarrollo cambiar a '' en produccion
-    // PP8: usuario de demo local; la contraseña NO se versiona (usar env local).
-    username: new FormControl('pp8.professor', [Validators.required]),
+    username: new FormControl(environment.defaultLoginUsername ?? '', [Validators.required]),
     password: new FormControl('', [Validators.required]),
   });
 
   onSubmit() {
     if (!this.loginForm.valid) return;
 
-    //Cramos el objeto de tipo Login par enviar al servidor
     const login: Login = {
       username: this.loginForm.value.username || '',
       password: this.loginForm.value.password || '',
     };
 
     this.authService.login(login).subscribe();
-
   }
-
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
@@ -46,7 +46,7 @@ export class ExpenseReceiptAccountingComponent implements OnInit {
       this.receiptId = +idParam;
       this.loadAccountingEntries(this.receiptId);
     } else {
-      this.errorMessage = 'No se proporcionó un ID de comprobante.';
+      this.errorMessage = 'No se proporcionó el identificador del comprobante.';
     }
   }
 

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
@@ -6,6 +6,12 @@
         <h1 class="font-['Titillium_Web'] font-bold text-3xl text-[var(--color-primary)] border-b-4 border-[var(--color-secondary)] inline-block pb-1">
             Efectuar Pago
         </h1>
+        <app-contextual-help
+            class="ml-3 inline-flex align-middle"
+            [title]="help.title"
+            [summary]="help.summary"
+            [helpCenterSlug]="help.slug">
+        </app-contextual-help>
         <p class="mt-2 text-base text-gray-600">
             Seleccione el proveedor y las facturas a pagar. Esto generará un Comprobante de Egreso (documento contable de pago).
         </p>
@@ -29,6 +35,7 @@
                         field="name"
                         placeholder="Buscar proveedor..."
                         [dropdown]="true"
+                        [emptyMessage]="supplierAutocompleteEmptyMessage"
                         (onSelect)="onSupplierSelect($event)"
                         [ngClass]="{'ng-invalid ng-dirty': expenseReceiptForm.get('supplier')?.invalid && expenseReceiptForm.get('supplier')?.touched}">
                     </p-autoComplete>
@@ -152,7 +159,7 @@
                         [ngClass]="{'ng-invalid ng-dirty': expenseReceiptForm.get('postToAccount')?.invalid && expenseReceiptForm.get('postToAccount')?.touched}">
                     </p-dropdown>
                     @if (expenseReceiptForm.get('postToAccount')?.touched && expenseReceiptForm.get('postToAccount')?.invalid) {
-                        <small class="p-error error-message">La cuenta Post To es requerida.</small>
+                        <small class="p-error error-message">La cuenta por pagar es requerida.</small>
                     }
                     <small class="text-gray-500">Solo cuentas de proveedores / pasivo corriente (CxP)</small>
                 </div>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.spec.ts
@@ -1,0 +1,40 @@
+import { ExpenseReceiptCreationComponent } from './expense-receipt-creation.component';
+
+describe('ExpenseReceiptCreationComponent payment validation', () => {
+  function component() {
+    const value = Object.create(ExpenseReceiptCreationComponent.prototype) as ExpenseReceiptCreationComponent;
+    value.selectedInvoices = [{ id: 1 }];
+    value.requiresBankAccount = false;
+    value.expenseReceiptForm = {
+      get: (name: string) => ({
+        valid: true,
+        value: name === 'bankAccountId' ? null : 'ok',
+      }),
+    } as any;
+    return value;
+  }
+
+  it('rejects submission when bank account is set but method does not require it', () => {
+    const value = component();
+    value.expenseReceiptForm.get = ((name: string) => ({
+      valid: true,
+      value: name === 'bankAccountId' ? 10 : 'ok',
+    })) as any;
+    expect(value.isFormValidForSubmission()).toBeFalse();
+  });
+
+  it('accepts submission when bank is omitted for non-bank methods', () => {
+    const value = component();
+    expect(value.isFormValidForSubmission()).toBeTrue();
+  });
+
+  it('requires bank account when method demands it', () => {
+    const value = component();
+    value.requiresBankAccount = true;
+    value.expenseReceiptForm.get = ((name: string) => ({
+      valid: name !== 'bankAccountId',
+      value: null,
+    })) as any;
+    expect(value.isFormValidForSubmission()).toBeFalse();
+  });
+});

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
@@ -25,6 +25,14 @@ import { PurchaseInvoice } from '../../Model/Models';
 import { ExpenseReceiptCreateRequest } from '../../Model/ExpenseReceiptCreateRequest';
 import { ChartAccountService } from '../../../../../GeneralMasters/AccountCatalogue/services/chart-account.service';
 import { BankAccountsService, BankAccount } from '../../../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
+import { forkJoin } from 'rxjs';
+import {
+  buildActiveAccountIdSet,
+  filterSelectablePaymentMethods,
+} from '../../../Shared/treasury-account.integration';
+import { translatePaymentMethodName } from '../../../Shared/treasury-status-labels';
+import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
 
 // Modelos adicionales para el frontend
 interface DropdownOption {
@@ -57,6 +65,7 @@ interface Supplier {
     MessagesModule,
     FormsModule,
     CardModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './expense-receipt-creation.component.html',
   styleUrl: './expense-receipt-creation.component.css',
@@ -74,6 +83,11 @@ export class ExpenseReceiptCreationComponent {
   receiptTypeOptions: DropdownOption[] = [];
   auxiliaryAccounts: DropdownOption[] = [];
   requiresBankAccount = false;
+  readonly help = TREASURY_HELP.makePayment;
+  readonly supplierEmptyMessage = 'No hay proveedores con facturas pendientes';
+  readonly supplierFilterEmptyMessage = 'No se encontraron proveedores que coincidan con la búsqueda';
+  supplierSearchQuery = '';
+  allSuppliersCount = 0;
 
   // Para Autocomplete de Proveedor
   suppliers: Supplier[] = [];
@@ -118,6 +132,9 @@ export class ExpenseReceiptCreationComponent {
   ngOnInit(): void {
     this.initializeForm();
     this.loadDropdownOptions();
+    this.expenseReceiptService.getSuppliers('').subscribe((suppliers) => {
+      this.allSuppliersCount = suppliers.length;
+    });
     this.updateTotalAmount();
     this.subscribeToFormChanges();
 
@@ -181,13 +198,20 @@ export class ExpenseReceiptCreationComponent {
       return;
     }
 
-    // Métodos de pago reales de la empresa (solo activos)
-    this.paymentMethodService.findAllActive(enterpriseId).subscribe({
-      next: (page) => {
-        this.paymentMethods = (page.content || []).filter(m => m.status !== false);
-        this.paymentMethodOptions = this.paymentMethods.map(method => ({
+    // Métodos de pago con cuenta contable activa en catálogo
+    forkJoin({
+      methods: this.paymentMethodService.findAllActive(enterpriseId),
+      accounts: this.chartAccountService.getListAuxiliaryAccounts(enterpriseId),
+    }).subscribe({
+      next: ({ methods, accounts }) => {
+        const activeAccountIds = buildActiveAccountIdSet(accounts);
+        this.paymentMethods = filterSelectablePaymentMethods(
+          (methods.content || []).filter((method) => method.status !== false),
+          activeAccountIds,
+        );
+        this.paymentMethodOptions = this.paymentMethods.map((method) => ({
           id: method.id!,
-          label: `${method.name} (${method.accountingAccount})`,
+          label: `${translatePaymentMethodName(method.name)} (${method.accountingAccount})`,
           requiresBankAccount: Boolean(method.requiresBankAccount),
         }));
       },
@@ -200,7 +224,7 @@ export class ExpenseReceiptCreationComponent {
           summary: 'Métodos de pago',
           detail: 'No se pudieron cargar los métodos de pago de la empresa.',
         });
-      }
+      },
     });
 
     // Cuentas bancarias reales (para Cheque / Transferencia)
@@ -324,9 +348,20 @@ export class ExpenseReceiptCreationComponent {
 
   // Autocompletado de proveedores
   searchSupplier(event: any): void {
-    this.expenseReceiptService.getSuppliers(event.query).subscribe(data => {
+    this.supplierSearchQuery = String(event.query || '').trim();
+    this.expenseReceiptService.getSuppliers(this.supplierSearchQuery).subscribe((data) => {
       this.filteredSuppliers = data;
+      if (!this.supplierSearchQuery) {
+        this.allSuppliersCount = data.length;
+      }
     });
+  }
+
+  get supplierAutocompleteEmptyMessage(): string {
+    if (this.allSuppliersCount === 0) {
+      return this.supplierEmptyMessage;
+    }
+    return this.supplierFilterEmptyMessage;
   }
 
   formatCurrency(amount: number): string {
@@ -417,12 +452,14 @@ export class ExpenseReceiptCreationComponent {
   }
 
   isFormValidForSubmission(): boolean {
-    // Validar que se haya seleccionado al menos una factura
     if (this.selectedInvoices.length === 0) {
       return false;
     }
 
-    // Validar los campos del formulario
+    if (!this.requiresBankAccount && this.expenseReceiptForm.get('bankAccountId')?.value) {
+      return false;
+    }
+
     const basicValidation = this.expenseReceiptForm.get('supplier')?.valid &&
                            this.expenseReceiptForm.get('postToAccount')?.valid &&
                            this.expenseReceiptForm.get('transferAccount')?.valid &&
@@ -451,12 +488,17 @@ export class ExpenseReceiptCreationComponent {
     }
 
     if (!this.isFormValidForSubmission()) {
+      const bankValue = this.expenseReceiptForm.get('bankAccountId')?.value;
+      let detail = 'Por favor, complete todos los campos requeridos.';
+      if (this.requiresBankAccount && !bankValue) {
+        detail = 'El método de pago exige una cuenta bancaria.';
+      } else if (!this.requiresBankAccount && bankValue) {
+        detail = 'El método seleccionado no admite cuenta bancaria.';
+      }
       this.messageService.add({
         severity: 'error',
         summary: 'Error de Validación',
-        detail: this.requiresBankAccount && !this.expenseReceiptForm.get('bankAccountId')?.value
-          ? 'El método de pago exige una cuenta bancaria.'
-          : 'Por favor, complete todos los campos requeridos.'
+        detail,
       });
       return;
     }
@@ -469,7 +511,7 @@ export class ExpenseReceiptCreationComponent {
       this.messageService.add({
         severity: 'error',
         summary: 'Error de Configuración',
-        detail: 'No se encontró el ID de la empresa. Por favor, inicie sesión de nuevo.'
+        detail: 'No se encontró el identificador de la empresa. Por favor, inicie sesión de nuevo.'
       });
       return;
     }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
@@ -43,7 +43,7 @@ export class ExpenseReceiptDetailsComponent {
       const receiptId = +idParam; // El '+' convierte el string a número
       this.loadReceiptDetails(receiptId);
     } else {
-      this.errorMessage = 'No se proporcionó un ID de comprobante.';
+      this.errorMessage = 'No se proporcionó el identificador del comprobante.';
     }
   }
 

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.html
@@ -1,16 +1,33 @@
 <div class="container-fluid p-4">
   <div class="flex justify-between items-center mb-6">
     <div>
-      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2">Comprobantes de Egreso</h1>
+      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Comprobantes de Egreso</h1>
+      <app-contextual-help
+        class="ml-2 inline-flex align-middle"
+        [title]="help.title"
+        [summary]="help.summary"
+        [helpCenterSlug]="help.slug">
+      </app-contextual-help>
       <p class="text-gray-600">Consulte y gestione los pagos realizados a proveedores</p>
     </div>
     <div class="flex gap-2">
       <p-button
-        label="Exportar CSV"
-        icon="pi pi-download"
-        severity="secondary"
+        label="Exportar PDF"
+        icon="pi pi-file-pdf"
+        severity="danger"
+        [outlined]="true"
+        [loading]="exportingPdf"
         [disabled]="!filteredReceipts.length"
-        (onClick)="onExportData()">
+        (onClick)="exportToPdf()">
+      </p-button>
+      <p-button
+        label="Exportar CSV"
+        icon="pi pi-file-excel"
+        severity="success"
+        [outlined]="true"
+        [loading]="exportingCsv"
+        [disabled]="!filteredReceipts.length"
+        (onClick)="exportToCsv()">
       </p-button>
       <p-button
         label="Efectuar Pago"
@@ -235,7 +252,7 @@
                 <p class="text-lg font-semibold text-gray-600 mb-2">No se encontraron comprobantes</p>
                 <p class="text-gray-500">
                   {{ allReceipts.length > 0
-                    ? 'Intente ajustar los filtros de búsqueda'
+                    ? emptyFiltersMessage
                     : 'Comience creando su primer comprobante de egreso' }}
                 </p>
               </div>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
@@ -15,7 +15,10 @@ import { TagModule } from 'primeng/tag';
 import { MessageService } from 'primeng/api';
 import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
 import { DropdownOption, ExpenseReceiptView, ReceiptFilterOption } from '../../Model/Models';
-import { voucherStatusFilterOptions } from '../../../Shared/treasury-status-labels';
+import { exportErrorDetail, exportSuccessDetail, reportEmptyFiltersMessage, voucherStatusFilterOptions } from '../../../Shared/treasury-status-labels';
+import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
+import { TreasuryExportService } from '../../../Shared/treasury-export.service';
 
 @Component({
   selector: 'app-expense-receipts-list',
@@ -34,6 +37,7 @@ import { voucherStatusFilterOptions } from '../../../Shared/treasury-status-labe
     CardModule,
     ToastModule,
     TagModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './expense-receipts-list.component.html',
   styleUrls: ['./expense-receipts-list.component.css'],
@@ -50,12 +54,17 @@ export class ExpenseReceiptsListComponent implements OnInit {
   allReceiptCodeOptions: ReceiptFilterOption[] = [];
 
   statusOptions: DropdownOption[] = voucherStatusFilterOptions();
+  readonly emptyFiltersMessage = reportEmptyFiltersMessage();
+  readonly help = TREASURY_HELP.expenseReceipts;
+  exportingPdf = false;
+  exportingCsv = false;
 
   constructor(
     private fb: FormBuilder,
     private router: Router,
     private expenseReceiptService: ExpenseReceiptService,
     private messageService: MessageService,
+    private exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
@@ -219,13 +228,13 @@ export class ExpenseReceiptsListComponent implements OnInit {
       case 'pagado':
       case 'completado':
         return 'success';
-      case 'sin contabilizar':
+      case 'borrador':
       case 'contabilizando':
       case 'pendiente':
         return 'warning';
       case 'anulado':
-      case 'no se pudo contabilizar':
-      case 'no se pudo anular':
+      case 'fallido':
+      case 'anulación fallida':
       case 'anulando':
       case 'cancelado':
         return 'danger';
@@ -271,40 +280,62 @@ export class ExpenseReceiptsListComponent implements OnInit {
     }).format(new Date(date));
   }
 
-  onExportData(): void {
+  exportToCsv(): void {
+    this.runExport('csv');
+  }
+
+  exportToPdf(): void {
+    this.runExport('pdf');
+  }
+
+  private runExport(format: 'csv' | 'pdf'): void {
     if (!this.filteredReceipts.length) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Sin datos',
-        detail: 'No hay comprobantes para exportar con los filtros actuales.',
+        detail: this.emptyFiltersMessage,
       });
       return;
     }
 
-    const header = ['Código', 'Fecha', 'Proveedor', 'Total', 'Estado'].join(',');
-    const rows = this.filteredReceipts.map((r) =>
-      [
-        r.receiptCode,
-        this.formatDate(r.issueDate),
-        `"${r.supplierName}"`,
-        r.totalAmount,
-        r.status,
-      ].join(','),
-    );
-    const blob = new Blob([[header, ...rows].join('\n')], {
-      type: 'text/csv;charset=utf-8;',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `comprobantes-egreso-${new Date().toISOString().slice(0, 10)}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
+    const headers = ['Código', 'Fecha', 'Proveedor', 'Total', 'Estado'];
+    const rows = this.filteredReceipts.map((receipt) => [
+      receipt.receiptCode,
+      this.formatDate(receipt.issueDate),
+      receipt.supplierName,
+      receipt.totalAmount,
+      receipt.status,
+    ]);
+    const options = {
+      title: 'Comprobantes de egreso',
+      subtitle: `${rows.length} comprobante(s) exportado(s)`,
+      filename: this.exportService.datedFilename('comprobantes-egreso', format),
+      headers,
+      rows,
+    };
 
-    this.messageService.add({
-      severity: 'success',
-      summary: 'Exportado',
-      detail: 'Se descargó el CSV de comprobantes.',
-    });
+    const loadingFlag = format === 'csv' ? 'exportingCsv' : 'exportingPdf';
+    this[loadingFlag] = true;
+    try {
+      if (format === 'csv') {
+        this.exportService.downloadCsv(options);
+      } else {
+        this.exportService.downloadPdf(options);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('comprobantes', format),
+      });
+    } catch (error) {
+      console.error(`Error al exportar ${format}:`, error);
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: exportErrorDetail(format),
+      });
+    } finally {
+      this[loadingFlag] = false;
+    }
   }
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -11,7 +11,8 @@ import { ExpenseReceiptResponse } from '../Model/ExpenseReceiptResponse';
 import { ExpenseReceiptCreateRequest } from '../Model/ExpenseReceiptCreateRequest';
 import { AccountingEntryLine } from '../Model/AccountingEntryLine';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
-import { educationalDescription, voucherStatusLabel } from '../../Shared/treasury-status-labels';
+import { educationalDescription, translatePaymentMethodName, voucherStatusLabel } from '../../Shared/treasury-status-labels';
+import { buildThirdPartyNameMap, resolveSupplierName } from '../../Shared/treasury-third-party.integration';
 
 @Injectable({ providedIn: 'root' })
 export class ExpenseReceiptService {
@@ -44,14 +45,32 @@ export class ExpenseReceiptService {
   }
 
   getSuppliers(query = ''): Observable<Supplier[]> {
-    return forkJoin({ payables: this.api.pending(this.enterpriseId()), thirds: this.thirds.getThirdParties(this.enterpriseId(), 0, 1000) }).pipe(map(({ payables, thirds }) => {
-      const ids = [...new Set(payables.map(item => item.supplierId))];
-      return ids.map(id => { const third = thirds.content.find(item => item.thId === id); return ({ id, name: third?.socialReason || [third?.names, third?.lastNames].filter(Boolean).join(' ') || `Proveedor ${id}`, accountsPayableAccount: {
-        id: payables.find(item => item.supplierId === id)!.payableAccountId,
-        code: payables.find(item => item.supplierId === id)!.payableAccountCode,
-        name: payables.find(item => item.supplierId === id)!.payableAccountCode,
-      }}); }).filter(supplier => supplier.name.toLowerCase().includes(query.toLowerCase()));
-    }));
+    const enterpriseId = this.enterpriseId();
+    return forkJoin({
+      payables: this.api.pending(enterpriseId),
+      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(
+        catchError(() => of({ content: [] } as any)),
+      ),
+    }).pipe(
+      map(({ payables, thirds }) => {
+        const thirdNames = buildThirdPartyNameMap(thirds?.content || []);
+        const ids = [...new Set(payables.map((item) => item.supplierId))];
+        return ids
+          .map((id) => {
+            const payable = payables.find((item) => item.supplierId === id)!;
+            return {
+              id,
+              name: resolveSupplierName(thirdNames, id),
+              accountsPayableAccount: {
+                id: payable.payableAccountId,
+                code: payable.payableAccountCode,
+                name: payable.payableAccountCode,
+              },
+            };
+          })
+          .filter((supplier) => supplier.name.toLowerCase().includes(query.toLowerCase()));
+      }),
+    );
   }
 
   getSupplierById(id: number): Observable<Supplier | undefined> {
@@ -112,26 +131,38 @@ export class ExpenseReceiptService {
     );
   }
   getExpenseReceiptById(id: number): Observable<ExpenseReceiptDetailsView> {
-    return this.api.voucher(id, this.enterpriseId()).pipe(map(voucher => ({
-      id: voucher.id,
-      receiptCode: voucher.voucherNumber,
-      issueDate: new Date(voucher.issueDate),
-      thirdPartyId: voucher.details[0]?.supplierId ?? 0,
-      supplierName: `Proveedor ${voucher.details[0]?.supplierId ?? ''}`,
-      paymentMethodName: `Método ${voucher.paymentMethodId}`,
-      status: voucherStatusLabel(voucher.status),
-      statusKey: voucher.status,
-      totalAmount: voucher.total,
-      observations: educationalDescription(voucher.observations, ''),
-      isDirectExpense: false,
-      details: voucher.details.map(detail => ({
-        invoiceId: detail.invoiceId,
-        amountPaid: detail.amountPaid,
-        invoiceCode: detail.invoiceReference,
-        accountingAccount: detail.payableAccountId,
-      })),
-      accountingEntry: undefined,
-    })));
+    const enterpriseId = this.enterpriseId();
+    return forkJoin({
+      voucher: this.api.voucher(id, enterpriseId),
+      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
+      methods: this.paymentMethods.findAll(this.enterpriseId(), 0, 100).pipe(catchError(() => of({ content: [] } as any))),
+    }).pipe(
+      map(({ voucher, thirds, methods }) => {
+        const thirdNames = buildThirdPartyNameMap(thirds?.content || []);
+        const supplierId = voucher.details[0]?.supplierId ?? 0;
+        const method = (methods.content || []).find((item: any) => item.id === voucher.paymentMethodId);
+        return {
+          id: voucher.id,
+          receiptCode: voucher.voucherNumber,
+          issueDate: new Date(voucher.issueDate),
+          thirdPartyId: supplierId,
+          supplierName: resolveSupplierName(thirdNames, supplierId),
+          paymentMethodName: translatePaymentMethodName(method?.name) || `Método ${voucher.paymentMethodId}`,
+          status: voucherStatusLabel(voucher.status),
+          statusKey: voucher.status,
+          totalAmount: voucher.total,
+          observations: educationalDescription(voucher.observations, ''),
+          isDirectExpense: false,
+          details: voucher.details.map((detail) => ({
+            invoiceId: detail.invoiceId,
+            amountPaid: detail.amountPaid,
+            invoiceCode: detail.invoiceReference,
+            accountingAccount: detail.payableAccountId,
+          })),
+          accountingEntry: undefined,
+        };
+      }),
+    );
   }
 
   createExpenseReceipt(request: ExpenseReceiptCreateRequest): Observable<ExpenseReceiptResponse> {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -1,10 +1,35 @@
 <div class="container-fluid p-4">
+  <p-toast></p-toast>
   <div class="flex justify-between items-center mb-6">
     <div>
-      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2">Operaciones de Tesorería</h1>
+      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Operaciones de Tesorería</h1>
+      <app-contextual-help
+        class="ml-2 inline-flex align-middle"
+        [title]="help.title"
+        [summary]="help.summary"
+        [helpCenterSlug]="help.slug">
+      </app-contextual-help>
       <p class="text-gray-600">Gestione obligaciones pendientes, borradores de pago, programaciones y bajas de CxP</p>
     </div>
     <div class="flex gap-2">
+      <p-button
+        label="Exportar PDF"
+        icon="pi pi-file-pdf"
+        severity="danger"
+        [outlined]="true"
+        [loading]="exportingPdf"
+        [disabled]="!hasExportData || busy"
+        (onClick)="exportToPdf()">
+      </p-button>
+      <p-button
+        label="Exportar CSV"
+        icon="pi pi-file-excel"
+        severity="success"
+        [outlined]="true"
+        [loading]="exportingCsv"
+        [disabled]="!hasExportData || busy"
+        (onClick)="exportToCsv()">
+      </p-button>
       <p-button
         label="Actualizar"
         icon="pi pi-refresh"
@@ -144,8 +169,8 @@
         <p-dropdown
           id="paymentMethod"
           [(ngModel)]="paymentMethodId"
-          [options]="methods"
-          optionLabel="name"
+          [options]="methodOptions"
+          optionLabel="label"
           optionValue="id"
           placeholder="Seleccione"
           [showClear]="true"
@@ -429,7 +454,7 @@
       currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} bajas">
       <ng-template pTemplate="header">
         <tr>
-          <th>ID</th>
+          <th>N.º</th>
           <th>Estado</th>
           <th class="text-right">Total</th>
           <th>Motivo</th>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -5,7 +5,22 @@ describe('TreasuryOperationsComponent PP8', () => {
   function component() {
     const api = { createVoucher: jasmine.createSpy('createVoucher').and.returnValue(NEVER) };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
-    const value = new TreasuryOperationsComponent(api as any, storage as any, {} as any, {} as any, {} as any);
+    const exportService = {
+      datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
+      downloadCsvSections: jasmine.createSpy('downloadCsvSections'),
+      downloadPdfSections: jasmine.createSpy('downloadPdfSections'),
+    };
+    const messageService = { add: jasmine.createSpy('add') };
+    const value = new TreasuryOperationsComponent(
+      api as any,
+      storage as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      exportService as any,
+      messageService as any,
+    );
     value.payables = [{
       id: 11, sourceInvoiceId: 50, reference: 'FC-50', enterpriseId: 'enterprise-a', supplierId: 7,
       originalAmount: 100, paidAmount: 0, pendingAmount: 100, reservedAmount: 0, availableAmount: 100,
@@ -15,7 +30,9 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.selected.add(11);
     value.amounts[11] = 25;
     value.paymentMethodId = 1;
-    value.methods = [{ id: 1, requiresBankAccount: true }];
+    value.methods = [{ id: 1, requiresBankAccount: true, accountingAccountId: 10 }];
+    value.accounts = [{ id: 100, code: '519999', description: 'Gasto', status: true }];
+    value.accountOptions = [{ id: 100, label: '519999 - Gasto' }];
     return { value, api };
   }
 
@@ -34,5 +51,37 @@ describe('TreasuryOperationsComponent PP8', () => {
       enterpriseId: 'enterprise-a', paymentMethodId: 1, bankAccountId: 33,
       details: [{ supplierId: 7, invoiceId: 11, amount: 25 }]
     }));
+  });
+
+  it('builds write-off options only with active accounts', () => {
+    const { value } = component();
+    const allAccounts = [
+      { id: 1, code: '111', description: 'Activa', status: true },
+      { id: 2, code: '222', description: 'Inactiva', status: false },
+    ] as any[];
+    value.accounts = allAccounts.filter((account) => account.status !== false);
+    value.accountOptions = value.accounts.map((account: any) => ({
+      id: account.id,
+      label: `${account.code} - ${account.description}`,
+    }));
+    expect(value.accountOptions.map((option) => option.id)).toEqual([1]);
+  });
+
+  it('exports operations to csv when data is available', () => {
+    const { value } = component();
+    const exportService = (value as any).exportService;
+    value.vouchers = [{
+      id: 1,
+      voucherNumber: 'CE-1',
+      issueDate: '2026-08-01',
+      status: 'POSTED',
+      total: 25,
+      paymentMethodId: 1,
+      enterpriseId: 'enterprise-a',
+      version: 0,
+      details: [],
+    }];
+    value.exportToCsv();
+    expect(exportService.downloadCsvSections).toHaveBeenCalled();
   });
 });

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1,7 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { CheckboxModule } from 'primeng/checkbox';
@@ -12,18 +13,32 @@ import { MessageModule } from 'primeng/message';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
 import { LocalStorageMethods } from '../../../Shared/Methods/local-storage.method';
 import { PaymentMethodsServiceService } from '../../../GeneralMasters/PaymentMethods/services/payment-methods-service.service';
 import { ChartAccountService } from '../../../GeneralMasters/AccountCatalogue/services/chart-account.service';
 import { BankAccountsService } from '../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
+import { ThirdService } from '../../../GeneralMasters/ThirdParties/Services/third.service';
 import { TreasuryApiService } from '../Shared/treasury-api.service';
 import { Payable, PaymentSchedule, PaymentVoucher } from '../Shared/treasury-api.models';
 import {
   accountingEntryStatusLabel,
+  exportErrorDetail,
+  exportSuccessDetail,
   scheduleStatusLabel,
+  translatePaymentMethodName,
   voucherStatusFilterOptions,
   voucherStatusLabel,
 } from '../Shared/treasury-status-labels';
+import { TreasuryExportService } from '../Shared/treasury-export.service';
+import {
+  buildActiveAccountIdSet,
+  filterSelectablePaymentMethods,
+} from '../Shared/treasury-account.integration';
+import { buildThirdPartyNameMap, resolveSupplierName } from '../Shared/treasury-third-party.integration';
+import { ContextualHelpComponent } from '../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../Shared/treasury-help-content';
 
 @Component({
   selector: 'app-treasury-operations',
@@ -40,10 +55,13 @@ import {
     MessageModule,
     TableModule,
     TagModule,
-    TooltipModule
+    TooltipModule,
+    ToastModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './treasury-operations.component.html',
-  styleUrl: './treasury-operations.component.css'
+  styleUrl: './treasury-operations.component.css',
+  providers: [MessageService],
 })
 export class TreasuryOperationsComponent implements OnInit {
   payables: Payable[] = [];
@@ -51,6 +69,7 @@ export class TreasuryOperationsComponent implements OnInit {
   schedules: PaymentSchedule[] = [];
   writeOffs: any[] = [];
   methods: any[] = [];
+  methodOptions: { id: number; label: string }[] = [];
   banks: any[] = [];
   accounts: any[] = [];
   bankOptions: { id: number; label: string }[] = [];
@@ -72,6 +91,10 @@ export class TreasuryOperationsComponent implements OnInit {
   accountingMovements: { account: string; description: string; debit: number; credit: number }[] = [];
   accountingDebitTotal = 0;
   accountingCreditTotal = 0;
+  exportingPdf = false;
+  exportingCsv = false;
+  readonly help = TREASURY_HELP.operations;
+  private supplierNames = new Map<number, string>();
 
   readonly voucherStatusOptions = voucherStatusFilterOptions();
 
@@ -87,7 +110,10 @@ export class TreasuryOperationsComponent implements OnInit {
     private readonly storage: LocalStorageMethods,
     private readonly paymentMethods: PaymentMethodsServiceService,
     private readonly chart: ChartAccountService,
-    private readonly bankAccounts: BankAccountsService
+    private readonly bankAccounts: BankAccountsService,
+    private readonly thirds: ThirdService,
+    private readonly exportService: TreasuryExportService,
+    private readonly messageService: MessageService,
   ) {
     this.enterpriseId = this.storage.getIdEnterprise();
   }
@@ -111,14 +137,17 @@ export class TreasuryOperationsComponent implements OnInit {
       writeOffs: this.api.writeOffs(this.enterpriseId),
       methods: this.paymentMethods.findAllActive(this.enterpriseId),
       banks: this.bankAccounts.findAllActive(this.enterpriseId),
-      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId)
+      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId),
+      thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(
+        catchError(() => of({ content: [] } as any)),
+      ),
     }).subscribe({
       next: data => {
         this.payables = data.payables;
+        this.supplierNames = buildThirdPartyNameMap(data.thirds?.content || []);
         this.vouchers = data.vouchers.content;
         this.schedules = data.schedules;
         this.writeOffs = data.writeOffs;
-        this.methods = data.methods.content;
         this.banks = data.banks.content;
         this.bankOptions = this.banks.map((bank: any) => ({
           id: bank.id,
@@ -128,6 +157,20 @@ export class TreasuryOperationsComponent implements OnInit {
         this.accountOptions = this.accounts.map((account: any) => ({
           id: account.id,
           label: `${account.code} - ${account.description}`
+        }));
+        const activeAccountIds = buildActiveAccountIdSet(data.accounts);
+        this.methods = filterSelectablePaymentMethods(
+          data.methods.content,
+          activeAccountIds,
+          this.paymentMethodId ?? null,
+        );
+        if (this.paymentMethodId && !this.methods.some((method) => method.id === this.paymentMethodId)) {
+          const preserved = data.methods.content.find((method: any) => method.id === this.paymentMethodId);
+          if (preserved) this.methods = [preserved, ...this.methods];
+        }
+        this.methodOptions = this.methods.map((method) => ({
+          id: method.id,
+          label: translatePaymentMethodName(method.name),
         }));
         this.payables.forEach(p => this.amounts[p.id] ??= p.availableAmount);
         this.busy = false;
@@ -183,15 +226,15 @@ export class TreasuryOperationsComponent implements OnInit {
 
   private paymentSelectionValid(): boolean {
     if (!this.paymentMethodId) {
-      this.error = 'Seleccione un metodo de pago activo.';
+      this.error = 'Seleccione un método de pago activo.';
       return false;
     }
     if (this.requiresBankAccount && !this.bankAccountId) {
-      this.error = 'El metodo seleccionado exige una cuenta bancaria.';
+      this.error = 'El método seleccionado exige una cuenta bancaria.';
       return false;
     }
     if (!this.requiresBankAccount && this.bankAccountId) {
-      this.error = 'El metodo seleccionado no admite cuenta bancaria.';
+      this.error = 'El método seleccionado no admite cuenta bancaria.';
       return false;
     }
     return true;
@@ -323,5 +366,107 @@ export class TreasuryOperationsComponent implements OnInit {
         this.busy = false;
       }
     });
+  }
+
+  get hasExportData(): boolean {
+    return (
+      this.payables.length > 0 ||
+      this.vouchers.length > 0 ||
+      this.schedules.length > 0 ||
+      this.writeOffs.length > 0
+    );
+  }
+
+  exportToCsv(): void {
+    this.runExport('csv');
+  }
+
+  exportToPdf(): void {
+    this.runExport('pdf');
+  }
+
+  private runExport(format: 'csv' | 'pdf'): void {
+    if (!this.hasExportData) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sin datos',
+        detail: 'No hay información de operaciones para exportar.',
+      });
+      return;
+    }
+
+    const sections = this.buildExportSections();
+    const filename = this.exportService.datedFilename('operaciones-tesoreria', format);
+    const loadingFlag = format === 'csv' ? 'exportingCsv' : 'exportingPdf';
+    this[loadingFlag] = true;
+
+    try {
+      if (format === 'csv') {
+        this.exportService.downloadCsvSections(filename, sections);
+      } else {
+        this.exportService.downloadPdfSections('Operaciones de Tesorería', filename, sections);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('operaciones', format),
+      });
+    } catch (error) {
+      console.error(`Error al exportar ${format}:`, error);
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: exportErrorDetail(format),
+      });
+    } finally {
+      this[loadingFlag] = false;
+    }
+  }
+
+  private buildExportSections() {
+    return [
+      {
+        title: 'Obligaciones pendientes',
+        headers: ['Proveedor', 'Factura', 'Vence', 'Disponible'],
+        rows: this.payables.map((item) => [
+          resolveSupplierName(this.supplierNames, item.supplierId),
+          item.reference,
+          item.dueDate,
+          item.availableAmount,
+        ]),
+      },
+      {
+        title: 'Comprobantes',
+        headers: ['Número', 'Fecha', 'Estado', 'Total', 'Asiento'],
+        rows: this.vouchers.map((item) => [
+          item.voucherNumber,
+          item.issueDate,
+          this.statusLabel(item.status),
+          item.total,
+          item.accountingEntryId || 'Pendiente',
+        ]),
+      },
+      {
+        title: 'Programaciones',
+        headers: ['Fecha', 'Estado', 'Total', 'Reintentos', 'Comprobante'],
+        rows: this.schedules.map((item) => [
+          item.executionDate,
+          this.scheduleLabel(item.status),
+          item.total,
+          item.retryCount,
+          item.voucherId || '-',
+        ]),
+      },
+      {
+        title: 'Bajas de CxP',
+        headers: ['N.º', 'Estado', 'Total', 'Motivo'],
+        rows: this.writeOffs.map((item) => [
+          item.id,
+          this.writeOffLabel(item.status),
+          item.total,
+          item.reason || '-',
+        ]),
+      },
+    ];
   }
 }

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
@@ -1,16 +1,33 @@
 <div class="container-fluid p-4">
   <div class="flex justify-between items-center mb-6">
     <div>
-      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2">Programación Pagos de Factura</h1>
+      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Programación Pagos de Factura</h1>
+      <app-contextual-help
+        class="ml-2 inline-flex align-middle"
+        [title]="help.title"
+        [summary]="help.summary"
+        [helpCenterSlug]="help.slug">
+      </app-contextual-help>
       <p class="text-gray-600">Organiza y controla los pagos pendientes a proveedores</p>
     </div>
     <div class="flex gap-2">
       <p-button
-        label="Exportar CSV"
-        icon="pi pi-download"
-        severity="secondary"
+        label="Exportar PDF"
+        icon="pi pi-file-pdf"
+        severity="danger"
+        [outlined]="true"
+        [loading]="exportingPdf"
         [disabled]="!filteredBills.length"
-        (onClick)="onExportData()">
+        (onClick)="exportToPdf()">
+      </p-button>
+      <p-button
+        label="Exportar CSV"
+        icon="pi pi-file-excel"
+        severity="success"
+        [outlined]="true"
+        [loading]="exportingCsv"
+        [disabled]="!filteredBills.length"
+        (onClick)="exportToCsv()">
       </p-button>
     </div>
   </div>
@@ -253,7 +270,7 @@
                 <p class="text-lg font-semibold text-gray-600 mb-2">No se encontraron programaciones</p>
                 <p class="text-gray-500">
                   {{ filteredBills.length === 0 && allBills.length > 0
-                    ? 'Intente ajustar los filtros de búsqueda'
+                    ? emptyFiltersMessage
                     : 'No hay obligaciones pendientes actualmente' }}
                 </p>
               </div>
@@ -288,7 +305,7 @@
       <div class="text-center">
         <i class="pi pi-clock text-3xl text-orange-500 mb-2"></i>
         <h3 class="text-2xl font-bold text-gray-800">{{ getPartialCount() }}</h3>
-        <p class="text-gray-600">Pago parcial</p>
+        <p class="text-gray-600">Abono parcial</p>
       </div>
     </p-card>
 

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
@@ -20,6 +20,14 @@ import { PurchaseBillService } from '../../Services/purchase-bill.service';
 import { BillFilterOption, PurchaseBillListView } from '../../Models/PurchaseBill';
 import { LocalStorageMethods } from '../../../../../Shared/Methods/local-storage.method';
 import { MessageService, ConfirmationService } from 'primeng/api';
+import { TreasuryExportService } from '../../../Shared/treasury-export.service';
+import {
+  exportErrorDetail,
+  exportSuccessDetail,
+  reportEmptyFiltersMessage,
+} from '../../../Shared/treasury-status-labels';
+import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
 
 interface StatusOption {
   label: string;
@@ -51,6 +59,7 @@ interface CutoffDateOption {
     ToastModule,
     ConfirmDialogModule,
     DialogModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './bill-list.component.html',
   styleUrls: ['./bill-list.component.css'],
@@ -71,7 +80,7 @@ export class BillListComponent implements OnInit {
   statusOptions: StatusOption[] = [
     { label: 'Todos los estados', value: '' },
     { label: 'Pendiente de pago', value: 'POSTED' },
-    { label: 'Pago parcial', value: 'PARTIALLY_PAID' },
+    { label: 'Abono parcial', value: 'PARTIALLY_PAID' },
     { label: 'Pagada', value: 'PAID' },
   ];
 
@@ -90,6 +99,10 @@ export class BillListComponent implements OnInit {
   loading = false;
   detailVisible = false;
   selectedBill: PurchaseBillListView | null = null;
+  exportingPdf = false;
+  exportingCsv = false;
+  readonly emptyFiltersMessage = reportEmptyFiltersMessage();
+  readonly help = TREASURY_HELP.paymentSchedule;
 
   constructor(
     private fb: FormBuilder,
@@ -97,6 +110,7 @@ export class BillListComponent implements OnInit {
     private purchaseBillService: PurchaseBillService,
     private messageService: MessageService,
     private confirmationService: ConfirmationService,
+    private exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
@@ -199,7 +213,7 @@ export class BillListComponent implements OnInit {
     this.allBillIdOptions = bills
       .map((b) => ({
         value: b.billId,
-        label: `${b.billId} · Prov. ${b.supplierId}`,
+        label: `${b.billId} · Proveedor ${b.supplierId}`,
         supplierId: b.supplierId,
       }))
       .sort((a, b) => String(a.label).localeCompare(String(b.label)));
@@ -398,42 +412,65 @@ export class BillListComponent implements OnInit {
     }).format(new Date(date));
   }
 
-  onExportData(): void {
+  exportToCsv(): void {
+    this.runExport('csv');
+  }
+
+  exportToPdf(): void {
+    this.runExport('pdf');
+  }
+
+  private runExport(format: 'csv' | 'pdf'): void {
     if (!this.filteredBills.length) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Sin datos',
-        detail: 'No hay facturas para exportar con los filtros actuales.',
+        detail: this.emptyFiltersMessage,
       });
       return;
     }
 
-    const header = ['Factura', 'Fecha', 'Proveedor', 'Total', 'Saldo', 'Estado'].join(',');
-    const rows = this.filteredBills.map((b) =>
-      [
-        b.billId,
-        this.formatDate(b.dateOpened),
-        `"${b.supplierName}"`,
-        b.total,
-        b.pendingBalance ?? '',
-        b.statusDisplay,
-      ].join(','),
-    );
-    const blob = new Blob([[header, ...rows].join('\n')], {
-      type: 'text/csv;charset=utf-8;',
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `programacion-pagos-${new Date().toISOString().slice(0, 10)}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
+    const headers = ['Factura', 'Fecha', 'Proveedor', 'Total', 'Pagado', 'Saldo', 'Estado'];
+    const rows = this.filteredBills.map((bill) => [
+      bill.billId,
+      this.formatDate(bill.dateOpened),
+      bill.supplierName,
+      bill.total,
+      bill.paidAmount ?? 0,
+      bill.pendingBalance ?? 0,
+      bill.statusDisplay,
+    ]);
+    const options = {
+      title: 'Programación de pagos de factura',
+      subtitle: `${rows.length} obligación(es) exportada(s)`,
+      filename: this.exportService.datedFilename('programacion-pagos', format),
+      headers,
+      rows,
+    };
 
-    this.messageService.add({
-      severity: 'success',
-      summary: 'Exportado',
-      detail: 'Se descargó el CSV de programaciones.',
-    });
+    const loadingFlag = format === 'csv' ? 'exportingCsv' : 'exportingPdf';
+    this[loadingFlag] = true;
+    try {
+      if (format === 'csv') {
+        this.exportService.downloadCsv(options);
+      } else {
+        this.exportService.downloadPdf(options);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('programación de pagos', format),
+      });
+    } catch (error) {
+      console.error(`Error al exportar ${format}:`, error);
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: exportErrorDetail(format),
+      });
+    } finally {
+      this[loadingFlag] = false;
+    }
   }
 
   getPartialCount(): number {

--- a/src/app/Financial/Treasury/PurchaseBills/Services/purchase-bill.service.spec.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Services/purchase-bill.service.spec.ts
@@ -1,0 +1,54 @@
+import { of } from 'rxjs';
+import { PurchaseBillService } from './purchase-bill.service';
+
+describe('PurchaseBillService suppliers', () => {
+  it('enriches CxP suppliers with third party names', (done) => {
+    const api = {
+      pending: jasmine.createSpy('pending').and.returnValue(
+        of([
+          {
+            supplierId: 7,
+            payableAccountId: 2205,
+            payableAccountCode: '2205',
+          },
+        ]),
+      ),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(
+        of({
+          content: [{ thId: 7, socialReason: 'Distribuidora Andina' }],
+        }),
+      ),
+    };
+    const storage = { getIdEnterprise: () => 'ent-1' };
+    const service = new PurchaseBillService(api as any, {} as any, thirds as any, storage as any);
+
+    service.getSuppliers('andina').subscribe((suppliers) => {
+      expect(suppliers.length).toBe(1);
+      expect(suppliers[0].name).toBe('Distribuidora Andina');
+      expect(suppliers[0].id).toBe(7);
+      done();
+    });
+  });
+
+  it('only returns suppliers with pending payables', (done) => {
+    const api = {
+      pending: jasmine.createSpy('pending').and.returnValue(
+        of([{ supplierId: 3, payableAccountId: 1, payableAccountCode: '2205' }]),
+      ),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(
+        of({ content: [{ thId: 3, socialReason: 'CxP Activa' }, { thId: 99, socialReason: 'Sin CxP' }] }),
+      ),
+    };
+    const storage = { getIdEnterprise: () => 'ent-1' };
+    const service = new PurchaseBillService(api as any, {} as any, thirds as any, storage as any);
+
+    service.getSuppliers('').subscribe((suppliers) => {
+      expect(suppliers.map((s) => s.id)).toEqual([3]);
+      done();
+    });
+  });
+});

--- a/src/app/Financial/Treasury/PurchaseBills/Services/purchase-bill.service.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Services/purchase-bill.service.ts
@@ -25,14 +25,29 @@ export class PurchaseBillService {
   }
 
   getSuppliers(query = ''): Observable<Supplier[]> {
-    return this.api.pending(this.enterpriseId()).pipe(
-      map((items) =>
-        [...new Set(items.map((item) => item.supplierId))]
+    return forkJoin({
+      payables: this.api.pending(this.enterpriseId()),
+      thirds: this.thirds.getThirdParties(this.enterpriseId(), 0, 1000).pipe(
+        catchError(() => of({ content: [] } as any)),
+      ),
+    }).pipe(
+      map(({ payables, thirds }) => {
+        const thirdNames = new Map<number, string>(
+          (thirds?.content || []).map((t: any) => {
+            const name =
+              (t.socialReason as string) ||
+              [t.names, t.lastNames].filter(Boolean).join(' ') ||
+              `Proveedor ${t.thId}`;
+            return [Number(t.thId), String(name)] as [number, string];
+          }),
+        );
+
+        return [...new Set(payables.map((item) => item.supplierId))]
           .map((id) => {
-            const payable = items.find((item) => item.supplierId === id)!;
+            const payable = payables.find((item) => item.supplierId === id)!;
             return {
               id,
-              name: `Proveedor ${id}`,
+              name: thirdNames.get(id) || `Proveedor ${id}`,
               accountsPayableAccount: {
                 id: payable.payableAccountId,
                 code: payable.payableAccountCode,
@@ -40,8 +55,8 @@ export class PurchaseBillService {
               },
             };
           })
-          .filter((item) => item.name.toLowerCase().includes(query.toLowerCase())),
-      ),
+          .filter((item) => item.name.toLowerCase().includes(query.toLowerCase()));
+      }),
     );
   }
 
@@ -94,7 +109,7 @@ export class PurchaseBillService {
             status === 'PAID'
               ? 'Pagada'
               : status === 'PARTIALLY_PAID'
-                ? 'Pago parcial'
+                ? 'Abono parcial'
                 : 'Pendiente de pago';
 
           return {

--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
@@ -1,21 +1,37 @@
 <div class="container-fluid p-4">
   <div class="flex justify-between items-center mb-6">
     <div>
-      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2">
+      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">
         Vencimiento por edades
       </h1>
+      <app-contextual-help
+        class="ml-2 inline-flex align-middle"
+        [title]="help.title"
+        [summary]="help.summary"
+        [helpCenterSlug]="help.slug">
+      </app-contextual-help>
       <p class="text-gray-600">
         Obligaciones de proveedores con saldo pendiente, agrupadas por días de mora a la fecha de corte
       </p>
     </div>
     <div class="flex gap-2">
       <p-button
-        label="Exportar CSV"
-        icon="pi pi-download"
-        severity="secondary"
-        [loading]="exporting"
+        label="Exportar PDF"
+        icon="pi pi-file-pdf"
+        severity="danger"
+        [outlined]="true"
+        [loading]="exportingPdf"
         [disabled]="!reportData?.lines?.length"
-        (onClick)="onExportData()">
+        (onClick)="exportToPdf()">
+      </p-button>
+      <p-button
+        label="Exportar CSV"
+        icon="pi pi-file-excel"
+        severity="success"
+        [outlined]="true"
+        [loading]="exportingCsv"
+        [disabled]="!reportData?.lines?.length"
+        (onClick)="exportToCsv()">
       </p-button>
     </div>
   </div>
@@ -201,8 +217,8 @@
         <tr>
           <td [attr.colspan]="filterForm.get('includeDocuments')?.value ? 11 : 6" class="text-center py-8">
             <i class="pi pi-inbox text-4xl text-gray-400 mb-3 block"></i>
-            <p class="text-lg font-semibold text-gray-600 mb-1">No hay obligaciones pendientes</p>
-            <p class="text-gray-500">Ajuste filtros o cree una factura de compra con saldo pendiente</p>
+            <p class="text-lg font-semibold text-gray-600 mb-1">{{ emptyFiltersMessage }}</p>
+            <p class="text-gray-500">Ajuste los filtros o genere el reporte con otros criterios</p>
           </td>
         </tr>
       </ng-template>

--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
@@ -21,6 +21,14 @@ import {
   DocumentOption,
 } from '../../Models/AgingReport';
 import { LocalStorageMethods } from '../../../../../../Shared/Methods/local-storage.method';
+import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
+import {
+  exportErrorDetail,
+  exportSuccessDetail,
+  reportEmptyFiltersMessage,
+} from '../../../../Shared/treasury-status-labels';
+import { ContextualHelpComponent } from '../../../../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../../../../Shared/treasury-help-content';
 
 @Component({
   selector: 'app-aging-report',
@@ -36,6 +44,7 @@ import { LocalStorageMethods } from '../../../../../../Shared/Methods/local-stor
     CardModule,
     ToastModule,
     InputSwitchModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './aging-report.component.html',
   styleUrls: ['./aging-report.component.css'],
@@ -51,12 +60,16 @@ export class AgingReportComponent implements OnInit {
   documentOptions: DocumentOption[] = [];
   allDocuments: DocumentOption[] = [];
   loading = false;
-  exporting = false;
+  exportingPdf = false;
+  exportingCsv = false;
+  readonly emptyFiltersMessage = reportEmptyFiltersMessage();
+  readonly help = TREASURY_HELP.agingReport;
 
   constructor(
     private fb: FormBuilder,
     private agingReportService: AgingReportService,
     private messageService: MessageService,
+    private exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
@@ -159,7 +172,7 @@ export class AgingReportComponent implements OnInit {
           summary: report.lines.length ? 'Reporte generado' : 'Sin resultados',
           detail: report.lines.length
             ? `Se encontraron ${report.lines.length} obligación(es) pendientes.`
-            : 'No hay obligaciones pendientes con esos filtros.',
+            : this.emptyFiltersMessage,
         });
       },
       error: (error) => {
@@ -186,9 +199,16 @@ export class AgingReportComponent implements OnInit {
     this.onGenerateReport();
   }
 
-  onExportData(): void {
-    const enterpriseId = this.localStorageMethods.getIdEnterprise();
-    if (!enterpriseId || !this.reportData) {
+  exportToCsv(): void {
+    this.runExport('csv');
+  }
+
+  exportToPdf(): void {
+    this.runExport('pdf');
+  }
+
+  private runExport(format: 'csv' | 'pdf'): void {
+    if (!this.reportData?.lines?.length) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Genere un reporte',
@@ -197,42 +217,66 @@ export class AgingReportComponent implements OnInit {
       return;
     }
 
-    this.exporting = true;
-    const supplierId = this.filterForm.value.supplierId;
-    const supplier = this.supplierOptions.find((s) => s.id === supplierId);
-    const filters: AgingReportFilter = {
-      supplierId,
-      supplierName: supplier?.name,
-      document: this.filterForm.value.document || undefined,
-      accountCode: this.filterForm.value.accountCode,
-      cutoffDate: this.filterForm.value.cutoffDate,
-      includeDocuments: this.filterForm.value.includeDocuments,
+    const headers = [
+      'Factura',
+      'Proveedor',
+      'Cuenta',
+      'Vence',
+      'Días vencidos',
+      'Total',
+      'Corriente',
+      '1-30',
+      '31-60',
+      '61-90',
+      '91+',
+    ];
+    const rows = this.reportData.lines.map((line) => [
+      line.reference,
+      this.supplierName(line.supplierId),
+      line.accountDescription,
+      this.formatDate(line.dueDate),
+      line.daysOverdue,
+      line.totalDue,
+      line.current,
+      line.days1to30,
+      line.days31to60,
+      line.days61to90,
+      line.days91Plus,
+    ]);
+    const subtitle = `Corte: ${this.formatDate(this.reportData.reportDate)} · ${this.reportData.supplierName}`;
+    const filename = this.exportService.datedFilename('vencimiento-edades', format);
+    const options = {
+      title: 'Vencimiento por edades',
+      subtitle,
+      filename,
+      headers,
+      rows,
+      orientation: 'landscape' as const,
     };
 
-    this.agingReportService.exportAgingReport(enterpriseId, filters).subscribe({
-      next: (blob) => {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `vencimiento-edades-${this.formatDate(this.reportData!.reportDate).replace(/\//g, '-')}.csv`;
-        a.click();
-        URL.revokeObjectURL(url);
-        this.exporting = false;
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Exportado',
-          detail: 'Se descargó el CSV del reporte.',
-        });
-      },
-      error: () => {
-        this.exporting = false;
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Error',
-          detail: 'No se pudo exportar el reporte.',
-        });
-      },
-    });
+    const loadingFlag = format === 'csv' ? 'exportingCsv' : 'exportingPdf';
+    this[loadingFlag] = true;
+    try {
+      if (format === 'csv') {
+        this.exportService.downloadCsv(options);
+      } else {
+        this.exportService.downloadPdf(options);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('antigüedad de saldos', format),
+      });
+    } catch (error) {
+      console.error(`Error al exportar ${format}:`, error);
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: exportErrorDetail(format),
+      });
+    } finally {
+      this[loadingFlag] = false;
+    }
   }
 
   formatCurrency(amount: number): string {

--- a/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
@@ -1,0 +1,74 @@
+import { of } from 'rxjs';
+import { AgingReportService } from './aging-report.service';
+
+describe('AgingReportService filter options', () => {
+  it('labels accounts by PUC code and documents by supplier name', (done) => {
+    const api = {
+      pending: jasmine.createSpy('pending').and.returnValue(
+        of([
+          {
+            supplierId: 7,
+            reference: 'FC-100',
+            payableAccountCode: '220501',
+          },
+        ]),
+      ),
+    };
+    const accounts = {
+      getListAuxiliaryAccounts: jasmine.createSpy('getListAuxiliaryAccounts').and.returnValue(
+        of([{ id: 55, code: '220501', description: 'Proveedores nacionales', status: true }]),
+      ),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(
+        of({ content: [{ thId: 7, socialReason: 'Acme Ltda.' }] }),
+      ),
+    };
+    const service = new AgingReportService(api as any, accounts as any, thirds as any);
+
+    service.getFilterOptions('ent-1').subscribe((options) => {
+      expect(options.accounts[0].label).toBe('220501 - Proveedores nacionales');
+      expect(options.documents[0].label).toBe('FC-100 · Acme Ltda.');
+      expect(options.suppliers[0].name).toBe('Acme Ltda.');
+      done();
+    });
+  });
+});
+
+describe('AgingReportService report lines', () => {
+  it('resolves account description using account code from aging API', (done) => {
+    const api = {
+      aging: jasmine.createSpy('aging').and.returnValue(
+        of([
+          {
+            invoiceId: 1,
+            supplierId: 7,
+            reference: 'FC-100',
+            accountCode: '220501',
+            dueDate: '2026-08-01',
+            daysOverdue: 5,
+            current: 100,
+            days1to30: 0,
+            days31to60: 0,
+            days61to90: 0,
+            days91Plus: 0,
+          },
+        ]),
+      ),
+    };
+    const accounts = {
+      getListAuxiliaryAccounts: jasmine.createSpy('getListAuxiliaryAccounts').and.returnValue(
+        of([{ id: 55, code: '220501', description: 'Proveedores nacionales', status: true }]),
+      ),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(of({ content: [] })),
+    };
+    const service = new AgingReportService(api as any, accounts as any, thirds as any);
+
+    service.getAgingReport('ent-1', { cutoffDate: new Date('2026-08-13'), includeDocuments: true }).subscribe((report) => {
+      expect(report.lines[0].accountDescription).toBe('220501 - Proveedores nacionales');
+      done();
+    });
+  });
+});

--- a/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.ts
@@ -34,7 +34,7 @@ export class AgingReportService {
     }).pipe(
       map(({ items, accounts, thirds }) => {
         const accountMap = new Map<string, string>(
-          (accounts || []).map((a: any) => [String(a.id), `${a.code} - ${a.description}`] as [string, string]),
+          (accounts || []).map((a: any) => [String(a.code), `${a.code} - ${a.description}`] as [string, string]),
         );
         const thirdMap = new Map<number, string>(
           (thirds?.content || []).map((t: any) => {
@@ -123,7 +123,7 @@ export class AgingReportService {
           }),
         );
         const accountLabels = new Map<string, string>(
-          (accounts || []).map((a: any) => [String(a.id), `${a.code} - ${a.description}`] as [string, string]),
+          (accounts || []).map((a: any) => [String(a.code), `${a.code} - ${a.description}`] as [string, string]),
         );
 
         const pending = payables || [];
@@ -136,12 +136,15 @@ export class AgingReportService {
           .sort((a, b) => a.label.localeCompare(b.label));
 
         const documents: DocumentOption[] = pending
-          .map((p) => ({
-            label: `${p.reference} · Prov. ${p.supplierId}`,
-            value: String(p.reference),
-            supplierId: Number(p.supplierId),
-            accountCode: String(p.payableAccountCode),
-          }))
+          .map((p) => {
+            const supplierName = thirdNames.get(Number(p.supplierId)) || `Proveedor ${p.supplierId}`;
+            return {
+              label: `${p.reference} · ${supplierName}`,
+              value: String(p.reference),
+              supplierId: Number(p.supplierId),
+              accountCode: String(p.payableAccountCode),
+            };
+          })
           .sort((a, b) => a.label.localeCompare(b.label));
 
         const accountCodes = [...new Set(pending.map((p) => String(p.payableAccountCode)))];
@@ -173,7 +176,7 @@ export class AgingReportService {
           'Proveedor',
           'Cuenta',
           'Vence',
-          'Dias vencidos',
+          'Días vencidos',
           'Total',
           'Corriente',
           '1-30',

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.html
@@ -3,15 +3,33 @@
     <!-- Page Header -->
     <div class="flex justify-between items-center mb-6">
         <div>
-            <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2">Reportes de Proveedores</h1>
+            <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Reportes de Proveedores</h1>
+            <app-contextual-help
+                class="ml-2 inline-flex align-middle"
+                [title]="help.title"
+                [summary]="help.summary"
+                [helpCenterSlug]="help.slug">
+            </app-contextual-help>
             <p class="text-gray-600">Consulte y analice el estado de cuentas de todos sus proveedores</p>
         </div>
         <div class="flex gap-2">
             <p-button
-                label="Exportar"
-                icon="pi pi-download"
-                severity="secondary"
-                (onClick)="onExportData()">
+                label="Exportar PDF"
+                icon="pi pi-file-pdf"
+                severity="danger"
+                [outlined]="true"
+                [loading]="exportingPdf"
+                [disabled]="!filteredVendors.length"
+                (onClick)="exportToPdf()">
+            </p-button>
+            <p-button
+                label="Exportar CSV"
+                icon="pi pi-file-excel"
+                severity="success"
+                [outlined]="true"
+                [loading]="exportingCsv"
+                [disabled]="!filteredVendors.length"
+                (onClick)="exportToCsv()">
             </p-button>
         </div>
     </div>
@@ -215,12 +233,8 @@
                         <div class="flex flex-col items-center gap-4">
                             <i class="pi pi-inbox text-4xl text-gray-400"></i>
                             <div>
-                                <p class="text-lg font-semibold text-gray-600 mb-2">No se encontraron proveedores</p>
-                                <p class="text-gray-500">
-                                    {{ filteredVendors.length === 0 && filteredVendors.length < vendors.length
-                                        ? 'Intente ajustar los filtros de búsqueda'
-                                        : 'No hay proveedores registrados en el sistema' }}
-                                </p>
+                                <p class="text-lg font-semibold text-gray-600 mb-2">{{ getEmptyTitle() }}</p>
+                                <p class="text-gray-500" *ngIf="getEmptySubtitle()">{{ getEmptySubtitle() }}</p>
                             </div>
                         </div>
                     </td>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.ts
@@ -19,6 +19,10 @@ import { TooltipModule } from 'primeng/tooltip';
 import { VendorReportService } from '../../Services/vendor-report.service';
 import { VendorReportSummary, VendorListFilter } from '../../Models/VendorReport';
 import { MessageService } from 'primeng/api';
+import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
+import { exportErrorDetail, exportSuccessDetail, reportEmptyFiltersMessage } from '../../../../Shared/treasury-status-labels';
+import { ContextualHelpComponent } from '../../../../../../Shared/Components/contextual-help/contextual-help.component';
+import { TREASURY_HELP } from '../../../../Shared/treasury-help-content';
 
 @Component({
   selector: 'app-vendor-list',
@@ -36,7 +40,8 @@ import { MessageService } from 'primeng/api';
     CardModule,
     ToastModule,
     TagModule,
-    TooltipModule
+    TooltipModule,
+    ContextualHelpComponent,
   ],
   templateUrl: './vendor-list.component.html',
   styleUrls: ['./vendor-list.component.css'],
@@ -49,18 +54,22 @@ export class VendorListComponent implements OnInit {
   loading: boolean = false;
 
   filterForm!: FormGroup;
+  exportingPdf = false;
+  exportingCsv = false;
 
   statusOptions = [
     { label: 'Todos los proveedores', value: 'all' },
     { label: 'Con saldo pendiente', value: 'with_balance' },
     { label: 'Sin saldo pendiente', value: 'no_balance' }
   ];
+  readonly help = TREASURY_HELP.vendorReports;
 
   constructor(
     private fb: FormBuilder,
     private vendorReportService: VendorReportService,
     private messageService: MessageService,
-    private router: Router
+    private router: Router,
+    private exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
@@ -150,6 +159,32 @@ export class VendorListComponent implements OnInit {
     return this.filteredVendors.reduce((sum, vendor) => sum + vendor.currentBalance, 0);
   }
 
+  hasActiveFilters(): boolean {
+    const filter = this.filterForm.value;
+    return !!(
+      filter.searchTerm?.trim()
+      || filter.dateFrom
+      || filter.dateTo
+      || filter.balanceFrom != null
+      || filter.balanceTo != null
+      || (filter.status && filter.status !== 'all')
+    );
+  }
+
+  getEmptyTitle(): string {
+    if (this.vendors.length === 0) {
+      return 'No hay proveedores con facturas pendientes';
+    }
+    if (this.hasActiveFilters()) {
+      return 'No se encontraron proveedores que coincidan con la búsqueda';
+    }
+    return 'No hay proveedores con facturas pendientes';
+  }
+
+  getEmptySubtitle(): string {
+    return this.hasActiveFilters() ? 'Intente ajustar los filtros de búsqueda' : '';
+  }
+
   // Utility methods for consistent formatting
   formatCurrency(amount: number): string {
     return new Intl.NumberFormat('es-CO', {
@@ -168,12 +203,73 @@ export class VendorListComponent implements OnInit {
     }).format(new Date(date));
   }
 
-  // Export functionality
-  onExportData(): void {
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Funcionalidad Pendiente',
-      detail: 'La exportación de datos será implementada próximamente.'
-    });
+  exportToCsv(): void {
+    this.runExport('csv');
+  }
+
+  exportToPdf(): void {
+    this.runExport('pdf');
+  }
+
+  private runExport(format: 'csv' | 'pdf'): void {
+    if (!this.filteredVendors.length) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sin datos',
+        detail: reportEmptyFiltersMessage(),
+      });
+      return;
+    }
+
+    const headers = [
+      'Proveedor',
+      'Transacciones',
+      'Débitos',
+      'Créditos',
+      'Saldo',
+      'Última transacción',
+      'Estado',
+    ];
+    const rows = this.filteredVendors.map((vendor) => [
+      vendor.name,
+      vendor.transactionCount,
+      vendor.totalDebits,
+      vendor.totalCredits,
+      vendor.currentBalance,
+      this.formatDate(vendor.lastTransactionDate),
+      this.getBalanceTagText(vendor.currentBalance),
+    ]);
+    const options = {
+      title: 'Reportes de proveedores',
+      subtitle: `${rows.length} proveedor(es) exportado(s)`,
+      filename: this.exportService.datedFilename('reportes-proveedores', format),
+      headers,
+      rows,
+      orientation: 'landscape' as const,
+    };
+
+    const loadingFlag = format === 'csv' ? 'exportingCsv' : 'exportingPdf';
+    this[loadingFlag] = true;
+    try {
+      if (format === 'csv') {
+        this.exportService.downloadCsv(options);
+      } else {
+        this.exportService.downloadPdf(options);
+      }
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('proveedores', format),
+      });
+    } catch (error) {
+      console.error(`Error al exportar ${format}:`, error);
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: exportErrorDetail(format),
+      });
+    } finally {
+      this[loadingFlag] = false;
+    }
   }
 }

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -112,18 +112,18 @@
             severity="danger"
             [outlined]="true"
             [loading]="exportingPdf"
-            pTooltip="Mismo contenido que Excel, en PDF"
+            pTooltip="Mismo contenido que CSV, en PDF"
             (onClick)="exportToPdf()"
             [disabled]="!vendorReport">
           </p-button>
           <p-button
-            label="Exportar Excel"
+            label="Exportar CSV"
             icon="pi pi-file-excel"
             severity="success"
             [outlined]="true"
-            [loading]="exportingExcel"
-            pTooltip="Mismo contenido que PDF, en Excel"
-            (onClick)="exportToExcel()"
+            [loading]="exportingCsv"
+            pTooltip="Mismo contenido que PDF, en CSV"
+            (onClick)="exportToCsv()"
             [disabled]="!vendorReport">
           </p-button>
         </div>
@@ -238,7 +238,7 @@
           <tr>
             <td colspan="10" class="text-center py-8">
               <i class="pi pi-inbox text-4xl text-gray-400 mb-3 block"></i>
-              <p class="text-gray-600">No hay transacciones en el período seleccionado</p>
+              <p class="text-gray-600">{{ emptyFiltersMessage }}</p>
             </td>
           </tr>
         </ng-template>
@@ -285,7 +285,7 @@
 
   <div *ngIf="!loading && !vendorReport" class="text-center py-12">
     <i class="pi pi-info-circle text-6xl text-gray-400 mb-4"></i>
-    <h3 class="text-xl font-semibold text-gray-600 mb-2">No hay datos para mostrar</h3>
+    <h3 class="text-xl font-semibold text-gray-600 mb-2">{{ emptyFiltersMessage }}</h3>
     <p class="text-gray-500">Ajuste los filtros y pulse «Generar reporte»</p>
   </div>
 </div>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { saveAs } from 'file-saver';
 
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -19,7 +18,13 @@ import { InputTextModule } from 'primeng/inputtext';
 import { VendorReportService } from '../../Services/vendor-report.service';
 import { VendorReport } from '../../Models/VendorReport';
 import { MessageService } from 'primeng/api';
-import { transactionTypeLabel } from '../../../../Shared/treasury-status-labels';
+import {
+  exportErrorDetail,
+  exportSuccessDetail,
+  reportEmptyFiltersMessage,
+  transactionTypeLabel,
+} from '../../../../Shared/treasury-status-labels';
+import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
 
 interface FilterOption {
   label: string;
@@ -53,7 +58,8 @@ export class VendorReportComponent implements OnInit {
   vendorReport: VendorReport | null = null;
   loading = false;
   exportingPdf = false;
-  exportingExcel = false;
+  exportingCsv = false;
+  readonly emptyFiltersMessage = reportEmptyFiltersMessage();
   vendorId = 0;
   vendorName = '';
 
@@ -81,6 +87,7 @@ export class VendorReportComponent implements OnInit {
     private router: Router,
     private vendorReportService: VendorReportService,
     private messageService: MessageService,
+    private exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
@@ -221,45 +228,78 @@ export class VendorReportComponent implements OnInit {
     if (!this.vendorReport) return;
     this.exportingPdf = true;
     try {
-      const blob = this.vendorReportService.exportToPdf(this.vendorReport);
-      saveAs(blob, this.exportFileName('pdf'));
+      this.exportService.triggerBrowserDownload(
+        this.vendorReportService.exportToPdf(this.vendorReport),
+        this.exportFileName('pdf'),
+      );
       this.messageService.add({
         severity: 'success',
-        summary: 'PDF exportado',
-        detail: 'El estado de cuenta se descargó en PDF',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('estado de cuenta', 'pdf'),
       });
     } catch (error) {
       console.error('Error al exportar PDF:', error);
       this.messageService.add({
         severity: 'error',
         summary: 'Error',
-        detail: 'No se pudo exportar el reporte a PDF',
+        detail: exportErrorDetail('pdf'),
       });
     } finally {
       this.exportingPdf = false;
     }
   }
 
-  exportToExcel(): void {
+  exportToCsv(): void {
     if (!this.vendorReport) return;
-    this.exportingExcel = true;
+    this.exportingCsv = true;
     try {
-      const blob = this.vendorReportService.exportToExcel(this.vendorReport);
-      saveAs(blob, this.exportFileName('xlsx'));
+      const headers = [
+        'Fecha',
+        'Vence',
+        'Referencia',
+        'Documento',
+        'Comp. egreso',
+        'Tipo',
+        'Descripción',
+        'Débitos',
+        'Créditos',
+        'Saldo',
+      ];
+      const rows = this.vendorReport.transactions.map((transaction) => [
+        this.formatDate(transaction.date),
+        transaction.dueDate ? this.formatDate(transaction.dueDate) : '-',
+        transaction.reference || '-',
+        transaction.documentNumber || '-',
+        transaction.expenseReceiptNumber || '-',
+        transaction.type === 'Bill' ? 'Factura' : 'Pago',
+        transaction.description || '-',
+        transaction.debits || 0,
+        transaction.credits || 0,
+        transaction.balance || 0,
+      ]);
+
+      this.exportService.downloadCsv({
+        title: 'Estado de cuenta por proveedor',
+        subtitle: `${this.vendorReport.vendor.name} · ${this.formatDate(this.vendorReport.dateRange.startDate)} — ${this.formatDate(this.vendorReport.dateRange.endDate)}`,
+        filename: this.exportFileName('csv'),
+        headers,
+        rows,
+      });
+
       this.messageService.add({
         severity: 'success',
-        summary: 'Excel exportado',
-        detail: 'El estado de cuenta se descargó en Excel',
+        summary: 'Exportado',
+        detail: exportSuccessDetail('estado de cuenta', 'csv'),
       });
     } catch (error) {
-      console.error('Error al exportar Excel:', error);
+      console.error('Error al exportar CSV:', error);
       this.messageService.add({
         severity: 'error',
         summary: 'Error',
-        detail: 'No se pudo exportar el reporte a Excel',
+        detail: exportErrorDetail('csv'),
       });
     } finally {
-      this.exportingExcel = false;
+      this.exportingCsv = false;
     }
   }
 
@@ -290,5 +330,9 @@ export class VendorReportComponent implements OnInit {
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(amount || 0);
+  }
+
+  formatDate(date: Date | string): string {
+    return this.exportService.formatDate(date);
   }
 }

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -368,7 +368,7 @@ export class VendorReportService {
       { wch: 14 },
     ];
 
-    XLSX.utils.book_append_sheet(wb, ws, 'Estado cuenta');
+    XLSX.utils.book_append_sheet(wb, ws, 'Estado de cuenta');
     const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
     return new Blob([wbout], {
       type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',

--- a/src/app/Financial/Treasury/Shared/treasury-account.integration.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-account.integration.spec.ts
@@ -1,0 +1,36 @@
+import { Account } from '../../../GeneralMasters/AccountCatalogue/models/ChartAccount';
+import { PaymentMethod } from '../../../GeneralMasters/PaymentMethods/models/PaymentMethods';
+import {
+  buildActiveAccountIdSet,
+  filterSelectablePaymentMethods,
+} from './treasury-account.integration';
+
+describe('treasury-account.integration', () => {
+  const accounts: Account[] = [
+    { id: 10, code: '11100501', description: 'Banco', status: true, nature: 'Debito', financialStatus: 'Estado de Situacion Financiero', classification: 'Activo Corriente' },
+    { id: 20, code: '22050101', description: 'CxP', status: false, nature: 'Credito', financialStatus: 'Estado de Situacion Financiero', classification: 'Pasivo Corriente' },
+    { id: 30, code: '22050102', description: 'CxP 2', status: true, nature: 'Credito', financialStatus: 'Estado de Situacion Financiero', classification: 'Pasivo Corriente' },
+  ];
+
+  const methods: PaymentMethod[] = [
+    { id: 1, name: 'Transferencia', accountingAccount: '11100501 - Banco', accountingAccountId: 10, status: true, requiresBankAccount: true, idEnterprise: 'ent-1' },
+    { id: 2, name: 'Efectivo inactivo', accountingAccount: '22050101 - CxP', accountingAccountId: 20, status: true, requiresBankAccount: false, idEnterprise: 'ent-1' },
+    { id: 3, name: 'Cheque', accountingAccount: '22050102 - CxP 2', accountingAccountId: 30, status: true, requiresBankAccount: false, idEnterprise: 'ent-1' },
+  ];
+
+  it('builds active account id set excluding inactive accounts', () => {
+    expect([...buildActiveAccountIdSet(accounts)]).toEqual([10, 30]);
+  });
+
+  it('excludes payment methods linked to inactive accounts for new operations', () => {
+    const activeIds = buildActiveAccountIdSet(accounts);
+    const selectable = filterSelectablePaymentMethods(methods, activeIds);
+    expect(selectable.map((item) => item.id)).toEqual([1, 3]);
+  });
+
+  it('preserves historical payment method even if its account was deactivated', () => {
+    const activeIds = buildActiveAccountIdSet(accounts);
+    const selectable = filterSelectablePaymentMethods(methods, activeIds, 2);
+    expect(selectable.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-account.integration.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-account.integration.ts
@@ -1,0 +1,23 @@
+import { Account } from '../../../GeneralMasters/AccountCatalogue/models/ChartAccount';
+import { PaymentMethod } from '../../../GeneralMasters/PaymentMethods/models/PaymentMethods';
+
+export function buildActiveAccountIdSet(accounts: Account[]): Set<number> {
+  return new Set(
+    accounts
+      .filter((account) => account.id !== undefined && account.status !== false)
+      .map((account) => account.id as number),
+  );
+}
+
+/** Métodos de pago usables en operaciones nuevas: cuenta contable activa o método histórico preservado. */
+export function filterSelectablePaymentMethods(
+  methods: PaymentMethod[],
+  activeAccountIds: Set<number>,
+  preserveMethodId?: number | null,
+): PaymentMethod[] {
+  return methods.filter((method) => {
+    if (preserveMethodId != null && method.id === preserveMethodId) return true;
+    if (!method.accountingAccountId) return false;
+    return activeAccountIds.has(method.accountingAccountId);
+  });
+}

--- a/src/app/Financial/Treasury/Shared/treasury-export.service.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-export.service.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { TreasuryExportService } from './treasury-export.service';
+
+describe('TreasuryExportService', () => {
+  let service: TreasuryExportService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TreasuryExportService);
+  });
+
+  it('escapes csv cells with commas and quotes', () => {
+    expect(service.escapeCsvCell('Proveedor, S.A.')).toBe('"Proveedor, S.A."');
+    expect(service.escapeCsvCell('Empresa "ABC"')).toBe('"Empresa ""ABC"""');
+    expect(service.escapeCsvCell('simple')).toBe('simple');
+  });
+
+  it('builds csv blob with utf-8 bom and header row', async () => {
+    const blob = service.buildCsvBlob({
+      title: 'Test',
+      filename: 'test.csv',
+      headers: ['Col A', 'Col B'],
+      rows: [['1', '2'], ['3', '4']],
+    });
+
+    expect(blob.type).toContain('text/csv');
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(bytes[0]).toBe(0xef);
+    expect(bytes[1]).toBe(0xbb);
+    expect(bytes[2]).toBe(0xbf);
+    const text = await blob.text();
+    expect(text).toContain('Col A,Col B');
+    expect(text).toContain('1,2');
+    expect(text).toContain('3,4');
+  });
+
+  it('builds pdf blob with non-zero size', () => {
+    const blob = service.buildPdfBlob({
+      title: 'Reporte de prueba',
+      subtitle: 'Subtítulo',
+      filename: 'reporte.pdf',
+      headers: ['Factura', 'Saldo'],
+      rows: [['FC-1', 100000]],
+    });
+
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(500);
+  });
+
+  it('builds multi-section pdf blob', () => {
+    const blob = service.buildPdfSectionsBlob('Operaciones', [
+      {
+        title: 'Obligaciones',
+        headers: ['Factura', 'Saldo'],
+        rows: [['FC-1', 1000]],
+      },
+      {
+        title: 'Comprobantes',
+        headers: ['Número', 'Estado'],
+        rows: [['CE-1', 'POSTED']],
+      },
+    ]);
+
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(800);
+  });
+
+  it('formats currency and dates for colombia', () => {
+    expect(service.formatCurrency(1500000)).toContain('1');
+    expect(service.formatDate('2026-08-13')).toMatch(/\d/);
+  });
+
+  it('sanitizes filenames', () => {
+    expect(service.sanitizeFilename('Estado / Proveedor #1')).toBe('Estado___Proveedor__1');
+    expect(service.datedFilename('programacion-pagos', 'csv')).toMatch(/^programacion-pagos-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-export.service.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-export.service.ts
@@ -1,0 +1,202 @@
+import { Injectable } from '@angular/core';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+export interface TreasuryExportSection {
+  title: string;
+  headers: string[];
+  rows: (string | number)[][];
+}
+
+export interface TreasuryExportOptions {
+  title: string;
+  subtitle?: string;
+  filename: string;
+  headers: string[];
+  rows: (string | number)[][];
+  orientation?: 'portrait' | 'landscape';
+}
+
+@Injectable({ providedIn: 'root' })
+export class TreasuryExportService {
+  downloadCsv(options: TreasuryExportOptions): void {
+    this.triggerBrowserDownload(this.buildCsvBlob(options), this.ensureExtension(options.filename, 'csv'));
+  }
+
+  buildCsvBlob(options: TreasuryExportOptions): Blob {
+    const lines = [options.headers.map((cell) => this.escapeCsvCell(cell)).join(',')];
+    for (const row of options.rows) {
+      lines.push(row.map((cell) => this.escapeCsvCell(cell)).join(','));
+    }
+    return new Blob(['\uFEFF' + lines.join('\r\n')], {
+      type: 'text/csv;charset=utf-8;',
+    });
+  }
+
+  downloadCsvSections(filename: string, sections: TreasuryExportSection[]): void {
+    const lines: string[] = [];
+    sections.forEach((section, index) => {
+      if (index > 0) lines.push('');
+      lines.push(this.escapeCsvCell(section.title));
+      lines.push(section.headers.map((cell) => this.escapeCsvCell(cell)).join(','));
+      for (const row of section.rows) {
+        lines.push(row.map((cell) => this.escapeCsvCell(cell)).join(','));
+      }
+    });
+    const blob = new Blob(['\uFEFF' + lines.join('\r\n')], {
+      type: 'text/csv;charset=utf-8;',
+    });
+    this.triggerBrowserDownload(blob, this.ensureExtension(filename, 'csv'));
+  }
+
+  downloadPdf(options: TreasuryExportOptions): void {
+    this.triggerBrowserDownload(this.buildPdfBlob(options), this.ensureExtension(options.filename, 'pdf'));
+  }
+
+  buildPdfBlob(options: TreasuryExportOptions): Blob {
+    return this.buildPdfDoc(options).output('blob');
+  }
+
+  private buildPdfDoc(options: TreasuryExportOptions): jsPDF {
+    const doc = new jsPDF({
+      orientation: options.orientation ?? 'landscape',
+      unit: 'pt',
+      format: 'a4',
+    });
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(16);
+    doc.text(options.title, 40, 36);
+
+    let startY = 54;
+    if (options.subtitle) {
+      doc.setFontSize(11);
+      doc.setFont('helvetica', 'normal');
+      doc.text(options.subtitle, 40, startY);
+      startY += 16;
+    }
+
+    doc.setFontSize(10);
+    doc.text(`Generado: ${this.formatDate(new Date())}`, 40, startY);
+    startY += 12;
+
+    autoTable(doc, {
+      startY: startY + 8,
+      theme: 'grid',
+      head: [options.headers],
+      body: options.rows.map((row) => row.map((cell) => String(cell ?? ''))),
+      styles: { fontSize: 8, cellPadding: 4 },
+      headStyles: { fillColor: [0, 86, 179], textColor: 255 },
+    });
+
+    return doc;
+  }
+
+  downloadPdfSections(
+    title: string,
+    filename: string,
+    sections: TreasuryExportSection[],
+    orientation: 'portrait' | 'landscape' = 'landscape',
+  ): void {
+    this.triggerBrowserDownload(
+      this.buildPdfSectionsBlob(title, sections, orientation),
+      this.ensureExtension(filename, 'pdf'),
+    );
+  }
+
+  buildPdfSectionsBlob(
+    title: string,
+    sections: TreasuryExportSection[],
+    orientation: 'portrait' | 'landscape' = 'landscape',
+  ): Blob {
+    return this.buildPdfSectionsDoc(title, sections, orientation).output('blob');
+  }
+
+  private buildPdfSectionsDoc(
+    title: string,
+    sections: TreasuryExportSection[],
+    orientation: 'portrait' | 'landscape' = 'landscape',
+  ): jsPDF {
+    const doc = new jsPDF({ orientation, unit: 'pt', format: 'a4' });
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(16);
+    doc.text(title, 40, 36);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.text(`Generado: ${this.formatDate(new Date())}`, 40, 52);
+
+    let startY = 68;
+    sections.forEach((section, index) => {
+      if (index > 0) startY += 16;
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(12);
+      doc.text(section.title, 40, startY);
+      startY += 10;
+
+      autoTable(doc, {
+        startY,
+        theme: 'grid',
+        head: [section.headers],
+        body: section.rows.map((row) => row.map((cell) => String(cell ?? ''))),
+        styles: { fontSize: 8, cellPadding: 4 },
+        headStyles: { fillColor: [0, 86, 179], textColor: 255 },
+      });
+
+      startY = ((doc as any).lastAutoTable?.finalY ?? startY) + 8;
+    });
+
+    return doc;
+  }
+
+  formatDate(date: Date | string): string {
+    return new Intl.DateTimeFormat('es-CO', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(date));
+  }
+
+  formatCurrency(amount: number): string {
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount || 0);
+  }
+
+  sanitizeFilename(name: string): string {
+    return name.replace(/[^a-zA-Z0-9_-]/g, '_');
+  }
+
+  datedFilename(prefix: string, ext: string): string {
+    return `${this.sanitizeFilename(prefix)}-${new Date().toISOString().slice(0, 10)}.${ext}`;
+  }
+
+  escapeCsvCell(value: string | number | null | undefined): string {
+    const text = String(value ?? '');
+    if (/[",\r\n]/.test(text)) {
+      return `"${text.replace(/"/g, '""')}"`;
+    }
+    return text;
+  }
+
+  private ensureExtension(filename: string, ext: string): string {
+    const normalized = filename.trim();
+    if (normalized.toLowerCase().endsWith(`.${ext}`)) {
+      return normalized;
+    }
+    return `${normalized}.${ext}`;
+  }
+
+  triggerBrowserDownload(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.rel = 'noopener';
+    anchor.click();
+    window.setTimeout(() => URL.revokeObjectURL(url), 40_000);
+  }
+}

--- a/src/app/Financial/Treasury/Shared/treasury-help-content.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-help-content.ts
@@ -1,0 +1,60 @@
+/** Textos iniciales del popover ? para pantallas de Tesorería (editable en Centro de Ayuda). */
+export const TREASURY_HELP = {
+  operations: {
+    title: 'Operaciones de Tesorería',
+    summary:
+      'Consolida obligaciones por pagar, comprobantes de egreso, programaciones y bajas de CxP. ' +
+      'Los métodos de pago activos se vinculan a cuentas contables del catálogo; si un método exige cuenta bancaria, debe seleccionarse antes de pagar.',
+    slug: 'tesoreria',
+  },
+  expenseReceipts: {
+    title: 'Comprobantes de egreso',
+    summary:
+      'Registro de pagos a proveedores. Solo aparecen proveedores con facturas pendientes (CxP). ' +
+      'Un abono parcial reduce el saldo; la anulación revierte el comprobante contabilizado.',
+    slug: 'tesoreria',
+  },
+  makePayment: {
+    title: 'Efectuar pago',
+    summary:
+      'Genera un comprobante de egreso aplicado a una o varias facturas del proveedor. ' +
+      'Seleccione método de pago y, si aplica, la cuenta bancaria exigida por el método.',
+    slug: 'tesoreria',
+  },
+  paymentSchedule: {
+    title: 'Programación de pagos',
+    summary:
+      'Consulta obligaciones sincronizadas desde Facturación con saldo pendiente. ' +
+      'Permite filtrar por proveedor, estado y vencimiento para planificar pagos.',
+    slug: 'tesoreria',
+  },
+  agingReport: {
+    title: 'Antigüedad de saldos',
+    summary:
+      'Clasifica las obligaciones pendientes por días de vencimiento (corriente, 1-30, 31-60, 61-90 y 91+). ' +
+      'Los filtros de proveedor provienen de cuentas por pagar activas.',
+    slug: 'tesoreria',
+  },
+  vendorReports: {
+    title: 'Estado de proveedores',
+    summary:
+      'Resume débitos, créditos y saldo pendiente por proveedor con CxP. ' +
+      'El detalle muestra movimientos del período y antigüedad de saldos.',
+    slug: 'tesoreria',
+  },
+} as const;
+
+export const ACCOUNT_CATALOGUE_HELP = {
+  title: 'Catálogo de Cuentas PUC',
+  summary:
+    'El Plan Único de Cuentas (PUC) es una herramienta contable que organiza y clasifica sistemáticamente las cuentas según su naturaleza y función. ' +
+    'Permite estructurar la información financiera de manera jerárquica mediante clases, grupos, cuentas y subcuentas para un registro contable preciso y estandarizado.',
+  slug: 'configuracion',
+} as const;
+
+export const PAYMENT_METHODS_HELP = {
+  title: 'Métodos de pago',
+  summary:
+    'Cada método se asocia a una cuenta contable del catálogo. La opción «Requiere cuenta bancaria al pagar» obliga a seleccionar una cuenta bancaria en Tesorería al efectuar el pago.',
+  slug: 'configuracion',
+} as const;

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.spec.ts
@@ -1,0 +1,48 @@
+import {
+  educationalDescription,
+  exportSuccessDetail,
+  payableStatusLabel,
+  scheduleStatusLabel,
+  translatePaymentMethodName,
+  voucherStatusLabel,
+} from './treasury-status-labels';
+
+describe('treasury-status-labels', () => {
+  it('maps voucher statuses to Spanish labels', () => {
+    expect(voucherStatusLabel('DRAFT')).toBe('Borrador');
+    expect(voucherStatusLabel('POSTED')).toBe('Contabilizado');
+    expect(voucherStatusLabel('VOIDED')).toBe('Anulado');
+    expect(voucherStatusLabel('FAILED')).toBe('Fallido');
+    expect(voucherStatusLabel('UNKNOWN')).toBe('Desconocido');
+  });
+
+  it('maps schedule statuses to Spanish labels', () => {
+    expect(scheduleStatusLabel('EXECUTED')).toBe('Ejecutado');
+    expect(scheduleStatusLabel('WAITING_ACCOUNTING')).toBe('Esperando contabilización');
+    expect(scheduleStatusLabel('FAILED')).toBe('Fallido');
+  });
+
+  it('maps payable statuses including partial payment', () => {
+    expect(payableStatusLabel('PARTIALLY_PAID')).toBe('Abono parcial');
+  });
+
+  it('translates payment method codes and common English names', () => {
+    expect(translatePaymentMethodName('CASH')).toBe('Efectivo');
+    expect(translatePaymentMethodName('BANK_TRANSFER')).toBe('Transferencia bancaria');
+    expect(translatePaymentMethodName('CHECK')).toBe('Cheque');
+    expect(translatePaymentMethodName('CREDIT_CARD')).toBe('Tarjeta');
+  });
+
+  it('translates lab observation patterns', () => {
+    expect(educationalDescription('VOID case')).toBe('Anulación de comprobante');
+    expect(educationalDescription('Bank transfer')).toBe('Transferencia bancaria');
+    expect(educationalDescription('Part abono')).toBe('Abono parcial');
+    expect(educationalDescription('Full cash')).toBe('Pago total en efectivo');
+    expect(educationalDescription('Multi invoice')).toBe('Pago múltiple');
+  });
+
+  it('builds export success messages in Spanish', () => {
+    expect(exportSuccessDetail('operaciones', 'pdf')).toContain('PDF');
+    expect(exportSuccessDetail('operaciones', 'csv')).toContain('CSV');
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
@@ -1,27 +1,27 @@
-/** Etiquetas en español para estados de Tesorería (uso educativo). */
+/** Etiquetas visuales en español para Tesorería (no alteran enums/API). */
 const VOUCHER_LABELS: Record<string, string> = {
-  DRAFT: 'Sin contabilizar',
+  DRAFT: 'Borrador',
   POSTING: 'Contabilizando',
   POSTED: 'Contabilizado',
-  FAILED: 'No se pudo contabilizar',
+  FAILED: 'Fallido',
   VOIDING: 'Anulando',
   VOIDED: 'Anulado',
-  VOID_FAILED: 'No se pudo anular',
+  VOID_FAILED: 'Anulación fallida',
 };
 
 const SCHEDULE_LABELS: Record<string, string> = {
   SCHEDULED: 'Programado',
   PROCESSING: 'En proceso',
-  WAITING_ACCOUNTING: 'Pendiente de contabilizar',
-  EXECUTED: 'Realizado',
-  FAILED: 'No se pudo ejecutar',
+  WAITING_ACCOUNTING: 'Esperando contabilización',
+  EXECUTED: 'Ejecutado',
+  FAILED: 'Fallido',
   CANCELED: 'Cancelado',
 };
 
 const PAYABLE_LABELS: Record<string, string> = {
   DRAFT: 'Borrador',
   POSTED: 'Pendiente de pago',
-  PARTIALLY_PAID: 'Pago parcial',
+  PARTIALLY_PAID: 'Abono parcial',
   PAID: 'Pagada',
   CANCELLED: 'Cancelada',
 };
@@ -36,29 +36,41 @@ const ACCOUNTING_ENTRY_LABELS: Record<string, string> = {
   VOIDED: 'Anulado',
 };
 
+const PAYMENT_METHOD_NAME_LABELS: Record<string, string> = {
+  CASH: 'Efectivo',
+  TRANSFER: 'Transferencia bancaria',
+  BANK_TRANSFER: 'Transferencia bancaria',
+  BANK: 'Transferencia bancaria',
+  CHECK: 'Cheque',
+  CHEQUE: 'Cheque',
+  CREDIT_CARD: 'Tarjeta',
+  CARD: 'Tarjeta',
+  DEBIT_CARD: 'Tarjeta débito',
+};
+
 export function voucherStatusLabel(status?: string | null): string {
   if (!status) return 'Desconocido';
-  return VOUCHER_LABELS[status] ?? status;
+  return VOUCHER_LABELS[status] ?? 'Desconocido';
 }
 
 export function scheduleStatusLabel(status?: string | null): string {
   if (!status) return 'Desconocido';
-  return SCHEDULE_LABELS[status] ?? status;
+  return SCHEDULE_LABELS[status] ?? 'Desconocido';
 }
 
 export function payableStatusLabel(status?: string | null): string {
   if (!status) return 'Desconocido';
-  return PAYABLE_LABELS[status] ?? status;
+  return PAYABLE_LABELS[status] ?? 'Desconocido';
 }
 
 export function transactionTypeLabel(type?: string | null): string {
   if (!type) return '-';
-  return TRANSACTION_TYPE_LABELS[type] ?? type;
+  return TRANSACTION_TYPE_LABELS[type] ?? 'Desconocido';
 }
 
 export function accountingEntryStatusLabel(status?: string | null): string {
   if (!status) return '-';
-  return ACCOUNTING_ENTRY_LABELS[status] ?? status;
+  return ACCOUNTING_ENTRY_LABELS[status] ?? 'Desconocido';
 }
 
 export function voucherStatusFilterOptions(includeAll = true) {
@@ -66,21 +78,55 @@ export function voucherStatusFilterOptions(includeAll = true) {
   return includeAll ? [{ label: 'Todos los estados', value: '' }, ...options] : options;
 }
 
-/** Observaciones de laboratorio → texto educativo para el estudiante. */
+export function exportFormatLabel(format: 'csv' | 'pdf'): string {
+  return format === 'pdf' ? 'PDF' : 'CSV';
+}
+
+export function exportSuccessDetail(context: string, format: 'csv' | 'pdf'): string {
+  return `Se descargó el ${exportFormatLabel(format)} de ${context}.`;
+}
+
+export function exportErrorDetail(format: 'csv' | 'pdf'): string {
+  return `No se pudo exportar el ${exportFormatLabel(format)}.`;
+}
+
+/** Traduce nombres/códigos visibles de métodos de pago sin tocar el valor interno. */
+export function translatePaymentMethodName(name?: string | null): string {
+  const text = (name ?? '').trim();
+  if (!text) return '-';
+
+  const normalized = text.toUpperCase().replace(/[\s-]+/g, '_');
+  if (PAYMENT_METHOD_NAME_LABELS[normalized]) {
+    return PAYMENT_METHOD_NAME_LABELS[normalized];
+  }
+
+  const replacements: Array<[RegExp, string]> = [
+    [/\bbank[\s_-]?transfer\b/i, 'Transferencia bancaria'],
+    [/\btransfer\b/i, 'Transferencia bancaria'],
+    [/\bfull[\s_-]?cash\b/i, 'Pago total en efectivo'],
+    [/\bcredit[\s_-]?card\b/i, 'Tarjeta'],
+    [/\bcheck\b/i, 'Cheque'],
+    [/\bcash\b/i, 'Efectivo'],
+  ];
+
+  let result = text;
+  for (const [pattern, label] of replacements) {
+    result = result.replace(pattern, label);
+  }
+  return result;
+}
+
+/** Observaciones técnicas → texto educativo en español. */
 const LAB_DESCRIPTION_PATTERNS: Array<{ test: RegExp; label: string }> = [
-  { test: /\bvoid\b/i, label: 'Anulación del pago (la deuda vuelve)' },
-  { test: /\bmulti\b/i, label: 'Un pago aplicado a varias facturas' },
-  { test: /\bbank\b/i, label: 'Pago por transferencia bancaria' },
-  { test: /\bpart\b/i, label: 'Abono parcial (pagó solo una parte)' },
-  { test: /\bfull\b/i, label: 'Pago total de la factura' },
+  { test: /\bvoid\b/i, label: 'Anulación de comprobante' },
+  { test: /\bmulti\b/i, label: 'Pago múltiple' },
+  { test: /\bbank[\s_-]?transfer\b|\bbank\b/i, label: 'Transferencia bancaria' },
+  { test: /\bpart\b|\babono\b/i, label: 'Abono parcial' },
+  { test: /\bfull[\s_-]?cash\b|\bfull\b/i, label: 'Pago total en efectivo' },
   { test: /\bover\b/i, label: 'Intento de pago por más del saldo' },
   { test: /\bsched\b/i, label: 'Pago programado' },
 ];
 
-/**
- * Convierte observaciones técnicas de prueba (VOID, MULTI, PART…)
- * en descripciones claras para uso educativo.
- */
 export function educationalDescription(raw?: string | null, fallback = 'Pago a proveedor'): string {
   const text = (raw ?? '').trim();
   if (!text) return fallback;
@@ -89,7 +135,6 @@ export function educationalDescription(raw?: string | null, fallback = 'Pago a p
     if (test.test(text)) return label;
   }
 
-  // "Pago de 1 factura(s): 9306" → "Pago de 1 factura: 9306"
   const paymentOfInvoices = text.match(/^Pago de (\d+)\s*factura\(s\):\s*(.+)$/i);
   if (paymentOfInvoices) {
     const count = Number(paymentOfInvoices[1]);
@@ -98,5 +143,9 @@ export function educationalDescription(raw?: string | null, fallback = 'Pago a p
     return `Pago de ${count} ${noun}: ${refs}`;
   }
 
-  return text;
+  return translatePaymentMethodName(text);
+}
+
+export function reportEmptyFiltersMessage(): string {
+  return 'No hay información para los filtros seleccionados';
 }

--- a/src/app/Financial/Treasury/Shared/treasury-third-party.integration.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-third-party.integration.spec.ts
@@ -1,0 +1,17 @@
+import { buildThirdPartyNameMap, resolveSupplierName } from './treasury-third-party.integration';
+
+describe('treasury-third-party.integration', () => {
+  it('builds a name map from third parties', () => {
+    const map = buildThirdPartyNameMap([
+      { thId: 7, socialReason: 'Proveedor Alfa S.A.S.' },
+      { thId: 8, names: 'Juan', lastNames: 'Pérez' },
+    ]);
+    expect(map.get(7)).toBe('Proveedor Alfa S.A.S.');
+    expect(map.get(8)).toBe('Juan Pérez');
+  });
+
+  it('falls back to Proveedor {id} when name is missing', () => {
+    const map = buildThirdPartyNameMap([]);
+    expect(resolveSupplierName(map, 99)).toBe('Proveedor 99');
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
@@ -1,0 +1,21 @@
+/** Resolución de nombres de proveedores desde Terceros (solo visualización). */
+export function buildThirdPartyNameMap(thirds: Array<{
+  thId?: number;
+  socialReason?: string;
+  names?: string;
+  lastNames?: string;
+}>): Map<number, string> {
+  return new Map(
+    (thirds || []).map((third) => {
+      const name =
+        (third.socialReason as string) ||
+        [third.names, third.lastNames].filter(Boolean).join(' ') ||
+        `Proveedor ${third.thId}`;
+      return [Number(third.thId), String(name)] as [number, string];
+    }),
+  );
+}
+
+export function resolveSupplierName(map: Map<number, string>, supplierId: number): string {
+  return map.get(Number(supplierId)) || `Proveedor ${supplierId}`;
+}

--- a/src/app/GeneralMasters/AccountCatalogue/services/account-catalogue-presentation.service.spec.ts
+++ b/src/app/GeneralMasters/AccountCatalogue/services/account-catalogue-presentation.service.spec.ts
@@ -1,0 +1,31 @@
+import { AccountCataloguePresentationService } from './account-catalogue-presentation.service';
+import { Account } from '../models/ChartAccount';
+
+describe('AccountCataloguePresentationService', () => {
+  let service: AccountCataloguePresentationService;
+
+  const accounts: Account[] = [
+    { id: 1, code: '11050501', description: 'Caja', status: true, nature: 'Debito', financialStatus: 'Estado de Situacion Financiero', classification: 'Activo Corriente' },
+    { id: 2, code: '22050101', description: 'Proveedor A', status: false, nature: 'Credito', financialStatus: 'Estado de Situacion Financiero', classification: 'Pasivo Corriente' },
+    { id: 3, code: '22050102', description: 'Proveedor B', status: true, nature: 'Credito', financialStatus: 'Estado de Situacion Financiero', classification: 'Pasivo Corriente' },
+  ];
+
+  beforeEach(() => {
+    service = new AccountCataloguePresentationService();
+  });
+
+  it('filters only active auxiliary accounts for new operations', () => {
+    const active = service.filterActiveAuxiliaryAccounts(accounts);
+    expect(active.map((item) => item.id)).toEqual([1, 3]);
+  });
+
+  it('keeps preserved inactive account visible in edit forms', () => {
+    const selectable = service.filterSelectableAuxiliaryAccounts(accounts, 2);
+    expect(selectable.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+
+  it('marks inactive preserved account in label', () => {
+    expect(service.formatAccountingAccountLabel(accounts[1], true)).toContain('(Inactiva)');
+    expect(service.formatAccountingAccountLabel(accounts[0], true)).not.toContain('(Inactiva)');
+  });
+});

--- a/src/app/GeneralMasters/AccountCatalogue/services/account-catalogue-presentation.service.ts
+++ b/src/app/GeneralMasters/AccountCatalogue/services/account-catalogue-presentation.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Account } from '../models/ChartAccount';
 
 @Injectable({
   providedIn: 'root'
@@ -38,5 +39,26 @@ export class AccountCataloguePresentationService {
    */
   isAccountLinked(accountCode: string, listRefundAccount: string[], listDepositAccount: string[]): boolean {
     return listRefundAccount.includes(accountCode) || listDepositAccount.includes(accountCode);
+  }
+
+  /** Cuentas auxiliares activas aptas para operaciones nuevas. */
+  filterActiveAuxiliaryAccounts(accounts: Account[]): Account[] {
+    return accounts.filter((account) => account.id !== undefined && account.status !== false);
+  }
+
+  /**
+   * Cuentas seleccionables en formularios: activas + la cuenta histórica preservada (p. ej. edición).
+   */
+  filterSelectableAuxiliaryAccounts(accounts: Account[], preserveAccountId?: number | null): Account[] {
+    return accounts.filter((account) => {
+      if (account.id === undefined) return false;
+      if (account.status !== false) return true;
+      return preserveAccountId != null && account.id === preserveAccountId;
+    });
+  }
+
+  formatAccountingAccountLabel(account: Account, markInactive = false): string {
+    const label = `${account.code} - ${account.description}`;
+    return markInactive && account.status === false ? `${label} (Inactiva)` : label;
   }
 }

--- a/src/app/GeneralMasters/PaymentMethods/components/payment-methods-creation/payment-methods-creation.component.ts
+++ b/src/app/GeneralMasters/PaymentMethods/components/payment-methods-creation/payment-methods-creation.component.ts
@@ -8,6 +8,7 @@ import { MessageService } from 'primeng/api';
 import { SelectModule } from 'primeng/select';
 import { PaymentMethodsServiceService } from '../../services/payment-methods-service.service';
 import { ChartAccountService } from '../../../AccountCatalogue/services/chart-account.service';
+import { AccountCataloguePresentationService } from '../../../AccountCatalogue/services/account-catalogue-presentation.service';
 import { Account } from '../../../AccountCatalogue/models/ChartAccount';
 import { AccountingAccountOption } from '../../models/PaymentMethods';
 
@@ -28,7 +29,8 @@ export class PaymentMethodsCreationComponent {
     private readonly router: Router,
     private readonly messageService: MessageService,
     private readonly service: PaymentMethodsServiceService,
-    private readonly chartAccountService: ChartAccountService
+    private readonly chartAccountService: ChartAccountService,
+    private readonly accountPresentation: AccountCataloguePresentationService
   ) {
     this.form = this.fb.group({
       name: ['', [Validators.required, Validators.maxLength(100)]],
@@ -45,12 +47,12 @@ export class PaymentMethodsCreationComponent {
       // Cargar cuentas auxiliares activas para el dropdown
       this.chartAccountService.getListAuxiliaryAccounts(enterpriseId).subscribe({
         next: (accounts: Account[]) => {
-          this.accountingAccountsOptions = accounts
-            .filter((account: Account) => account.id !== undefined)
+          this.accountingAccountsOptions = this.accountPresentation
+            .filterActiveAuxiliaryAccounts(accounts)
             .map((account: Account) => ({
-              label: `${account.code} - ${account.description}`,
-              value: account.id!, // Usar ID como value
-              code: account.code // Mantener código para referencia
+              label: this.accountPresentation.formatAccountingAccountLabel(account),
+              value: account.id!,
+              code: account.code,
             }));
         },
         error: (error: any) => {
@@ -87,9 +89,14 @@ export class PaymentMethodsCreationComponent {
     const entData = localStorage.getItem('entData');
     const enterpriseId = entData ? JSON.parse(entData).id : '';
     const selectedAccountId = this.form.value.accountingAccount;
-
-    // Obtener la opción seleccionada por ID
-    const selectedOption = this.accountingAccountsOptions.find(option => option.value === selectedAccountId);
+    if (!this.accountingAccountsOptions.some((option) => option.value === selectedAccountId)) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Cuenta no válida',
+        detail: 'Seleccione una cuenta contable activa del catálogo.',
+      });
+      return;
+    }
 
     const payload = {
       idEnterprise: enterpriseId,

--- a/src/app/GeneralMasters/PaymentMethods/components/payment-methods-edit/payment-methods-edit.component.ts
+++ b/src/app/GeneralMasters/PaymentMethods/components/payment-methods-edit/payment-methods-edit.component.ts
@@ -9,6 +9,7 @@ import { SelectModule } from 'primeng/select';
 import { TooltipModule } from 'primeng/tooltip';
 import { PaymentMethodsServiceService } from '../../services/payment-methods-service.service';
 import { ChartAccountService } from '../../../AccountCatalogue/services/chart-account.service';
+import { AccountCataloguePresentationService } from '../../../AccountCatalogue/services/account-catalogue-presentation.service';
 import { Account } from '../../../AccountCatalogue/models/ChartAccount';
 import { AccountingAccountOption, PaymentMethod } from '../../models/PaymentMethods';
 
@@ -23,6 +24,7 @@ export class PaymentMethodsEditComponent implements OnInit {
   form: FormGroup;
   id!: number;
   accountingAccountsOptions: AccountingAccountOption[] = [];
+  private allAuxiliaryAccounts: Account[] = [];
   initialValue: any = {};
   isEditMode: boolean = true; // Siempre es true en este componente de edición
 
@@ -32,7 +34,8 @@ export class PaymentMethodsEditComponent implements OnInit {
     private readonly router: Router,
     private readonly messageService: MessageService,
     private readonly service: PaymentMethodsServiceService,
-    private readonly chartAccountService: ChartAccountService
+    private readonly chartAccountService: ChartAccountService,
+    private readonly accountPresentation: AccountCataloguePresentationService
   ) {
     this.form = this.fb.group({
       name: ['', [Validators.required, Validators.maxLength(100)]],
@@ -73,6 +76,8 @@ export class PaymentMethodsEditComponent implements OnInit {
           requiresBankAccount: paymentMethod.requiresBankAccount
         });
 
+        this.refreshAccountingAccountOptions(accountId);
+
         // Guardar valores iniciales para comparar cambios
         this.initialValue = {
           name: paymentMethod.name,
@@ -93,15 +98,9 @@ export class PaymentMethodsEditComponent implements OnInit {
   private loadAccountingAccounts(enterpriseId: string, callback?: () => void): void {
     this.chartAccountService.getListAuxiliaryAccounts(enterpriseId).subscribe({
       next: (accounts: Account[]) => {
-        this.accountingAccountsOptions = accounts
-          .filter((account: Account) => account.id !== undefined)
-          .map((account: Account) => ({
-            label: `${account.code} - ${account.description}`,
-            value: account.id!, // Usar ID como value
-            code: account.code // Mantener código para referencia
-          }));
+        this.allAuxiliaryAccounts = accounts;
+        this.refreshAccountingAccountOptions();
 
-        // Ejecutar callback si se proporciona
         if (callback) {
           callback();
         }
@@ -115,6 +114,17 @@ export class PaymentMethodsEditComponent implements OnInit {
         });
       }
     });
+  }
+
+  private refreshAccountingAccountOptions(preserveAccountId?: number | null): void {
+    const preserveId = preserveAccountId ?? this.form.get('accountingAccount')?.value ?? null;
+    this.accountingAccountsOptions = this.accountPresentation
+      .filterSelectableAuxiliaryAccounts(this.allAuxiliaryAccounts, preserveId)
+      .map((account: Account) => ({
+        label: this.accountPresentation.formatAccountingAccountLabel(account, account.status === false),
+        value: account.id!,
+        code: account.code,
+      }));
   }
 
   goBack() {
@@ -140,6 +150,18 @@ export class PaymentMethodsEditComponent implements OnInit {
     const entData = localStorage.getItem('entData');
     const enterpriseId = entData ? JSON.parse(entData).id : '';
     const formValues = this.form.value;
+    const selectedAccount = this.allAuxiliaryAccounts.find((account) => account.id === formValues.accountingAccount);
+    if (
+      selectedAccount?.status === false &&
+      formValues.accountingAccount !== this.initialValue.accountingAccount
+    ) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Cuenta no válida',
+        detail: 'No puede asignar una cuenta contable inactiva a un método de pago.',
+      });
+      return;
+    }
 
     const payload = {
       id: this.id,

--- a/src/app/Shared/Components/contextual-help/contextual-help.component.ts
+++ b/src/app/Shared/Components/contextual-help/contextual-help.component.ts
@@ -1,0 +1,47 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnChanges } from '@angular/core';
+import { PopoverModule } from 'primeng/popover';
+import { HelpCenterService } from '../../services/help-center.service';
+
+/**
+ * Icono ? con resumen contextual y enlace al Centro de Ayuda (misma arquitectura que Catálogo PUC).
+ * El contenido extendido lo administra el administrador en /gen-masters/help-center.
+ */
+@Component({
+  selector: 'app-contextual-help',
+  standalone: true,
+  imports: [CommonModule, PopoverModule],
+  template: `
+    <span class="text-primary cursor-pointer inline-flex items-center" (click)="popover.toggle($event)">
+      <i class="pi pi-question-circle" [ngClass]="iconClass"></i>
+    </span>
+    <p-popover #popover>
+      <div class="p-4" style="max-width: 420px">
+        <h3 class="font-bold text-lg mb-3 text-primary">{{ title }}</h3>
+        <p class="text-sm mb-3 text-primary whitespace-pre-line">{{ summary }}</p>
+        <a
+          [href]="helpCenterUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-sm text-blue-600 hover:text-blue-800 underline flex items-center gap-1">
+          Abrir centro de ayuda para más información.
+          <i class="pi pi-external-link text-xs"></i>
+        </a>
+      </div>
+    </p-popover>
+  `,
+})
+export class ContextualHelpComponent implements OnChanges {
+  @Input({ required: true }) title!: string;
+  @Input({ required: true }) summary!: string;
+  @Input({ required: true }) helpCenterSlug!: string;
+  @Input() iconClass = 'text-xl';
+
+  helpCenterUrl = '';
+
+  constructor(private readonly helpCenterService: HelpCenterService) {}
+
+  ngOnChanges(): void {
+    this.helpCenterUrl = this.helpCenterService.getHelpCenterUrl(this.helpCenterSlug || '');
+  }
+}

--- a/src/app/Shared/config/primeng-spanish.translation.ts
+++ b/src/app/Shared/config/primeng-spanish.translation.ts
@@ -1,0 +1,22 @@
+import { Translation } from 'primeng/api';
+
+/** Traducciones visuales mínimas de PrimeNG para la UI en español. */
+export const PRIMENG_SPANISH_TRANSLATION: Translation = {
+  emptyMessage: 'No hay registros disponibles.',
+  emptyFilterMessage: 'No se encontraron resultados.',
+  emptySearchMessage: 'No se encontraron resultados.',
+  emptySelectionMessage: 'No hay elementos seleccionados.',
+  searchMessage: 'Buscar',
+  selectionMessage: '{0} elemento(s) seleccionado(s)',
+  accept: 'Aceptar',
+  reject: 'Rechazar',
+  choose: 'Elegir',
+  upload: 'Subir',
+  cancel: 'Cancelar',
+  clear: 'Limpiar',
+  apply: 'Aplicar',
+  today: 'Hoy',
+  weekHeader: 'Sem',
+  dateFormat: 'dd/mm/yy',
+  firstDayOfWeek: 1,
+};

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -11,6 +11,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { authInterceptor } from './Core/Interceptors/auth.interceptor';
 import { withInterceptors } from '@angular/common/http';
 import { MessageService } from 'primeng/api';
+import { PRIMENG_SPANISH_TRANSLATION } from './Shared/config/primeng-spanish.translation';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -24,6 +25,7 @@ export const appConfig: ApplicationConfig = {
           darkModeSelector: '.my-app-dark',
         },
       },
+      translation: PRIMENG_SPANISH_TRANSLATION,
     }),
     AuthService,
     {

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -3,4 +3,6 @@ export const environment = {
   keycloak_url: 'http://contables.unicauca.edu.co/dev/api/keycloak/',
   keycloak_url_token: 'http://contables.unicauca.edu.co/dev/api/keycloak/token/',
   API_URL: 'http://contables.unicauca.edu.co/dev/api/',
+  /** Solo UI DEV: precarga el correo en login; la contraseña siempre la ingresa el usuario. */
+  defaultLoginUsername: 'contables2@unicauca.edu.co',
 };

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -3,4 +3,5 @@ export const environment = {
   keycloak_url: 'http://localhost:8080/api/keycloak/',
   keycloak_url_token: 'http://localhost:8080/api/keycloak/token/',
   API_URL: 'http://localhost:8080/api/',
+  defaultLoginUsername: '',
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -3,4 +3,5 @@ export const environment = {
   keycloak_url: 'http://contables.unicauca.edu.co/dev/api/keycloak/',
   keycloak_url_token: 'http://contables.unicauca.edu.co/dev/api/keycloak/token/',
   API_URL: 'http://contables.unicauca.edu.co/test/api/',
+  defaultLoginUsername: '',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,4 +3,5 @@ export const environment = {
   keycloak_url: 'http://contables.unicauca.edu.co/dev/api/keycloak/',
   keycloak_url_token: 'http://contables.unicauca.edu.co/dev/api/keycloak/token/',
   API_URL: 'http://contables.unicauca.edu.co/dev/api/',
+  defaultLoginUsername: '',
 };


### PR DESCRIPTION
## Summary
- Treasury module in consistent Spanish with PDF/CSV exports across operations, bills, receipts, aging and vendor reports.
- Account catalogue and payment method integration (active accounts only, preserve historical inactive links, requiresBankAccount validation).
- Supplier selectors remain CxP-driven with ThirdService name enrichment; aging account labels fixed by PUC code.
- Contextual Help Center hooks on Treasury screens; PrimeNG Spanish locale; DEV login preloads contables2@unicauca.edu.co (password always empty).
- Unit tests (36) and Playwright Treasury E2E (9) added/updated.

## Test plan
- [x] ng test Treasury + login specs (36/36)
- [x] ng build --configuration=local
- [x] ng build --configuration=dev
- [x] playwright treasury-catalogue-integration + treasury-exports (9/9)
- [ ] CI build-for-develop after merge
- [ ] DEV smoke on http://contables.unicauca.edu.co/dev/#/login (email prefilled, Keycloak auth unchanged)