### PR TITLE
fix(thirds): selector único de tipo de tercero en crear/editar

### DIFF
--- a/src/app/GeneralMasters/ThirdParties/Components/third-creation/third-creation.component.html
+++ b/src/app/GeneralMasters/ThirdParties/Components/third-creation/third-creation.component.html
@@ -52,20 +52,29 @@
             </div>
 
             <div class="flex flex-col gap-2">
-              <app-form-field-label label="Tipos de Tercero" [required]="true"></app-form-field-label>
-              <p-multiSelect 
+              <app-form-field-label label="Tipo de Tercero" [required]="true"></app-form-field-label>
+              <p-select 
                 [options]="thirdTypes" 
-                formControlName="thirdTypes"
+                formControlName="thirdType"
                 optionLabel="thirdTypeName"
                 [dataKey]="'thirdTypeId'"
-                placeholder="Seleccione tipos de tercero"
+                placeholder="Seleccione tipo de tercero"
                 [filter]="true"
                 filterBy="thirdTypeName"
+                [showClear]="true"
                 [loading]="loadingThirdTypes"
                 class="max-w-sm">
-              </p-multiSelect>
-              <app-form-field-error [form]="createdThirdForm" fieldName="thirdTypes" [submitted]="submitted">
-                Seleccione al menos un tipo de tercero
+                <ng-template pTemplate="selectedItem" let-selectedOption>
+                  <div *ngIf="selectedOption">
+                    {{ selectedOption.thirdTypeName }}
+                  </div>
+                </ng-template>
+                <ng-template pTemplate="item" let-option>
+                  <div>{{ option.thirdTypeName }}</div>
+                </ng-template>
+              </p-select>
+              <app-form-field-error [form]="createdThirdForm" fieldName="thirdType" [submitted]="submitted">
+                Seleccione un tipo de tercero
               </app-form-field-error>
             </div>
           </div>

--- a/src/app/GeneralMasters/ThirdParties/Components/third-creation/third-creation.component.ts
+++ b/src/app/GeneralMasters/ThirdParties/Components/third-creation/third-creation.component.ts
@@ -7,7 +7,6 @@ import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { DropdownModule } from 'primeng/dropdown';
 import { RadioButtonModule } from 'primeng/radiobutton';
-import { MultiSelectModule } from 'primeng/multiselect';
 import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 import { CardModule } from 'primeng/card';
@@ -49,7 +48,6 @@ import { FormFieldErrorComponent } from '../shared/form-field-error.component';
     InputTextModule,
     DropdownModule,
     RadioButtonModule,
-    MultiSelectModule,
     ToastModule,
     CardModule,
     DividerModule,
