### PR TITLE
fix(commercial): enviar empresa al consultar unidad de medida

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -343,11 +343,12 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   }
 
   private loadUnitOfMeasureAbbreviations(): void {
+    const enterpriseId = this.localStorageMethods.getIdEnterprise();
     this.lstProducts.forEach((prod) => {
       if (!prod.unitOfMeasureId) {
         return;
       }
-      this.unitMeasureService.getUnitOfMeasuresId(String(prod.unitOfMeasureId)).subscribe({
+      this.unitMeasureService.getUnitOfMeasuresId(String(prod.unitOfMeasureId), enterpriseId).subscribe({
         next: (response: { abbreviation: string }) => {
           prod.unitOfMeasure = response.abbreviation;
         },

--- a/src/app/Commercial/SaleInvoice/components/sale-invoice-creation/sale-invoice-creation.component.ts
+++ b/src/app/Commercial/SaleInvoice/components/sale-invoice-creation/sale-invoice-creation.component.ts
@@ -331,9 +331,10 @@ export class SaleInvoiceCreationComponent {
    */
   getUnitOfMeasureForId(lstProducts: ProductToSale[]): ProductToSale[] {
     if (lstProducts != null || this.lstProducts.length > 0) {
+      const enterpriseId = this.localStorageMethods.getIdEnterprise();
 
       lstProducts.forEach((prod) => {
-        this.UnitMeasureService.getUnitOfMeasuresId("" + prod.unitOfMeasureId).subscribe({
+        this.UnitMeasureService.getUnitOfMeasuresId("" + prod.unitOfMeasureId, enterpriseId).subscribe({
           next: (response) => {
             prod.unitOfMeasure = response.abbreviation;
           }

--- a/src/app/Commercial/SaleInvoice/services/unit-of-measure.service.spec.ts
+++ b/src/app/Commercial/SaleInvoice/services/unit-of-measure.service.spec.ts
@@ -1,16 +1,35 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { UnitOfMeasureService } from './unit-of-measure.service';
 
 describe('UnitOfMeasureService', () => {
   let service: UnitOfMeasureService;
+  let http: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    });
     service = TestBed.inject(UnitOfMeasureService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should include enterpriseId when requesting a unit of measure', () => {
+    service.getUnitOfMeasuresId('1', 'enterprise-a').subscribe();
+
+    const request = http.expectOne(req =>
+      req.url.endsWith('unit-measures/findById/1') &&
+      req.params.get('enterpriseId') === 'enterprise-a'
+    );
+    expect(request.request.method).toBe('GET');
+    request.flush({ id: 1, abbreviation: 'UND' });
   });
 });

--- a/src/app/Commercial/SaleInvoice/services/unit-of-measure.service.ts
+++ b/src/app/Commercial/SaleInvoice/services/unit-of-measure.service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { environment } from '../../../../environments/environment';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UnitOfMeasure } from '../models/UnitOfMeasure';
-
-let API_URL = environment.API_URL + 'thirds/';
 
 @Injectable({
   providedIn: 'root'
@@ -14,8 +12,9 @@ export class UnitOfMeasureService {
   constructor(private http: HttpClient) { }
 
   // Método para obtener por Id las unidades de medida
-  getUnitOfMeasuresId(id: string): Observable<UnitOfMeasure> {
+  getUnitOfMeasuresId(id: string, enterpriseId: string): Observable<UnitOfMeasure> {
     const url = `${environment.API_URL}unit-measures/findById/${id}`;
-    return this.http.get<UnitOfMeasure>(url);
+    const params = new HttpParams().set('enterpriseId', enterpriseId);
+    return this.http.get<UnitOfMeasure>(url, { params });
   }
 }


### PR DESCRIPTION
## Summary
- Incluye `enterpriseId` al consultar `/unit-measures/findById/{id}`.
- Corrige la carga de abreviaturas en facturas de compra y venta.
- Agrega una prueba HTTP que verifica el parámetro requerido.

## Root cause
El endpoint de productos exige `enterpriseId` para aislar datos por empresa, pero el servicio comercial llamaba `findById/{id}` sin ese query param. El gateway respondía 400 `MISSING_REQUEST_PARAMETER`.

## Test plan
- [x] `npm run build`
- [x] Unit test de `UnitOfMeasureService` (2 tests OK)
- [ ] Seleccionar productos en una factura de compra en DEV.
- [ ] Confirmar que la consulta incluye `?enterpriseId=...`.
- [ ] Guardar la factura de compra exitosamente.