### PR TITLE
fix(commercial): selector de proveedores activos y UI factura de compra

### DIFF
--- a/e2e/pp8/critical-journeys.spec.ts
+++ b/e2e/pp8/critical-journeys.spec.ts
@@ -4,9 +4,9 @@ const gateway = process.env.PP8_GATEWAY_URL ?? 'http://localhost:8080';
 const username = process.env.PP8_E2E_USERNAME;
 const password = process.env.PP8_E2E_PASSWORD;
 const enterpriseId = process.env.PP8_E2E_ENTERPRISE_ID ?? 'enterprise-e2e';
-const supplierId = Number(process.env.PP8_E2E_SUPPLIER_ID ?? '77');
 const paymentMethodId = Number(process.env.PP8_E2E_PAYMENT_METHOD_ID ?? '8');
 const mailpit = process.env.PP8_MAILPIT_URL ?? 'http://localhost:18025';
+let supplierId: number;
 
 /** Fecha local ISO (YYYY-MM-DD) para evitar fechas fijas que caducan en @FutureOrPresent. */
 function isoDateLocal(date = new Date()): string {
@@ -47,7 +47,16 @@ async function loginThroughAngular(page: Page): Promise<string> {
   await page.evaluate((enterprise) => localStorage.setItem('entData', JSON.stringify({
     id: enterprise, name: 'PP8 E2E', nit: 'E2E', logo: '', inventoryConfigType: 'WEIGHTED_AVERAGE',
   })), enterpriseId);
-  return (await page.evaluate(() => localStorage.getItem('token'))) as string;
+  const token = (await page.evaluate(() => localStorage.getItem('token'))) as string;
+  const activeThirds = await page.request.get(`${gateway}/api/thirds/findAllActive`, {
+    headers: headers(token),
+    params: { entId: enterpriseId },
+  });
+  expect(activeThirds.ok()).toBe(true);
+  const thirds = (await activeThirds.json()).content;
+  expect(thirds.length).toBeGreaterThan(0);
+  supplierId = Number(thirds[0].thId);
+  return token;
 }
 
 function headers(token: string) {

--- a/e2e/pp8/critical-journeys.spec.ts
+++ b/e2e/pp8/critical-journeys.spec.ts
@@ -6,6 +6,7 @@ const password = process.env.PP8_E2E_PASSWORD;
 const enterpriseId = process.env.PP8_E2E_ENTERPRISE_ID ?? 'enterprise-e2e';
 const paymentMethodId = Number(process.env.PP8_E2E_PAYMENT_METHOD_ID ?? '8');
 const mailpit = process.env.PP8_MAILPIT_URL ?? 'http://localhost:18025';
+const supplierTypeName = 'Proveedor';
 let supplierId: number;
 
 /** Fecha local ISO (YYYY-MM-DD) para evitar fechas fijas que caducan en @FutureOrPresent. */
@@ -48,14 +49,14 @@ async function loginThroughAngular(page: Page): Promise<string> {
     id: enterprise, name: 'PP8 E2E', nit: 'E2E', logo: '', inventoryConfigType: 'WEIGHTED_AVERAGE',
   })), enterpriseId);
   const token = (await page.evaluate(() => localStorage.getItem('token'))) as string;