@@ -72,7 +70,6 @@ export class ThirdCreationComponent implements OnInit {
   contendPDFRUT: string | null = null;
 
   infoThird: string[] | null = null;
-  selectedThirdTypes: ThirdType[] = [];
 
   submitted = false;
 
@@ -183,7 +180,7 @@ export class ThirdCreationComponent implements OnInit {
     this.createdThirdForm = this.fb.group({
       personType: [null, Validators.required],
       state: [true, Validators.required],
-      thirdTypes: [[], Validators.required],
+      thirdType: [null, Validators.required],
       typeId: [null, Validators.required],
       idNumber: [null, [Validators.required, Validators.min(1)]],
       verificationNumber: [null],
@@ -731,12 +728,14 @@ export class ThirdCreationComponent implements OnInit {
     this.submitted = true;
 
     if (this.createdThirdForm.valid) {
-      const formData = this.createdThirdForm.value;
+      const formData = this.createdThirdForm.getRawValue();
+      const { thirdType, ...formFields } = formData;
 
       // Preparar datos para enviar al backend con códigos geográficos
       const newThird: any = {
         ...this.thirdData,
-        ...formData,
+        ...formFields,
+        thirdTypes: thirdType ? [thirdType] : [],
         entId: this.entData,
         countryCode: formData.country,
         stateCode: formData.province,

--- a/src/app/GeneralMasters/ThirdParties/Components/third-edit/third-edit.component.html
+++ b/src/app/GeneralMasters/ThirdParties/Components/third-edit/third-edit.component.html
@@ -52,20 +52,29 @@
             </div>
 
             <div class="flex flex-col gap-2">
-              <app-form-field-label label="Tipos de Tercero" [required]="true"></app-form-field-label>
-              <p-multiSelect 
+              <app-form-field-label label="Tipo de Tercero" [required]="true"></app-form-field-label>
+              <p-select 
                 [options]="thirdTypes" 
-                formControlName="thirdTypes"
+                formControlName="thirdType"
                 optionLabel="thirdTypeName"
                 [dataKey]="'thirdTypeId'"
-                placeholder="Seleccione tipos de tercero"
+                placeholder="Seleccione tipo de tercero"
                 [filter]="true"
                 filterBy="thirdTypeName"
+                [showClear]="true"
                 [loading]="loadingThirdTypes"
                 class="max-w-sm">
-              </p-multiSelect>
-              <app-form-field-error [form]="createdThirdForm" fieldName="thirdTypes" [submitted]="submitted">
-                Seleccione al menos un tipo de tercero
+                <ng-template pTemplate="selectedItem" let-selectedOption>
+                  <div *ngIf="selectedOption">
+                    {{ selectedOption.thirdTypeName }}
+                  </div>
+                </ng-template>
+                <ng-template pTemplate="item" let-option>
+                  <div>{{ option.thirdTypeName }}</div>
+                </ng-template>
+              </p-select>
+              <app-form-field-error [form]="createdThirdForm" fieldName="thirdType" [submitted]="submitted">
+                Seleccione un tipo de tercero
               </app-form-field-error>
             </div>
           </div>

--- a/src/app/GeneralMasters/ThirdParties/Components/third-edit/third-edit.component.ts
+++ b/src/app/GeneralMasters/ThirdParties/Components/third-edit/third-edit.component.ts
@@ -10,7 +10,6 @@ import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
 import { DropdownModule } from 'primeng/dropdown';
 import { RadioButtonModule } from 'primeng/radiobutton';
-import { MultiSelectModule } from 'primeng/multiselect';
 import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
 import { CardModule } from 'primeng/card';
@@ -52,7 +51,6 @@ import Swal from 'sweetalert2';
     InputTextModule,
     DropdownModule,
     RadioButtonModule,
-    MultiSelectModule,
     ToastModule,
     CardModule,
     DividerModule,
@@ -250,7 +248,7 @@ export class ThirdEditComponent implements OnInit {
   private initializeForm(): void {
     this.createdThirdForm = this.fb.group({
       personType: ['', Validators.required],
-      thirdTypes: [[], Validators.required],
+      thirdType: [null, Validators.required],
       typeId: ['', Validators.required],
       idNumber: ['', [Validators.required, Validators.min(1)]],
       verificationNumber: [''],
@@ -450,9 +448,17 @@ export class ThirdEditComponent implements OnInit {
       }
     }
 
+    let selectedThirdType = null;
+    if (third.thirdTypes?.length) {
+      const firstType = third.thirdTypes[0];
+      selectedThirdType = this.thirdTypes.find(
+        t => t.thirdTypeId === firstType.thirdTypeId
+      ) ?? firstType;
+    }
+
     this.createdThirdForm.patchValue({
       personType: third.personType,
-      thirdTypes: third.thirdTypes,
+      thirdType: selectedThirdType,
       typeId: selectedTypeId,
       idNumber: third.idNumber,
       verificationNumber: third.verificationNumber,
@@ -512,11 +518,9 @@ export class ThirdEditComponent implements OnInit {
   private normalizeFormValue(value: any): any {
     const normalized = { ...value };
     
-    // Normalizar arrays de objetos (thirdTypes) comparando por IDs
-    if (normalized.thirdTypes && Array.isArray(normalized.thirdTypes)) {
-      normalized.thirdTypes = normalized.thirdTypes
-        .map((t: any) => t.thirdTypeId)
-        .sort();
+    // Normalizar tipo de tercero (objeto único) comparando por ID
+    if (normalized.thirdType && typeof normalized.thirdType === 'object') {
+      normalized.thirdType = normalized.thirdType.thirdTypeId;
     }
     
     // Normalizar typeId (comparar solo el ID)
@@ -691,12 +695,14 @@ export class ThirdEditComponent implements OnInit {
     this.submitted = true;
 
     if (this.createdThirdForm.valid) {
-      const formData = this.createdThirdForm.value;
+      const formData = this.createdThirdForm.getRawValue();
+      const { thirdType, ...formFields } = formData;
       
       // Preparar datos para enviar al backend con códigos geográficos
       const updatedThird: any = {
         ...this.thirdEdit,
-        ...formData,
+        ...formFields,
+        thirdTypes: thirdType ? [thirdType] : [],
         countryCode: formData.country,
         stateCode: formData.province,
         cityCode: formData.city,


### PR DESCRIPTION
## Summary
- Cambia el selector de tipo de tercero de multiselect a select único en crear y editar tercero.
- Envía `thirdTypes` como array de un elemento para mantener compatibilidad con el backend.
- Ajusta detección de cambios en edición al nuevo control `thirdType`.

## Test plan
- [ ] Desplegar ContAppAng19 en DEV (junto con thirds-management #68 o equivalente).
- [ ] En crear tercero, verificar que solo se puede elegir un tipo de tercero.
- [ ] Seleccionar persona Natural/Jurídica y confirmar filtrado de tipo de identificación.
- [ ] Guardar tercero y validar que aparece en listado con el tipo correcto.
- [ ] Editar tercero existente y confirmar que carga un solo tipo preseleccionado.