### PR TITLE
fix(treasury): make Contabilizar reliable with polling and feedback

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -278,6 +278,7 @@
           <td>{{ voucher.issueDate }}</td>
           <td>
             <p-tag [value]="statusLabel(voucher.status)" [severity]="getStatusSeverity(voucher.status)"></p-tag>
+            <small *ngIf="voucher.failureReason" class="block text-red-600 mt-1">{{ voucher.failureReason }}</small>
           </td>
           <td class="text-right font-semibold">{{ voucher.total | currency:'COP' }}</td>
           <td>{{ voucher.accountingEntryId || 'Pendiente' }}</td>
@@ -288,6 +289,8 @@
                 [label]="voucher.status === 'FAILED' ? 'Reintentar' : 'Contabilizar'"
                 icon="pi pi-check"
                 size="small"
+                [loading]="postingVoucherId === voucher.id"
+                [disabled]="busy && postingVoucherId !== voucher.id"
                 (onClick)="post(voucher)">
               </p-button>
               <p-button

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -1,9 +1,33 @@
-import { NEVER } from 'rxjs';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { NEVER, of, TimeoutError } from 'rxjs';
 import { TreasuryOperationsComponent } from './treasury-operations.component';
 
 describe('TreasuryOperationsComponent PP8', () => {
   function component() {
-    const api = { createVoucher: jasmine.createSpy('createVoucher').and.returnValue(NEVER) };
+    const api = {
+      createVoucher: jasmine.createSpy('createVoucher').and.returnValue(NEVER),
+      postVoucher: jasmine.createSpy('postVoucher').and.returnValue(of({
+        id: 9,
+        voucherNumber: 'CE-9',
+        status: 'POSTING',
+        enterpriseId: 'enterprise-a',
+        paymentMethodId: 1,
+        total: 25,
+        version: 0,
+        details: [],
+      })),
+      voucher: jasmine.createSpy('voucher').and.returnValue(of({
+        id: 9,
+        voucherNumber: 'CE-9',
+        status: 'POSTED',
+        accountingEntryId: 100,
+        enterpriseId: 'enterprise-a',
+        paymentMethodId: 1,
+        total: 25,
+        version: 1,
+        details: [],
+      })),
+    };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const exportService = {
       datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
@@ -84,4 +108,60 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.exportToCsv();
     expect(exportService.downloadCsvSections).toHaveBeenCalled();
   });
+
+  it('posts a draft voucher and shows success when accounting completes', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    spyOn(value, 'reload');
+
+    value.post({
+      id: 9,
+      voucherNumber: 'CE-9',
+      issueDate: '2026-08-13',
+      status: 'DRAFT',
+      total: 25,
+      paymentMethodId: 1,
+      enterpriseId: 'enterprise-a',
+      version: 0,
+      details: [],
+    });
+
+    tick();
+
+    expect(api.postVoucher).toHaveBeenCalledWith(9, 'enterprise-a');
+    expect(api.voucher).toHaveBeenCalledWith(9, 'enterprise-a');
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      severity: 'success',
+      summary: 'Contabilizado',
+    }));
+    expect(value.reload).toHaveBeenCalled();
+    expect(value.busy).toBeFalse();
+    expect(value.postingVoucherId).toBeUndefined();
+  }));
+
+  it('shows timeout feedback when posting hangs', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    api.postVoucher.and.returnValue(NEVER);
+
+    value.post({
+      id: 9,
+      voucherNumber: 'CE-9',
+      issueDate: '2026-08-13',
+      status: 'DRAFT',
+      total: 25,
+      paymentMethodId: 1,
+      enterpriseId: 'enterprise-a',
+      version: 0,
+      details: [],
+    });
+
+    tick(20_001);
+
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      severity: 'warn',
+      summary: 'Respuesta demorada',
+    }));
+    expect(value.busy).toBeFalse();
+  }));
 });

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { forkJoin, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { forkJoin, of, timer, TimeoutError } from 'rxjs';
+import { catchError, finalize, switchMap, take, takeWhile, timeout } from 'rxjs/operators';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { CheckboxModule } from 'primeng/checkbox';
@@ -64,6 +64,10 @@ import { TREASURY_HELP } from '../Shared/treasury-help-content';
   providers: [MessageService],
 })
 export class TreasuryOperationsComponent implements OnInit {
+  private static readonly OPERATION_TIMEOUT_MS = 20_000;
+  private static readonly POST_POLL_INTERVAL_MS = 2_000;
+  private static readonly POST_POLL_MAX_ATTEMPTS = 15;
+
   payables: Payable[] = [];
   vouchers: PaymentVoucher[] = [];
   schedules: PaymentSchedule[] = [];
@@ -84,6 +88,7 @@ export class TreasuryOperationsComponent implements OnInit {
   counterpartAccountId?: number;
   writeOffReason = '';
   busy = false;
+  postingVoucherId?: number;
   error = '';
   voucherNumberFilter = '';
   voucherStatusFilter = '';
@@ -310,7 +315,62 @@ export class TreasuryOperationsComponent implements OnInit {
     }));
   }
 