-  const activeThirds = await page.request.get(`${gateway}/api/thirds/findAllActive`, {
+  const suppliersResponse = await page.request.get(`${gateway}/api/thirds/by-type`, {
     headers: headers(token),
-    params: { entId: enterpriseId },
+    params: { entId: enterpriseId, thirdTypeName: supplierTypeName },
   });
-  expect(activeThirds.ok()).toBe(true);
-  const thirds = (await activeThirds.json()).content;
-  expect(thirds.length).toBeGreaterThan(0);
-  supplierId = Number(thirds[0].thId);
+  expect(suppliersResponse.ok()).toBe(true);
+  const suppliers = (await suppliersResponse.json()).content;
+  expect(suppliers.length).toBeGreaterThan(0);
+  supplierId = Number(suppliers[0].thId);
   return token;
 }
 
@@ -129,6 +130,19 @@ test('2. compra → obligación → pago → asiento → correo con servicios re
   const token = await loginThroughAngular(page);
   const beforeMail = (await (await page.request.get(`${mailpit}/api/v1/messages`)).json()).messages_count;
   const { payable } = await createPurchaseAndWaitForPayable(page, token);
+  const suppliers = await page.request.get(`${gateway}/api/thirds/by-type`, {
+    headers: headers(token),
+    params: { entId: enterpriseId, thirdTypeName: supplierTypeName },
+  });
+  expect(suppliers.ok()).toBe(true);
+  const supplier = (await suppliers.json()).content.find((item: any) => Number(item.thId) === supplierId);
+  expect(supplier).toBeTruthy();
+  const supplierLabel = supplier.socialReason
+    || [supplier.names, supplier.lastNames].filter(Boolean).join(' ')
+    || `Proveedor ${supplierId}`;
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  await expect(page.locator('.p-datatable').first().getByText(supplierLabel, { exact: false }).first()).toBeVisible();
   const voucherId = await createAndPostVoucher(page, token, payable, 40);
   const voucher = await (await page.request.get(`${gateway}/api/treasury/payment-vouchers/${voucherId}`, {
     headers: headers(token), params: { enterpriseId },

--- a/e2e/pp8/purchase-invoice-ui.spec.ts
+++ b/e2e/pp8/purchase-invoice-ui.spec.ts
@@ -4,6 +4,7 @@ const gateway = process.env.PP8_GATEWAY_URL ?? 'http://localhost:8080';
 const username = process.env.PP8_E2E_USERNAME;
 const password = process.env.PP8_E2E_PASSWORD;
 const enterpriseId = process.env.PP8_E2E_ENTERPRISE_ID ?? 'enterprise-e2e';
+const supplierTypeName = 'Proveedor';
 
 test('factura de compra selecciona un tercero activo y envía su thId', async ({ page }) => {
   if (!username || !password) {
@@ -13,7 +14,11 @@ test('factura de compra selecciona un tercero activo y envía su thId', async ({
   await page.goto('/login');
   await page.locator('#username').fill(username!);
   await page.locator('#password').fill(password!);
+  const tokenResponse = page.waitForResponse((response) =>
+    response.url().includes('/api/keycloak/token/') && response.request().method() === 'POST',
+  );
   await page.getByRole('button', { name: 'Iniciar sesión' }).click();
+  expect((await tokenResponse).status()).toBe(200);
   await page.waitForURL(/#\/enterprise\/list/, { timeout: 20_000 });
   const token = await page.evaluate(() => localStorage.getItem('token'));
   expect(token).toBeTruthy();
@@ -21,17 +26,17 @@ test('factura de compra selecciona un tercero activo y envía su thId', async ({
     id: enterprise, name: 'PP8 E2E', nit: 'E2E', logo: '', inventoryConfigType: 'WEIGHTED_AVERAGE',
   })), enterpriseId);
 
-  const activeThirdsResponse = await page.request.get(`${gateway}/api/thirds/findAllActive`, {
+  const suppliersResponse = await page.request.get(`${gateway}/api/thirds/by-type`, {
     headers: { Authorization: `Bearer ${token}` },
-    params: { entId: enterpriseId },
+    params: { entId: enterpriseId, thirdTypeName: supplierTypeName },
   });
-  expect(activeThirdsResponse.ok()).toBe(true);
-  const activeThirds = (await activeThirdsResponse.json()).content;
-  expect(activeThirds.length).toBeGreaterThan(0);
-  const expectedThird = activeThirds[0];
+  expect(suppliersResponse.ok()).toBe(true);
+  const suppliers = (await suppliersResponse.json()).content;
+  expect(suppliers.length).toBeGreaterThan(0);
+  const expectedThird = suppliers[0];
 
   const supplierLoad = page.waitForResponse((response) =>
-    response.url().includes('/api/thirds/findAllActive') && response.request().method() === 'GET',
+    response.url().includes('/api/thirds/by-type') && response.request().method() === 'GET',
   );
   await page.goto('/#/commercial/purchase-invoice');
   expect((await supplierLoad).status()).toBe(200);
@@ -52,7 +57,7 @@ test('factura de compra selecciona un tercero activo y envía su thId', async ({
         content: [{
           id: 501, code: 'E2E-501', name: 'Producto E2E', description: 'Producto para validar payload',
           quantity: 10, unitOfMeasureId: null, categoryId: null, enterpriseId, cost: 100,
-          state: true, reference: 'E2E-501',
+          state: true, reference: 'E2E-501', taxPercentage: 0,
         }],
         page: { size: 1, number: 0, totalElements: 1, totalPages: 1 },
       }),
@@ -61,8 +66,12 @@ test('factura de compra selecciona un tercero activo y envía su thId', async ({
   await page.getByRole('button', { name: 'Agregar productos' }).click();
   const productDialog = page.locator('.p-dialog');
   await expect(productDialog).toBeVisible();
-  await productDialog.getByRole('checkbox').first().click();
-  await productDialog.getByRole('button', { name: 'Confirmar Selección' }).click();
+  await expect(productDialog.getByText('E2E-501')).toBeVisible({ timeout: 10_000 });
+  const productRow = productDialog.locator('tbody tr').filter({ hasText: 'E2E-501' });
+  await productRow.getByRole('checkbox').click();
+  const confirmSelection = productDialog.getByRole('button', { name: 'Confirmar Selección' });
+  await expect(confirmSelection).toBeEnabled();
+  await confirmSelection.click();
   await expect(productDialog).toBeHidden({ timeout: 10_000 });
   await expect(page.getByText('Producto E2E')).toBeVisible();
 

--- a/e2e/pp8/purchase-invoice-ui.spec.ts
+++ b/e2e/pp8/purchase-invoice-ui.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
 
+const gateway = process.env.PP8_GATEWAY_URL ?? 'http://localhost:8080';
 const username = process.env.PP8_E2E_USERNAME;
 const password = process.env.PP8_E2E_PASSWORD;
 const enterpriseId = process.env.PP8_E2E_ENTERPRISE_ID ?? 'enterprise-e2e';
 
-test('factura de compra UI no expone cuenta CxP ni thId manual', async ({ page }) => {
+test('factura de compra selecciona un tercero activo y envía su thId', async ({ page }) => {
   if (!username || !password) {
     test.skip(true, 'PP8_E2E_USERNAME y PP8_E2E_PASSWORD son obligatorios');
   }
@@ -14,13 +15,67 @@ test('factura de compra UI no expone cuenta CxP ni thId manual', async ({ page }
   await page.locator('#password').fill(password!);
   await page.getByRole('button', { name: 'Iniciar sesión' }).click();
   await page.waitForURL(/#\/enterprise\/list/, { timeout: 20_000 });
+  const token = await page.evaluate(() => localStorage.getItem('token'));
+  expect(token).toBeTruthy();
   await page.evaluate((enterprise) => localStorage.setItem('entData', JSON.stringify({
     id: enterprise, name: 'PP8 E2E', nit: 'E2E', logo: '', inventoryConfigType: 'WEIGHTED_AVERAGE',
   })), enterpriseId);
 
+  const activeThirdsResponse = await page.request.get(`${gateway}/api/thirds/findAllActive`, {
+    headers: { Authorization: `Bearer ${token}` },
+    params: { entId: enterpriseId },
+  });
+  expect(activeThirdsResponse.ok()).toBe(true);
+  const activeThirds = (await activeThirdsResponse.json()).content;
+  expect(activeThirds.length).toBeGreaterThan(0);
+  const expectedThird = activeThirds[0];
+
+  const supplierLoad = page.waitForResponse((response) =>
+    response.url().includes('/api/thirds/findAllActive') && response.request().method() === 'GET',
+  );
   await page.goto('/#/commercial/purchase-invoice');
+  expect((await supplierLoad).status()).toBe(200);
   await expect(page.getByRole('heading', { name: /Creaci[oó]n de Factura de Compra/i })).toBeVisible();
-  await expect(page.locator('#supplierSearch')).toBeVisible();
+  const supplierInput = page.locator('#supplierSearch input');
+  await expect(supplierInput).toBeVisible();
+  await supplierInput.fill(String(expectedThird.idNumber));
+  const supplierOptions = page.locator('[role="option"]').filter({ hasNotText: 'No se encontraron resultados' });
+  await expect(supplierOptions.first()).toBeVisible();
+  await expect(supplierOptions).not.toHaveCount(0);
+  await supplierOptions.first().click();
+
+  await page.route('**/api/products/findActivate**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        content: [{
+          id: 501, code: 'E2E-501', name: 'Producto E2E', description: 'Producto para validar payload',
+          quantity: 10, unitOfMeasureId: null, categoryId: null, enterpriseId, cost: 100,
+          state: true, reference: 'E2E-501',
+        }],
+        page: { size: 1, number: 0, totalElements: 1, totalPages: 1 },
+      }),
+    });
+  });
+  await page.getByRole('button', { name: 'Agregar productos' }).click();
+  const productDialog = page.locator('.p-dialog');
+  await expect(productDialog).toBeVisible();
+  await productDialog.getByRole('checkbox').first().click();
+  await productDialog.getByRole('button', { name: 'Confirmar Selección' }).click();
+  await expect(productDialog).toBeHidden({ timeout: 10_000 });
+  await expect(page.getByText('Producto E2E')).toBeVisible();
+
+  let purchasePayload: any;
+  await page.route('**/api/factures/skeleton/purchase', async (route) => {
+    purchasePayload = route.request().postDataJSON();
+    await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 1 }) });
+  });
+  const saveButton = page.getByRole('button', { name: 'Guardar factura' });
+  await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+  await saveButton.click();
+  await expect.poll(() => purchasePayload?.thId).toBe(expectedThird.thId);
+
   await expect(page.getByText(/Plazo de pago/i)).toBeVisible();
   await expect(page.getByLabel(/ID Tercero/i)).toHaveCount(0);
   await expect(page.getByLabel(/Cuenta Contable/i)).toHaveCount(0);

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.css
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.css
@@ -1,0 +1,204 @@
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
+.purchase-page {
+  color: #1f2937;
+}
+
+.purchase-shell {
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 6%);
+}
+
+.automation-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.75rem;
+  color: #1e3a8a;
+  background: #eff6ff;
+  font-size: 0.8rem;
+}
+
+.automation-note .pi {
+  color: #16a34a;
+}
+
+.form-section {
+  min-width: 0;
+  padding: 1.25rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 1rem;
+  background: #fff;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.section-heading.compact {
+  margin-bottom: 0;
+}
+
+.section-heading > .pi {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 2.25rem;
+  place-items: center;
+  border-radius: 0.65rem;
+  color: #fff;
+  background: #111a68;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #111a68;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.section-heading p {
+  margin: 0.15rem 0 0;
+  color: #6b7280;
+  font-family: sans-serif;
+  font-size: 0.78rem;
+}
+
+.field-label {
+  margin-bottom: 0.35rem;
+  color: #1e2a78;
+  font-weight: 600;
+}
+
+.field-label span {
+  color: #dc2626;
+}
+
+.field-help {
+  margin-top: 0.3rem;
+  color: #6b7280;
+}
+
+.empty-products {
+  display: flex;
+  min-height: 9rem;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.85rem;
+  color: #64748b;
+  background: #f8fafc;
+  text-align: center;
+}
+
+.empty-products .pi {
+  margin-bottom: 0.2rem;
+  color: #94a3b8;
+  font-size: 1.75rem;
+}
+
+.empty-products strong {
+  color: #334155;
+}
+
+.empty-products span {
+  max-width: 28rem;
+  font-family: sans-serif;
+  font-size: 0.8rem;
+}
+
+.summary-panel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #dbe2ea;
+  border-radius: 1rem;
+  background: #f8fafc;
+}
+
+.summary-card {
+  display: flex;
+  min-width: 0;
+  min-height: 5rem;
+  justify-content: center;
+  flex-direction: column;
+  padding: 0.85rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+}
+
+.summary-card span,
+.summary-card label {
+  margin-bottom: 0.2rem;
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.summary-card strong {
+  color: #111827;
+  font-size: 1.15rem;
+}
+
+.summary-card.total-card {
+  border-color: #26348c;
+  color: #fff;
+  background: #111a68;
+}
+
+.summary-card.total-card span,
+.summary-card.total-card strong,
+.summary-card.total-card small {
+  color: #fff;
+}
+
+.summary-card.total-card small {
+  margin-top: 0.2rem;
+  opacity: 0.8;
+}
+
+:host ::ng-deep .p-autocomplete,
+:host ::ng-deep .p-datepicker,
+:host ::ng-deep .p-inputnumber {
+  width: 100%;
+}
+
+:host ::ng-deep .p-autocomplete-input,
+:host ::ng-deep .p-datepicker-input,
+:host ::ng-deep .p-inputnumber-input {
+  width: 100%;
+}
+
+@media (max-width: 900px) {
+  .summary-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .purchase-shell {
+    margin: 0.5rem;
+    padding: 1rem;
+  }
+
+  .form-section {
+    padding: 1rem;
+  }
+
+  .summary-panel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -1,69 +1,92 @@
-<div class="flex w-full h-full font-titillium bg-gray-50 md:bg-transparent">
+<div class="purchase-page flex w-full min-h-full font-titillium bg-gray-50">
   <p-toast></p-toast>
   <p-confirmDialog></p-confirmDialog>
 
-  <div class="m-2 md:m-10 w-full font-sm bg-white rounded-2xl md:rounded-3xl p-4 md:p-10">
-    <div class="grid grid-cols-1 md:grid-cols-2 md:justify-between items-center mb-8">
-      <div class="items-center mb-6 md:mb-0">
+  <div class="purchase-shell flex-1 min-w-0 m-2 md:m-6 font-sm bg-white rounded-2xl p-4 md:p-8">
+    <div class="flex flex-col lg:flex-row lg:justify-between lg:items-start gap-5 mb-8">
+      <div>
         <h1 class="font-family-titillium font-bold text-2xl md:text-3xl/41 text-primary border-b-4 border-secondary inline-block pb-1">
           Creación de Factura de Compra
         </h1>
-        <p class="font-family-sans font-normal text-sm mt-2 hidden sm:block">
+        <p class="font-family-sans font-normal text-sm mt-2 text-gray-600">
           Registre la compra al proveedor. La obligación se sincronizará automáticamente con Tesorería.
         </p>
-      </div>
-      <div class="flex justify-start md:justify-end">
-        <div class="flex flex-wrap gap-2 sm:gap-3 w-full justify-evenly md:w-auto">
-          <p-button label="Guardar" icon="pi pi-save" (click)="saveInvoice()"
-            [disabled]="lstProducts.length === 0 || !supplier" [loading]="saving"></p-button>
-          <p-button label="Cancelar" icon="pi pi-times" styleClass="p-button-danger p-button-outlined" (click)="cancel()"></p-button>
+        <div class="automation-note mt-3">
+          <i class="pi pi-check-circle"></i>
+          <span>La cuenta por pagar y el código de factura se asignan automáticamente.</span>
         </div>
       </div>
-    </div>
-
-    <div class="w-full grid grid-cols-1 md:grid-cols-2 gap-y-6 gap-x-8 text-sm mb-8 mt-10">
-      <div class="flex flex-col md:col-span-1">
-        <label for="supplierSearch" class="font-normal text-primary mb-1">Proveedor *</label>
-        <p-autoComplete id="supplierSearch" [(ngModel)]="supplier" [suggestions]="filteredSuppliers" size="small"
-          (completeMethod)="searchSupplier($event)" (onFocus)="searchSupplier({ query: '' })"
-          (onSelect)="onSupplierSelect()" [dropdown]="true" optionLabel="displayName" [forceSelection]="true"
-          placeholder="Busca o selecciona un proveedor..." styleClass="w-full">
-          <ng-template let-supplier pTemplate="item">
-            <div class="flex flex-col">
-              <span class="font-semibold">{{ supplier.displayName }}</span>
-              <small>{{ supplier.typeId?.typeId }} {{ supplier.idNumber }}</small>
-            </div>
-          </ng-template>
-        </p-autoComplete>
-      </div>
-
-      <div class="flex flex-col">
-        <label class="font-normal text-primary mb-1">Fecha de emisión</label>
-        <p-datepicker [(ngModel)]="currentDate" [disabled]="true" dateFormat="dd/mm/yy" styleClass="w-full" size="small"></p-datepicker>
-      </div>
-
-      <div class="flex flex-col">
-        <label for="paymentTermDays" class="font-normal text-primary mb-1">Plazo de pago (días)</label>
-        <p-inputNumber id="paymentTermDays" [(ngModel)]="paymentTermDays" [min]="0" (onInput)="onPaymentTermChange()"
-          styleClass="w-full" size="small"></p-inputNumber>
-      </div>
-
-      <div class="flex flex-col">
-        <label for="dueDate" class="font-normal text-primary mb-1">Fecha de vencimiento</label>
-        <p-datepicker id="dueDate" [(ngModel)]="dueDate" (onSelect)="onDueDateChange()" dateFormat="dd/mm/yy" size="small"
-          placeholder="Opcional: se calcula con el plazo" [showIcon]="true" iconDisplay="input" styleClass="w-full"></p-datepicker>
-      </div>
-
-      <div class="flex flex-col md:col-span-2">
-        <label for="observations" class="font-normal text-primary mb-1">Observaciones</label>
-        <input pInputText id="observations" [(ngModel)]="observations" placeholder="Observaciones opcionales" class="w-full" />
+      <div class="flex flex-wrap gap-2 lg:justify-end shrink-0">
+        <p-button label="Guardar factura" icon="pi pi-save" (click)="saveInvoice()"
+          [disabled]="lstProducts.length === 0 || !supplier" [loading]="saving"></p-button>
+        <p-button label="Cancelar" icon="pi pi-times" severity="secondary" [outlined]="true"
+          (click)="cancel()"></p-button>
       </div>
     </div>
 
-    <div class="p-0 sm:p-2 text-sm mt-10">
+    <section class="form-section">
+      <div class="section-heading">
+        <i class="pi pi-file-edit"></i>
+        <div>
+          <h2>Datos de la compra</h2>
+          <p>Seleccione el tercero y defina las condiciones de pago.</p>
+        </div>
+      </div>
+
+      <div class="w-full grid grid-cols-1 md:grid-cols-2 gap-y-5 gap-x-6 text-sm">
+        <div class="flex flex-col">
+          <label for="supplierSearch" class="field-label">Proveedor <span aria-hidden="true">*</span></label>
+          <p-autoComplete id="supplierSearch" [(ngModel)]="supplier" [suggestions]="filteredSuppliers" size="small"
+            (completeMethod)="searchSupplier($event)" (onFocus)="searchSupplier({ query: '' })"
+            (onSelect)="onSupplierSelect()" [dropdown]="true" optionLabel="displayName" [forceSelection]="true"
+            placeholder="Busque por nombre o NIT..." styleClass="w-full">
+            <ng-template let-supplier pTemplate="item">
+              <div class="flex flex-col py-1">
+                <span class="font-semibold">{{ supplier.displayName }}</span>
+                <small class="text-gray-500">{{ supplier.typeId?.typeId || 'Identificación' }} {{ supplier.idNumber }}</small>
+              </div>
+            </ng-template>
+          </p-autoComplete>
+          <small class="field-help">Se muestran los terceros activos de la empresa.</small>
+        </div>
+
+        <div class="flex flex-col">
+          <label class="field-label">Fecha de emisión</label>
+          <p-datepicker [(ngModel)]="currentDate" [disabled]="true" dateFormat="dd/mm/yy"
+            styleClass="w-full" size="small"></p-datepicker>
+        </div>
+
+        <div class="flex flex-col">
+          <label for="paymentTermDays" class="field-label">Plazo de pago (días)</label>
+          <p-inputNumber id="paymentTermDays" [(ngModel)]="paymentTermDays" [min]="0"
+            (onInput)="onPaymentTermChange()" styleClass="w-full" size="small"></p-inputNumber>
+        </div>
+
+        <div class="flex flex-col">
+          <label for="dueDate" class="field-label">Fecha de vencimiento</label>
+          <p-datepicker id="dueDate" [(ngModel)]="dueDate" (onSelect)="onDueDateChange()" dateFormat="dd/mm/yy"
+            size="small" placeholder="Se calcula con el plazo" [showIcon]="true" iconDisplay="input"
+            styleClass="w-full"></p-datepicker>
+        </div>
+
+        <div class="flex flex-col md:col-span-2">
+          <label for="observations" class="field-label">Observaciones</label>
+          <input pInputText id="observations" [(ngModel)]="observations"
+            placeholder="Información adicional para esta compra (opcional)" class="w-full" />
+        </div>
+      </div>
+    </section>
+
+    <section class="form-section mt-6">
       <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-4">
-        <h3 class="font-bold text-lg text-primary">Detalle de la compra</h3>
-        <p-button class="w-full sm:w-auto" label="Seleccionar productos" icon="pi pi-list" (click)="selectProducts()"
+        <div class="section-heading compact">
+          <i class="pi pi-shopping-cart"></i>
+          <div>
+            <h2>Detalle de la compra</h2>
+            <p>Agregue los productos incluidos en la factura.</p>
+          </div>
+        </div>
+        <p-button class="w-full sm:w-auto" label="Agregar productos" icon="pi pi-plus" (click)="selectProducts()"
           [disabled]="!supplier" pTooltip="Primero seleccione un proveedor" tooltipPosition="top"></p-button>
       </div>
 
@@ -116,27 +139,33 @@
           </ng-template>
         </p-table>
       </div>
-    </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mt-10 bg-neutral-50 p-4 rounded-lg">
-      <div>
-        <label class="block mb-2 font-semibold">Subtotal</label>
-        <p-inputNumber [(ngModel)]="subTotal" mode="currency" currency="COP" locale="es-CO" [readonly]="true" styleClass="w-full"></p-inputNumber>
+      <div class="empty-products" *ngIf="lstProducts.length === 0">
+        <i class="pi pi-shopping-cart"></i>
+        <strong>Aún no hay productos</strong>
+        <span>Seleccione un proveedor y luego agregue los productos de la compra.</span>
       </div>
-      <div>
-        <label class="block mb-2 font-semibold">Impuestos</label>
-        <p-inputNumber [(ngModel)]="taxTotal" mode="currency" currency="COP" locale="es-CO" [readonly]="true" styleClass="w-full"></p-inputNumber>
+    </section>
+
+    <section class="summary-panel mt-6">
+      <div class="summary-card">
+        <span>Subtotal</span>
+        <strong>{{ subTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
       </div>
-      <div>
-        <label class="block mb-2 font-semibold">Abono inicial</label>
+      <div class="summary-card">
+        <span>Impuestos</span>
+        <strong>{{ taxTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+      </div>
+      <div class="summary-card editable">
+        <label for="initialPayment">Abono inicial</label>
         <p-inputNumber [(ngModel)]="initialPayment" mode="currency" currency="COP" locale="es-CO" [min]="0"
-          (onInput)="calculateTotals()" styleClass="w-full"></p-inputNumber>
+          inputId="initialPayment" (onInput)="calculateTotals()" styleClass="w-full"></p-inputNumber>
       </div>
-      <div>
-        <label class="block mb-2 font-semibold">Total / Pendiente</label>
-        <p-inputNumber [(ngModel)]="total" mode="currency" currency="COP" locale="es-CO" [readonly]="true" styleClass="w-full mb-2"></p-inputNumber>
-        <p-inputNumber [(ngModel)]="pendingTotal" mode="currency" currency="COP" locale="es-CO" [readonly]="true" styleClass="w-full"></p-inputNumber>
+      <div class="summary-card total-card">
+        <span>Total factura</span>
+        <strong>{{ total | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+        <small>Pendiente: {{ pendingTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</small>
       </div>
-    </div>
+    </section>
   </div>
 </div>

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -47,7 +47,7 @@
               </div>
             </ng-template>
           </p-autoComplete>
-          <small class="field-help">Se muestran los terceros activos de la empresa.</small>
+          <small class="field-help">Se muestran los proveedores activos de la empresa.</small>
         </div>
 
         <div class="flex flex-col">

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -16,6 +16,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Subscription } from 'rxjs';
 import { Third } from '../../../../GeneralMasters/ThirdParties/models/Third';
+import { eThirdType } from '../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
 import { LocalStorageMethods } from '../../../../Shared/Methods/local-storage.method';
 import { ProductToSale } from '../../../SaleInvoice/models/ProductToSale';
@@ -89,7 +90,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
 
   loadSuppliers(): void {
     const entId = this.localStorageMethods.getIdEnterprise();
-    this.thirdService.getActiveThirds(entId.toString()).subscribe({
+    this.thirdService.getThirdsByType(entId.toString(), eThirdType.Proveedor).subscribe({
       next: (data) => {
         this.allSuppliers = data.content || [];
       },

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -16,7 +16,6 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Subscription } from 'rxjs';
 import { Third } from '../../../../GeneralMasters/ThirdParties/models/Third';
-import { ThirdType } from '../../../../GeneralMasters/ThirdParties/models/ThirdType';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
 import { LocalStorageMethods } from '../../../../Shared/Methods/local-storage.method';
 import { ProductToSale } from '../../../SaleInvoice/models/ProductToSale';
@@ -90,9 +89,9 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
 
   loadSuppliers(): void {
     const entId = this.localStorageMethods.getIdEnterprise();
-    this.thirdService.getThirdList(entId).subscribe({
-      next: (data: Third[]) => {
-        this.allSuppliers = (data || []).filter((third) => this.isSupplier(third));
+    this.thirdService.getActiveThirds(entId.toString()).subscribe({
+      next: (data) => {
+        this.allSuppliers = data.content || [];
       },
       error: () => {
         this.messageService.add({
@@ -340,12 +339,6 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
 
   private stripTime(date: Date): Date {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  }
-
-  private isSupplier(third: Third): boolean {
-    return (third.thirdTypes || []).some((type: ThirdType) =>
-      String(type.thirdTypeName || '').toLowerCase().includes('proveedor'),
-    );
   }
 
   private loadUnitOfMeasureAbbreviations(): void {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -117,7 +117,7 @@
             <td>
               <div class="flex items-center gap-2">
                 <i class="pi pi-building text-gray-500"></i>
-                <span>{{ payable.supplierId }}</span>
+                <span>{{ supplierName(payable.supplierId) }}</span>
               </div>
             </td>
             <td><span class="font-mono font-semibold text-blue-600">{{ payable.reference }}</span></td>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -102,6 +102,7 @@ export class TreasuryOperationsComponent implements OnInit {
   scheduleLabel = scheduleStatusLabel;
   writeOffLabel = voucherStatusLabel;
   accountingStatusLabel = accountingEntryStatusLabel;
+  supplierName = (supplierId: number) => resolveSupplierName(this.supplierNames, supplierId);
 
   private readonly enterpriseId: string;
 

--- a/src/app/GeneralMasters/ThirdParties/Services/third.service.ts
+++ b/src/app/GeneralMasters/ThirdParties/Services/third.service.ts
@@ -260,10 +260,10 @@ export class ThirdService {
    * @param entId ID de la empresa
    * @returns Observable con la lista de terceros activos
    */
-  getActiveThirds(entId: string): Observable<any> {
+  getActiveThirds(entId: string): Observable<PageResponse<Third>> {
     const params = new HttpParams().set('entId', entId);
 
-    return this.http.get<any>(`${this.thirdApiUrl}findAllActive`, { params }).pipe(
+    return this.http.get<PageResponse<Third>>(`${this.thirdApiUrl}findAllActive`, { params }).pipe(
       catchError((error) => {
         return throwError(() => error);
       })


### PR DESCRIPTION
## Summary
- Factura de compra carga proveedores con getThirdsByType(..., Proveedor) en lugar de findAllActive.
- Tesorería Operaciones muestra nombre del proveedor (resolveSupplierName) en obligaciones pendientes.
- E2E alineado a by-type, nombre en Operaciones y selección PrimeNG en diálogo de productos.

## Test plan
- [x] ng build --configuration=local
- [x] critical-journeys.spec.ts (validado localmente cuando Keycloak responde)
- [x] purchase-invoice-ui.spec.ts (fix mock/checkbox PrimeNG; no defecto de pantalla)
- [ ] Mergear primero thirds-management PR con tipos base Proveedor

## Dependencia
Requiere despliegue de thirds-management con aprovisionamiento de tipo Proveedor por empresa.