### PR TITLE
fix(purchase): show and recalculate purchase detail totals

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -113,11 +113,11 @@
               </td>
               <td>
                 <p-inputNumber [(ngModel)]="prod.amount" mode="decimal" size="small" [showButtons]="true" [min]="1"
-                  (onInput)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
+                  (ngModelChange)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
               </td>
               <td>
                 <p-inputNumber [(ngModel)]="prod.cost" mode="currency" size="small" currency="COP" locale="es-CO"
-                  (onInput)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
+                  (ngModelChange)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
               </td>
               <td>
                 <div class="flex gap-2">
@@ -129,7 +129,7 @@
               </td>
               <td>
                 <p-inputNumber [(ngModel)]="prod.IVA" size="small" suffix="%" [min]="0" [max]="100"
-                  (onInput)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
+                  (ngModelChange)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
               </td>
               <td class="text-right">{{ lineSubtotal(prod) | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</td>
               <td>
@@ -145,26 +145,26 @@
         <strong>Aún no hay productos</strong>
         <span>Seleccione un proveedor y luego agregue los productos de la compra.</span>
       </div>
-    </section>
 
-    <section class="summary-panel mt-6">
-      <div class="summary-card">
-        <span>Subtotal</span>
-        <strong>{{ subTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
-      </div>
-      <div class="summary-card">
-        <span>Impuestos</span>
-        <strong>{{ taxTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
-      </div>
-      <div class="summary-card editable">
-        <label for="initialPayment">Abono inicial</label>
-        <p-inputNumber [(ngModel)]="initialPayment" mode="currency" currency="COP" locale="es-CO" [min]="0"
-          inputId="initialPayment" (onInput)="calculateTotals()" styleClass="w-full"></p-inputNumber>
-      </div>
-      <div class="summary-card total-card">
-        <span>Total factura</span>
-        <strong>{{ total | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
-        <small>Pendiente: {{ pendingTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</small>
+      <div class="summary-panel mt-6" *ngIf="lstProducts.length > 0">
+        <div class="summary-card">
+          <span>Subtotal</span>
+          <strong>{{ subTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+        </div>
+        <div class="summary-card">
+          <span>Impuestos</span>
+          <strong>{{ taxTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+        </div>
+        <div class="summary-card editable">
+          <label for="initialPayment">Abono inicial</label>
+          <p-inputNumber [(ngModel)]="initialPayment" mode="currency" currency="COP" locale="es-CO" [min]="0"
+            inputId="initialPayment" (ngModelChange)="calculateTotals()" styleClass="w-full"></p-inputNumber>
+        </div>
+        <div class="summary-card total-card">
+          <span>Total factura</span>
+          <strong>{{ total | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+          <small>Pendiente: {{ pendingTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</small>
+        </div>
       </div>
     </section>
   </div>

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
@@ -1,7 +1,61 @@
 import { fakeAsync, tick } from '@angular/core/testing';
 import { NEVER } from 'rxjs';
-
 import { PurchaseInvoiceCreationComponent } from './purchase-invoice-creation.component';
+
+describe('PurchaseInvoiceCreationComponent totals', () => {
+  function component(): PurchaseInvoiceCreationComponent {
+    return new PurchaseInvoiceCreationComponent(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  }
+
+  it('calculates subtotal, taxes, total and pending balance', () => {
+    const value = component();
+    value.lstProducts = [
+      {
+        cost: 100_000,
+        amount: 2,
+        IVA: 19,
+        IvaValor: 19_000,
+        descuentos: [10, 0],
+      } as any,
+    ];
+    value.initialPayment = 50_000;
+
+    value.calculateTotals();
+
+    expect(value.subTotal).toBe(180_000);
+    expect(value.taxTotal).toBe(38_000);
+    expect(value.total).toBe(218_000);
+    expect(value.pendingTotal).toBe(168_000);
+  });
+
+  it('recalculates line and invoice totals after editing a product', () => {
+    const value = component();
+    const product = {
+      cost: 25_000,
+      amount: 3,
+      IVA: 19,
+      IvaValor: 0,
+      totalValue: 0,
+      descuentos: [0, 0],
+    } as any;
+    value.lstProducts = [product];
+
+    value.calculateLine(product);
+
+    expect(product.totalValue).toBe(75_000);
+    expect(value.subTotal).toBe(75_000);
+    expect(value.total).toBe(89_250);
+    expect(value.pendingTotal).toBe(89_250);
+  });
+});
 
 describe('PurchaseInvoiceCreationComponent save state', () => {
   it('releases the loading button when the server does not respond', fakeAsync(() => {


### PR DESCRIPTION
## Summary
- show subtotal, taxes, invoice total, initial payment, and pending balance inside Detalle de la compra
- recalculate values after PrimeNG ngModel updates for quantity, price, IVA, and initial payment
- add unit coverage for subtotal, tax, total, and pending calculations

## Test plan
- [x] `npx ng test --include=src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts --browsers=ChromeHeadless --watch=false` (3/3)

Made with [Cursor](https://cursor.com)