### PR TITLE
fix(treasury): cargar CxP desde obligaciones pendientes

### DIFF
--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
@@ -243,17 +243,20 @@ export class ExpenseReceiptCreationComponent {
       }
     });
 
-    // Solo cuentas de CxP (pasivo corriente / proveedores), no todo el catálogo
-    this.chartAccountService.getListAuxiliaryAccounts(enterpriseId).subscribe(accounts => {
-      this.payableAccounts = accounts
-        .filter(account => account.status !== false)
-        .filter(account => this.isPayableAccount(account))
-        .map(account => ({
-          id: account.id,
-          code: account.code,
-          name: account.description,
-          fullName: `${account.code} - ${account.description}`
-        }));
+    // Las CxP disponibles son las que realmente están asociadas a obligaciones pendientes.
+    this.expenseReceiptService.getPayableAccounts().subscribe({
+      next: accounts => {
+        this.payableAccounts = accounts;
+      },
+      error: (error) => {
+        console.error('Error al cargar cuentas por pagar:', error);
+        this.payableAccounts = [];
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Cuentas por pagar',
+          detail: 'No se pudieron cargar las cuentas de las facturas pendientes.',
+        });
+      },
     });
 
     // Cargar cuentas auxiliares para gastos directos
@@ -275,15 +278,6 @@ export class ExpenseReceiptCreationComponent {
       bankCtrl?.setValue(null);
     }
     bankCtrl?.updateValueAndValidity();
-  }
-
-  /** Cuentas válidas para CxP: pasivo corriente o código PUC de proveedores (22...). */
-  private isPayableAccount(account: { code?: string; classification?: string; nature?: string }): boolean {
-    const code = String(account.code || '');
-    const classification = String(account.classification || '').toLowerCase();
-    if (code.startsWith('22')) return true;
-    if (classification.includes('pasivo corriente')) return true;
-    return false;
   }
 
   subscribeToFormChanges(): void {

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
@@ -1,0 +1,31 @@
+import { firstValueFrom, of } from 'rxjs';
+
+import { ExpenseReceiptService } from './expense-receipt.service';
+
+describe('ExpenseReceiptService payable accounts', () => {
+  it('builds unique options from pending obligations', async () => {
+    const api = {
+      pending: jasmine.createSpy().and.returnValue(of([
+        { payableAccountId: 20, payableAccountCode: '2205' },
+        { payableAccountId: 20, payableAccountCode: '2205' },
+        { payableAccountId: 30, payableAccountCode: '2335' },
+      ])),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const service = new ExpenseReceiptService(
+      api as any,
+      null as any,
+      null as any,
+      null as any,
+      storage as any,
+    );
+
+    const result = await firstValueFrom(service.getPayableAccounts());
+
+    expect(api.pending).toHaveBeenCalledWith('enterprise-a');
+    expect(result).toEqual([
+      { id: 20, code: '2205', name: 'Cuenta por pagar', fullName: '2205 - Cuenta por pagar' },
+      { id: 30, code: '2335', name: 'Cuenta por pagar', fullName: '2335 - Cuenta por pagar' },
+    ]);
+  });
+});

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -89,6 +89,27 @@ export class ExpenseReceiptService {
     }))));
   }
 
+  getPayableAccounts(): Observable<{ id: number; code: string; name: string; fullName: string }[]> {
+    return this.api.pending(this.enterpriseId()).pipe(
+      map(items => {
+        const accounts = new Map<number, { id: number; code: string; name: string; fullName: string }>();
+        items.forEach(item => {
+          if (!item.payableAccountId) {
+            return;
+          }
+          const code = item.payableAccountCode || String(item.payableAccountId);
+          accounts.set(item.payableAccountId, {
+            id: item.payableAccountId,
+            code,
+            name: 'Cuenta por pagar',
+            fullName: `${code} - Cuenta por pagar`,
+          });
+        });
+        return [...accounts.values()].sort((left, right) => left.code.localeCompare(right.code));
+      }),
+    );
+  }
+
   getAllExpenseReceipts(): Observable<ExpenseReceiptView[]> {
     const enterpriseId = this.enterpriseId();
     return forkJoin({


### PR DESCRIPTION
## Summary
- Carga el selector Cuenta por Pagar desde las obligaciones pendientes de Tesorería.
- Elimina la dependencia del filtro de cuentas auxiliares del catálogo, que dejaba el selector vacío.
- Deduplica las cuentas por ID y muestra código contable legible.
- Agrega prueba para construir las opciones desde facturas pendientes.

## Test plan
- [x] `npm run build`
- [x] Tests de ExpenseReceipt (4 tests OK)
- [ ] Abrir `/financial/treasury/expense-receipts/creation` en DEV.
- [ ] Verificar que Cuenta por Pagar muestra las cuentas asociadas a facturas pendientes.
- [ ] Seleccionar proveedor y factura, y confirmar que la CxP se preselecciona.
- [ ] Efectuar el pago exitosamente.