### PR TITLE
fix(purchase): liberar botón guardar ante respuesta demorada

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
@@ -1,0 +1,44 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { NEVER } from 'rxjs';
+
+import { PurchaseInvoiceCreationComponent } from './purchase-invoice-creation.component';
+
+describe('PurchaseInvoiceCreationComponent save state', () => {
+  it('releases the loading button when the server does not respond', fakeAsync(() => {
+    const component = Object.create(PurchaseInvoiceCreationComponent.prototype) as any;
+    component.supplier = { thId: 1 };
+    component.lstProducts = [{
+      id: 10,
+      amount: 1,
+      description: 'Producto',
+      cost: 100,
+      IVA: 0,
+      descuentos: [0, 0],
+    }];
+    component.initialPayment = 0;
+    component.total = 100;
+    component.pendingTotal = 100;
+    component.currentDate = new Date('2026-08-13T12:00:00');
+    component.paymentTermDays = 30;
+    component.impuestoCheck = true;
+    component.localStorageMethods = {
+      loadEnterpriseData: () => ({ id: 'enterprise-a' }),
+      getInventoryConfigType: () => 'WEIGHTED_AVERAGE',
+    };
+    component.purchaseInvoiceService = {
+      createPurchaseInvoice: () => NEVER,
+    };
+    component.messageService = { add: jasmine.createSpy() };
+
+    component.saveInvoice();
+    expect(component.saving).toBeTrue();
+
+    tick(20_001);
+
+    expect(component.saving).toBeFalse();
+    expect(component.messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      severity: 'warn',
+      summary: 'Respuesta demorada',
+    }));
+  }));
+});

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -14,7 +14,7 @@ import { TableModule } from 'primeng/table';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { Subscription } from 'rxjs';
+import { finalize, Subscription, timeout, TimeoutError } from 'rxjs';
 import { Third } from '../../../../GeneralMasters/ThirdParties/models/Third';
 import { eThirdType } from '../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
@@ -47,6 +47,8 @@ import { PurchaseInvoiceService } from '../../services/purchase-invoice.service'
   styleUrl: './purchase-invoice-creation.component.css',
 })
 export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
+  private static readonly SAVE_TIMEOUT_MS = 20_000;
+
   private readonly localStorageMethods = new LocalStorageMethods();
   private ref?: DynamicDialogRef;
   private dialogSubscription?: Subscription;
@@ -254,9 +256,13 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
     };
 
     this.saving = true;
-    this.purchaseInvoiceService.createPurchaseInvoice(payload).subscribe({
-      next: () => {
+    this.purchaseInvoiceService.createPurchaseInvoice(payload).pipe(
+      timeout(PurchaseInvoiceCreationComponent.SAVE_TIMEOUT_MS),
+      finalize(() => {
         this.saving = false;
+      }),
+    ).subscribe({
+      next: () => {
         this.messageService.add({
           severity: 'success',
           summary: 'Factura creada',
@@ -265,12 +271,14 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
         });
         this.resetForm();
       },
-      error: () => {
-        this.saving = false;
+      error: (error) => {
+        const timedOut = error instanceof TimeoutError;
         this.messageService.add({
-          severity: 'error',
-          summary: 'Error',
-          detail: 'No se pudo crear la factura de compra',
+          severity: timedOut ? 'warn' : 'error',
+          summary: timedOut ? 'Respuesta demorada' : 'Error',
+          detail: timedOut
+            ? 'El servidor tardó demasiado en responder. Verifique el listado antes de intentar guardar nuevamente.'
+            : 'No se pudo crear la factura de compra',
         });
       },
     });


### PR DESCRIPTION
## Summary
- Garantiza que el estado `saving` se libere con `finalize` tanto en éxito como en error.
- Aplica un timeout de 20 segundos para evitar que Guardar factura quede cargando indefinidamente.
- Muestra una advertencia para revisar el listado antes de reintentar, evitando facturas duplicadas.
- Agrega prueba del escenario donde el servidor no responde.

## Test plan
- [x] `npm run build`
- [x] Test de timeout del guardado (1 test OK)
- [ ] Guardar factura de compra en DEV y verificar que el botón se libera.
- [ ] Simular respuesta demorada y confirmar advertencia después de 20 segundos.
- [ ] Verificar el listado antes de reintentar el guardado.