-  post(voucher: PaymentVoucher) { this.run(this.api.postVoucher(voucher.id, this.enterpriseId)); }
+  post(voucher: PaymentVoucher) {
+    if (!this.enterpriseId) {
+      this.error = 'Seleccione una empresa activa.';
+      return;
+    }
+
+    this.postingVoucherId = voucher.id;
+    this.busy = true;
+    this.error = '';
+
+    this.api.postVoucher(voucher.id, this.enterpriseId).pipe(
+      timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
+      switchMap((posted) => this.waitForAccounting(posted.id)),
+      finalize(() => {
+        this.busy = false;
+        this.postingVoucherId = undefined;
+      }),
+    ).subscribe({
+      next: (updated) => {
+        if (updated.status === 'POSTED') {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Contabilizado',
+            detail: `El comprobante ${updated.voucherNumber} quedó contabilizado.`,
+            life: 6000,
+          });
+        } else if (updated.status === 'FAILED') {
+          this.error = updated.failureReason || 'No se pudo contabilizar el comprobante.';
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Contabilización fallida',
+            detail: this.error,
+            life: 8000,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Contabilización en proceso',
+            detail: `El comprobante ${updated.voucherNumber} sigue en estado ${this.statusLabel(updated.status)}. Actualice en unos segundos.`,
+            life: 8000,
+          });
+        }
+        this.reload();
+      },
+      error: (err) => this.handleOperationError(err, 'contabilizar el comprobante'),
+    });
+  }
+
+  private waitForAccounting(voucherId: number) {
+    return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
+      take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
+      switchMap(() => this.api.voucher(voucherId, this.enterpriseId)),
+      takeWhile((voucher) => voucher.status === 'POSTING', true),
+    );
+  }
+
   remove(voucher: PaymentVoucher) { this.run(this.api.deleteVoucher(voucher.id, this.enterpriseId)); }
   void(voucher: PaymentVoucher) {
     const reason = window.prompt('Motivo de anulación');
@@ -356,16 +416,31 @@ export class TreasuryOperationsComponent implements OnInit {
   private run(request: any) {
     this.busy = true;
     this.error = '';
-    request.subscribe({
+    request.pipe(
+      timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
+      finalize(() => {
+        this.busy = false;
+      }),
+    ).subscribe({
       next: () => {
         this.selected.clear();
         this.editingVoucherId = undefined;
         this.reload();
       },
-      error: (err: any) => {
-        this.error = err?.error?.message ?? 'La operación fue rechazada.';
-        this.busy = false;
-      }
+      error: (err: any) => this.handleOperationError(err, 'completar la operación'),
+    });
+  }
+
+  private handleOperationError(err: unknown, action: string): void {
+    const timedOut = err instanceof TimeoutError;
+    this.error = timedOut
+      ? 'El servidor tardó demasiado en responder. Verifique el listado antes de reintentar.'
+      : (err as any)?.error?.message ?? `No se pudo ${action}.`;
+    this.messageService.add({
+      severity: timedOut ? 'warn' : 'error',
+      summary: timedOut ? 'Respuesta demorada' : 'Error',
+      detail: this.error,
+      life: 8000,
     });
   }
 


### PR DESCRIPTION
## Summary
- Add polling after POST until the voucher reaches POSTED or FAILED.
- Reset loading state on timeout and show toast feedback for success, failure, and delays.
- Display failureReason under the voucher status in Operations.

## Test plan
- [x] 	reasury-operations.component.spec.ts (6/6 unit tests)
- [ ] In Operations, click Contabilizar on a DRAFT voucher and verify POSTED + toast
- [ ] Verify failureReason appears when accounting rejects the voucher

Made with [Cursor](https://cursor.com)