### PR TITLE
feat(treasury): reorganize operations UX and reactive vendor reports

### DIFF
--- a/e2e/pp8/payable-writeoff-e2e.spec.ts
+++ b/e2e/pp8/payable-writeoff-e2e.spec.ts
@@ -1,0 +1,318 @@
+import { expect, Page, test } from '@playwright/test';
+
+const gateway = process.env.PP8_GATEWAY_URL ?? 'http://localhost:8080';
+const username = process.env.PP8_E2E_USERNAME;
+const password = process.env.PP8_E2E_PASSWORD;
+const enterpriseId = process.env.PP8_E2E_ENTERPRISE_ID ?? 'enterprise-e2e';
+const supplierTypeName = 'Proveedor';
+
+let supplierId: number;
+let token: string;
+let payable: any;
+let factCode: number;
+let counterpartAccount: { id: number; code: string; description: string } | undefined;
+const totalAmount = 1000;
+const partialAmount = 400;
+
+function isoDateLocal(date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function headers(authToken: string) {
+  return { Authorization: `Bearer ${authToken}` };
+}
+
+async function loginThroughAngular(page: Page): Promise<string> {
+  if (!username || !password) {
+    throw new Error('PP8_E2E_USERNAME y PP8_E2E_PASSWORD son obligatorios');
+  }
+  await page.goto('/login');
+  await page.locator('#username').fill(username);
+  await page.locator('#password').fill(password);
+  const tokenResponse = page.waitForResponse((response) =>
+    response.url().includes('/api/keycloak/token/') && response.status() === 200,
+    { timeout: 20_000 },
+  );
+  await page.getByRole('button', { name: 'Iniciar sesión' }).click();
+  await tokenResponse;
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('token'))).not.toBeNull();
+  await page.waitForURL(/#\/enterprise\/list/, { timeout: 20_000 });
+  await page.evaluate((enterprise) => localStorage.setItem('entData', JSON.stringify({
+    id: enterprise, name: 'PP8 E2E', nit: 'E2E', logo: '', inventoryConfigType: 'WEIGHTED_AVERAGE',
+  })), enterpriseId);
+  const authToken = (await page.evaluate(() => localStorage.getItem('token'))) as string;
+  const suppliersResponse = await page.request.get(`${gateway}/api/thirds/by-type`, {
+    headers: headers(authToken),
+    params: { entId: enterpriseId, thirdTypeName: supplierTypeName },
+  });
+  expect(suppliersResponse.ok()).toBeTruthy();
+  const suppliers = (await suppliersResponse.json()).content;
+  expect(suppliers.length).toBeGreaterThan(0);
+  supplierId = Number(suppliers[0].thId);
+  return authToken;
+}
+
+async function createPurchaseAndWaitForPayable(page: Page, authToken: string) {
+  factCode = Number(`${Date.now()}`.slice(-9));
+  const response = await page.request.post(`${gateway}/api/factures/skeleton/purchase`, {
+    headers: headers(authToken),
+    data: {
+      factCode,
+      entId: enterpriseId,
+      thId: supplierId,
+      products: [{
+        productId: 1,
+        amount: 1,
+        description: 'E2E Baja CxP',
+        discount: 0,
+        unitPrice: totalAmount,
+        subtotal: totalAmount,
+        taxPercentage: [],
+      }],
+      totalValue: String(totalAmount),
+      totalPay: '0',
+      pendingValue: String(totalAmount),
+      factureType: 'PURCHASE',
+      inventoryConfigType: 'WEIGHTED_AVERAGE',
+    },
+  });
+  expect(response.status()).toBe(201);
+  await expect.poll(async () => {
+    const pending = await page.request.get(`${gateway}/api/treasury/payables/pending`, {
+      headers: headers(authToken),
+      params: { enterpriseId },
+    });
+    if (!pending.ok()) return false;
+    payable = (await pending.json()).find((item: any) => item.reference === String(factCode));
+    return Boolean(payable);
+  }, { timeout: 45_000 }).toBeTruthy();
+  expect(payable.payableAccountId).toBeTruthy();
+  expect(payable.payableAccountCode).toBeTruthy();
+}
+
+async function pickCounterpartInDialog(page: Page, payableCode: string) {
+  const dialog = page.getByRole('dialog', { name: 'Baja de CxP' });
+  const dropdownHost = dialog.locator('p-dropdown').filter({
+    has: dialog.locator('[id="writeOffCounterpartAccount"]'),
+  });
+  await dropdownHost.locator('.p-dropdown-trigger, button[aria-haspopup="listbox"]').first().click();
+  const panel = page.locator('.p-dropdown-panel:visible, .p-select-overlay:visible').first();
+  await expect(panel).toBeVisible({ timeout: 30_000 });
+  const options = page.locator('.p-dropdown-item, .p-select-option, [role="option"]');
+  await expect.poll(async () => await options.count(), { timeout: 30_000 }).toBeGreaterThan(0);
+  const count = await options.count();
+  for (let index = 0; index < count; index += 1) {
+    const text = (await options.nth(index).textContent())?.trim() ?? '';
+    if (!text || text.includes(payableCode)) {
+      continue;
+    }
+    const match = text.match(/^(.+?)\s*-\s*(.+)$/);
+    await options.nth(index).click();
+    counterpartAccount = {
+      id: -1,
+      code: match?.[1]?.trim() ?? text,
+      description: match?.[2]?.trim() ?? text,
+    };
+    return;
+  }
+  throw new Error('No se encontró cuenta contrapartida activa en el dropdown de la UI');
+}
+
+async function getPayableById(page: Page, authToken: string, invoiceId: number) {
+  const pending = await page.request.get(`${gateway}/api/treasury/payables/pending`, {
+    headers: headers(authToken),
+    params: { enterpriseId },
+  });
+  expect(pending.ok()).toBeTruthy();
+  return (await pending.json()).find((item: any) => item.id === invoiceId);
+}
+
+async function getWriteOff(page: Page, authToken: string, writeOffId: number) {
+  const response = await page.request.get(`${gateway}/api/treasury/payable-write-offs/${writeOffId}`, {
+    headers: headers(authToken),
+  });
+  expect(response.ok()).toBeTruthy();
+  return await response.json();
+}
+
+async function getAccountingEntry(page: Page, authToken: string, entryId: number) {
+  const response = await page.request.get(
+    `${gateway}/api/accountCatalogue/accounting/entries/${entryId}`,
+    { headers: headers(authToken) },
+  );
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()).data;
+}
+
+async function openWriteOffDialogForReference(page: Page, reference: string) {
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  const payablesCard = page.locator('.p-card').filter({ hasText: 'Obligaciones pendientes' });
+  await page.getByRole('button', { name: 'Actualizar' }).click();
+  await page.waitForResponse((response) =>
+    response.url().includes('/api/treasury/payables/pending') && response.ok(),
+  );
+  let row = payablesCard.locator('tbody tr').filter({ hasText: reference }).first();
+  for (let attempt = 0; attempt < 15 && (await row.count()) === 0; attempt += 1) {
+    const nextPage = payablesCard.locator('.p-paginator-next');
+    if (await nextPage.isEnabled()) {
+      await nextPage.click();
+      await page.waitForTimeout(300);
+      row = payablesCard.locator('tbody tr').filter({ hasText: reference }).first();
+    } else {
+      break;
+    }
+  }
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await row.getByRole('button', { name: 'Baja CxP' }).click();
+  await expect(page.getByRole('dialog', { name: 'Baja de CxP' })).toBeVisible();
+}
+
+async function fillWriteOffDialog(page: Page, amount: number, reason: string) {
+  const dialog = page.getByRole('dialog', { name: 'Baja de CxP' });
+  const amountInput = dialog.getByRole('spinbutton', { name: 'Monto de baja *' });
+  await amountInput.click();
+  await amountInput.fill(String(amount));
+  await pickCounterpartInDialog(page, payable.payableAccountCode);
+  await dialog.getByRole('textbox', { name: 'Motivo *' }).fill(reason);
+  await dialog.getByRole('button', { name: 'Crear baja' }).click();
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test('Baja de CxP E2E real', async ({ page }) => {
+  token = await loginThroughAngular(page);
+  await createPurchaseAndWaitForPayable(page, token);
+
+  const reference = String(factCode);
+  await openWriteOffDialogForReference(page, reference);
+  const dialog = page.getByRole('dialog', { name: 'Baja de CxP' });
+  await expect(dialog.getByText(reference)).toBeVisible();
+  await expect(dialog.getByText(payable.payableAccountCode, { exact: false })).toBeVisible();
+  await fillWriteOffDialog(page, partialAmount, 'E2E baja parcial CxP');
+
+  await expect.poll(async () => {
+    const list = await page.request.get(`${gateway}/api/treasury/payable-write-offs`, {
+      headers: headers(token),
+      params: { enterpriseId },
+    });
+    if (!list.ok()) return null;
+    return (await list.json()).find((item: any) => item.reason === 'E2E baja parcial CxP');
+  }, { timeout: 20_000 }).toBeTruthy();
+
+  const writeOffs = await (await page.request.get(`${gateway}/api/treasury/payable-write-offs`, {
+    headers: headers(token),
+    params: { enterpriseId },
+  })).json();
+  const partialWriteOff = writeOffs.find((item: any) => item.reason === 'E2E baja parcial CxP');
+  expect(partialWriteOff.status).toBe('DRAFT');
+  expect(Number(partialWriteOff.total)).toBe(partialAmount);
+  counterpartAccount = {
+    id: partialWriteOff.counterpartAccountId,
+    code: partialWriteOff.counterpartAccountCode,
+    description: counterpartAccount?.description ?? partialWriteOff.counterpartAccountCode,
+  };
+
+  await page.locator('.p-card').filter({ hasText: 'Bajas de CxP' })
+    .locator('tbody tr').filter({ hasText: 'E2E baja parcial CxP' })
+    .getByRole('button', { name: 'Contabilizar' }).click();
+  await expect.poll(async () => {
+    const current = await getWriteOff(page, token, partialWriteOff.id);
+    return current.status;
+  }, { timeout: 45_000 }).toBe('POSTED');
+
+  const postedPartial = await getWriteOff(page, token, partialWriteOff.id);
+  expect(postedPartial.accountingEntryId).toBeTruthy();
+
+  const remaining = totalAmount - partialAmount;
+  await expect.poll(async () => {
+    const currentPayable = await getPayableById(page, token, payable.id);
+    return currentPayable ? Number(currentPayable.availableAmount) : -1;
+  }, { timeout: 20_000 }).toBe(remaining);
+
+  const entry = await getAccountingEntry(page, token, postedPartial.accountingEntryId);
+  expect(entry.type).toBe('PAYABLE_WRITEOFF');
+  const movements = entry.movements;
+  expect(movements.length).toBe(2);
+  const debitTotal = movements.reduce((sum: number, movement: any) => sum + Number(movement.debit), 0);
+  const creditTotal = movements.reduce((sum: number, movement: any) => sum + Number(movement.credit), 0);
+  expect(debitTotal).toBe(partialAmount);
+  expect(creditTotal).toBe(partialAmount);
+  const payableMovement = movements.find((movement: any) => movement.account === payable.payableAccountId);
+  const counterpartMovement = movements.find((movement: any) => movement.account === counterpartAccount.id);
+  expect(payableMovement).toBeTruthy();
+  expect(Number(payableMovement.debit)).toBe(partialAmount);
+  expect(Number(payableMovement.credit)).toBe(0);
+  expect(counterpartMovement).toBeTruthy();
+  expect(Number(counterpartMovement.credit)).toBe(partialAmount);
+  expect(Number(counterpartMovement.debit)).toBe(0);
+
+  const draftForVoidResponse = await page.request.post(`${gateway}/api/treasury/payable-write-offs`, {
+    headers: headers(token),
+    data: {
+      enterpriseId,
+      reason: 'E2E void draft probe',
+      counterpartAccountId: counterpartAccount!.id,
+      counterpartAccountCode: counterpartAccount!.code,
+      details: [{ supplierId, invoiceId: payable.id, amount: 50 }],
+    },
+  });
+  expect(draftForVoidResponse.ok()).toBeTruthy();
+  const draftForVoid = await draftForVoidResponse.json();
+  expect(draftForVoid.status).toBe('DRAFT');
+  const voidResponse = await page.request.post(
+    `${gateway}/api/treasury/payable-write-offs/${draftForVoid.id}/void`,
+    { headers: headers(token) },
+  );
+  expect(voidResponse.ok()).toBeFalsy();
+  await page.goto('/#/financial/treasury/operations');
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  const draftRow = page.locator('.p-card').filter({ hasText: 'Bajas de CxP' })
+    .locator('tbody tr').filter({ hasText: 'E2E void draft probe' }).first();
+  await expect(draftRow).toBeVisible();
+  await expect(draftRow.getByRole('button', { name: 'Anular' })).toHaveCount(0);
+
+  await openWriteOffDialogForReference(page, reference);
+  await fillWriteOffDialog(page, remaining, 'E2E baja total CxP');
+
+  await expect.poll(async () => {
+    const list = await (await page.request.get(`${gateway}/api/treasury/payable-write-offs`, {
+      headers: headers(token),
+      params: { enterpriseId },
+    })).json();
+    return list.find((item: any) => item.reason === 'E2E baja total CxP');
+  }, { timeout: 20_000 }).toBeTruthy();
+
+  const totalWriteOff = (await (await page.request.get(`${gateway}/api/treasury/payable-write-offs`, {
+    headers: headers(token),
+    params: { enterpriseId },
+  })).json()).find((item: any) => item.reason === 'E2E baja total CxP');
+  expect(totalWriteOff.status).toBe('DRAFT');
+
+  await page.locator('.p-card').filter({ hasText: 'Bajas de CxP' })
+    .locator('tbody tr').filter({ hasText: 'E2E baja total CxP' })
+    .getByRole('button', { name: 'Contabilizar' }).click();
+
+  await expect.poll(async () => {
+    const current = await getWriteOff(page, token, totalWriteOff.id);
+    return current.status;
+  }, { timeout: 45_000 }).toBe('POSTED');
+
+  await expect.poll(async () => {
+    const currentPayable = await getPayableById(page, token, payable.id);
+    if (!currentPayable) return 0;
+    return Number(currentPayable.availableAmount);
+  }, { timeout: 20_000 }).toBe(0);
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: /Operaciones de Tesorer[ií]a/i })).toBeVisible();
+  const finalRow = page.locator('.p-card').filter({ hasText: 'Obligaciones pendientes' })
+    .locator('tbody tr').filter({ hasText: reference });
+  if (await finalRow.count() > 0) {
+    const writeOffButton = finalRow.first().getByRole('button', { name: 'Baja CxP' });
+    await expect(writeOffButton).toBeDisabled();
+  }
+});

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.css
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.css
@@ -149,8 +149,11 @@
 }
 
 .summary-card strong {
+  display: block;
+  min-height: 1.35rem;
   color: #111827;
   font-size: 1.15rem;
+  line-height: 1.35;
 }
 
 .summary-card.total-card {

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -58,15 +58,17 @@
 
         <div class="flex flex-col">
           <label for="paymentTermDays" class="field-label">Plazo de pago (días)</label>
-          <p-inputNumber id="paymentTermDays" [(ngModel)]="paymentTermDays" [min]="0"
-            (onInput)="onPaymentTermChange()" styleClass="w-full" size="small"></p-inputNumber>
+          <p-inputNumber id="paymentTermDays" [(ngModel)]="paymentTermDays" [min]="1"
+            (ngModelChange)="onPaymentTermChange()" styleClass="w-full" size="small"></p-inputNumber>
+          <small class="field-help">Se sincroniza con la fecha de vencimiento.</small>
         </div>
 
         <div class="flex flex-col">
           <label for="dueDate" class="field-label">Fecha de vencimiento</label>
-          <p-datepicker id="dueDate" [(ngModel)]="dueDate" (onSelect)="onDueDateChange()" dateFormat="dd/mm/yy"
-            size="small" placeholder="Se calcula con el plazo" [showIcon]="true" iconDisplay="input"
-            styleClass="w-full"></p-datepicker>
+          <p-datepicker id="dueDate" [(ngModel)]="dueDate" (ngModelChange)="onDueDateChange($event)"
+            dateFormat="dd/mm/yy" size="small" placeholder="Seleccione o use el plazo" [showIcon]="true"
+            [minDate]="minDueDate" styleClass="w-full"></p-datepicker>
+          <small class="field-help">Debe ser posterior a la emisión. Al cambiarla, se actualiza el plazo.</small>
         </div>
 
         <div class="flex flex-col md:col-span-2">
@@ -112,8 +114,10 @@
                 <small class="text-gray-500">{{ prod.description }}</small>
               </td>
               <td>
-                <p-inputNumber [(ngModel)]="prod.amount" mode="decimal" size="small" [showButtons]="true" [min]="1"
-                  (ngModelChange)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
+                <p-inputNumber [(ngModel)]="prod.amount" mode="decimal" size="small" [showButtons]="true"
+                  [min]="maxQuantityFor(prod) > 0 ? 1 : 0" [max]="maxQuantityFor(prod)"
+                  (ngModelChange)="onQuantityChange(prod)" inputStyleClass="w-full"></p-inputNumber>
+                <small class="field-help">Disponible: {{ maxQuantityFor(prod) }}</small>
               </td>
               <td>
                 <p-inputNumber [(ngModel)]="prod.cost" mode="currency" size="small" currency="COP" locale="es-CO"
@@ -122,16 +126,16 @@
               <td>
                 <div class="flex gap-2">
                   <p-inputNumber [(ngModel)]="prod.descuentos[0]" size="small" suffix="%" [min]="0" [max]="100"
-                    (onInput)="switchDescuento('porc', prod)" inputStyleClass="w-full"></p-inputNumber>
+                    (ngModelChange)="switchDescuento('porc', prod)" inputStyleClass="w-full"></p-inputNumber>
                   <p-inputNumber [(ngModel)]="prod.descuentos[1]" size="small" mode="currency" currency="COP" locale="es-CO"
-                    (onInput)="switchDescuento('val', prod)" inputStyleClass="w-full"></p-inputNumber>
+                    (ngModelChange)="switchDescuento('val', prod)" inputStyleClass="w-full"></p-inputNumber>
                 </div>
               </td>
               <td>
                 <p-inputNumber [(ngModel)]="prod.IVA" size="small" suffix="%" [min]="0" [max]="100"
                   (ngModelChange)="calculateLine(prod)" inputStyleClass="w-full"></p-inputNumber>
               </td>
-              <td class="text-right">{{ lineSubtotal(prod) | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</td>
+              <td class="text-right">{{ formatCop(lineSubtotal(prod)) }}</td>
               <td>
                 <p-button icon="pi pi-trash" severity="danger" [text]="true" (onClick)="deleteProduct(i)"></p-button>
               </td>
@@ -149,21 +153,23 @@
       <div class="summary-panel mt-6" *ngIf="lstProducts.length > 0">
         <div class="summary-card">
           <span>Subtotal</span>
-          <strong>{{ subTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+          <strong>{{ formatCop(subTotal) }}</strong>
         </div>
         <div class="summary-card">
           <span>Impuestos</span>
-          <strong>{{ taxTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
+          <strong>{{ formatCop(taxTotal) }}</strong>
         </div>
         <div class="summary-card editable">
           <label for="initialPayment">Abono inicial</label>
-          <p-inputNumber [(ngModel)]="initialPayment" mode="currency" currency="COP" locale="es-CO" [min]="0"
-            inputId="initialPayment" (ngModelChange)="calculateTotals()" styleClass="w-full"></p-inputNumber>
+          <p-inputNumber [(ngModel)]="initialPayment" mode="currency" currency="COP" locale="es-CO"
+            [min]="0" [max]="maxInitialPayment()" inputId="initialPayment"
+            (ngModelChange)="onInitialPaymentChange()" styleClass="w-full"></p-inputNumber>
+          <small class="field-help">Opcional (0 = todo pendiente). Mín. {{ formatCop(minInitialPayment()) }} si registra abono. No use el total completo.</small>
         </div>
         <div class="summary-card total-card">
           <span>Total factura</span>
-          <strong>{{ total | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</strong>
-          <small>Pendiente: {{ pendingTotal | currency:'COP':'symbol-narrow':'1.0-0':'es-CO' }}</small>
+          <strong>{{ formatCop(total) }}</strong>
+          <small>Pendiente: {{ formatCop(pendingTotal) }}</small>
         </div>
       </div>
     </section>

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
@@ -31,9 +31,81 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
     value.calculateTotals();
 
     expect(value.subTotal).toBe(180_000);
-    expect(value.taxTotal).toBe(38_000);
-    expect(value.total).toBe(218_000);
-    expect(value.pendingTotal).toBe(168_000);
+    expect(value.taxTotal).toBe(34_200);
+    expect(value.total).toBe(214_200);
+    expect(value.pendingTotal).toBe(164_200);
+  });
+
+  it('caps initial payment above total and enforces minimum partial payment', () => {
+    const value = component();
+    value.lstProducts = [
+      {
+        cost: 100,
+        amount: 1,
+        IVA: 0,
+        descuentos: [0, 0],
+      } as any,
+    ];
+    value.calculateTotals();
+
+    value.initialPayment = 250;
+    value.onInitialPaymentChange();
+    expect(value.initialPayment).toBe(99);
+    expect(value.pendingTotal).toBe(1);
+
+    value.initialPayment = 10;
+    value.onInitialPaymentChange();
+    expect(value.initialPayment).toBe(50);
+    expect(value.pendingTotal).toBe(50);
+  });
+
+  it('rejects full initial payment on save', () => {
+    const value = component();
+    value.supplier = { thId: 1 } as any;
+    value.lstProducts = [{
+      id: 1,
+      name: 'Producto',
+      amount: 1,
+      cost: 100,
+      IVA: 0,
+      descuentos: [0, 0],
+      maxQuantity: 10,
+    } as any];
+    value.calculateTotals();
+    value.initialPayment = 100;
+
+    const error = (value as any).validateInitialPayment();
+    expect(error).toContain('Tesorería');
+  });
+
+  it('does not allow due dates on or before emission date', () => {
+    const value = component();
+    value.currentDate = new Date('2026-08-13T12:00:00');
+    value.minDueDate = new Date('2026-08-14T00:00:00');
+    value.dueDate = new Date('2026-08-13T12:00:00');
+
+    value.onDueDateChange(value.dueDate);
+
+    expect(value.dueDate?.toISOString().slice(0, 10)).toBe('2026-08-14');
+    expect(value.paymentTermDays).toBe(1);
+  });
+
+  it('keeps payment term and due date in sync', () => {
+    const value = component();
+    value.currentDate = new Date('2026-08-13T12:00:00');
+    value.minDueDate = new Date('2026-08-14T00:00:00');
+    value.paymentTermDays = 30;
+    value.onPaymentTermChange();
+
+    expect(value.paymentTermDays).toBe(30);
+    expect(value.dueDate?.toISOString().slice(0, 10)).toBe('2026-09-12');
+
+    value.paymentTermDays = 10;
+    value.onPaymentTermChange();
+    expect(value.dueDate?.toISOString().slice(0, 10)).toBe('2026-08-23');
+
+    value.onDueDateChange(new Date('2026-08-20T12:00:00'));
+    expect(value.paymentTermDays).toBe(7);
   });
 
   it('recalculates line and invoice totals after editing a product', () => {

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -48,6 +48,7 @@ import { PurchaseInvoiceService } from '../../services/purchase-invoice.service'
 })
 export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   private static readonly SAVE_TIMEOUT_MS = 20_000;
+  private static readonly MIN_INITIAL_PAYMENT_COP = 50;
 
   private readonly localStorageMethods = new LocalStorageMethods();
   private ref?: DynamicDialogRef;
@@ -55,6 +56,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
 
   currentDate = new Date();
   dueDate?: Date;
+  minDueDate!: Date;
   paymentTermDays = 30;
   initialPayment = 0;
   observations = '';
@@ -71,6 +73,8 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   pendingTotal = 0;
   impuestoCheck = true;
 
+  private syncingPaymentSchedule = false;
+
   constructor(
     private readonly thirdService: ThirdService,
     private readonly unitMeasureService: UnitOfMeasureService,
@@ -82,6 +86,8 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    this.minDueDate = this.addDays(this.stripTime(this.currentDate), 1);
+    this.syncDueDateFromPaymentTerm();
     this.loadSuppliers();
   }
 
@@ -161,47 +167,83 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
       if (!result?.length) {
         return;
       }
-      this.lstProducts = result.map((prod) => ({
-        id: prod.id,
-        name: prod.name,
-        description: prod.description,
-        cost: prod.cost,
-        displayPrice: String(prod.cost),
-        taxPercentage: prod.taxPercentage,
-        unitOfMeasureId: prod.unitOfMeasureId,
-        IVA: prod.taxPercentage || 0,
-        IvaValor: 0,
-        amount: 1,
-        totalValue: 0,
-        descuentos: [0, 0] as [number, number],
-        displayDescuentos: '0',
-      })) as ProductToSale[];
-      this.lstProducts.forEach((prod) => {
-        prod.IVA = prod.taxPercentage;
-        prod.IvaValor = (prod.cost * prod.IVA) / 100;
+      this.lstProducts = result.map((prod) => {
+        const maxQuantity = this.toAmount(prod.quantity, 0);
+        const initialAmount = maxQuantity > 0 ? Math.min(1, maxQuantity) : 0;
+        return this.normalizeProductLine({
+          id: prod.id,
+          name: prod.name,
+          description: prod.description,
+          cost: prod.cost,
+          displayPrice: String(prod.cost ?? 0),
+          taxPercentage: prod.taxPercentage,
+          unitOfMeasureId: prod.unitOfMeasureId,
+          minQuantity: 1,
+          maxQuantity,
+          IVA: prod.taxPercentage ?? 0,
+          IvaValor: 0,
+          amount: initialAmount,
+          totalValue: 0,
+          descuentos: [0, 0] as [number, number],
+          displayDescuentos: '0',
+        } as ProductToSale);
       });
+      this.lstProducts.forEach((prod) => this.calculateLine(prod));
       this.loadUnitOfMeasureAbbreviations();
-      this.calculateTotals();
     });
   }
 
   calculateTotals(): void {
-    this.subTotal = this.lstProducts.reduce((acc, prod) => acc + this.computeLineSubtotal(prod), 0);
+    this.subTotal = this.sumLineValues((prod) => this.computeLineSubtotal(prod));
     this.taxTotal = this.impuestoCheck
-      ? this.lstProducts.reduce((acc, prod) => acc + (prod.IvaValor || 0) * (prod.amount || 0), 0)
+      ? this.sumLineValues((prod) => this.computeLineTax(prod))
       : 0;
     this.total = this.subTotal + this.taxTotal;
-    this.pendingTotal = Math.max(this.total - (this.initialPayment || 0), 0);
+    this.enforceInitialPaymentLimit(false);
+    this.pendingTotal = Math.max(this.total - this.toAmount(this.initialPayment), 0);
+  }
+
+  onInitialPaymentChange(): void {
+    this.enforceInitialPaymentLimit(true);
+    this.calculateTotals();
+  }
+
+  maxInitialPayment(): number {
+    return Math.max(this.toAmount(this.total), 0);
+  }
+
+  minInitialPayment(): number {
+    return this.canRegisterPartialInitialPayment() ? PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP : 0;
   }
 
   calculateLine(prod: ProductToSale): void {
-    prod.totalValue = this.lineSubtotal(prod);
-    prod.IvaValor = this.impuestoCheck ? (prod.cost * (prod.IVA || 0)) / 100 : 0;
+    this.enforceQuantityLimit(prod, true);
+    this.normalizeProductLine(prod);
+    prod.totalValue = this.computeLineSubtotal(prod);
+    prod.IvaValor = this.computeLineTax(prod);
     this.calculateTotals();
+  }
+
+  onQuantityChange(prod: ProductToSale): void {
+    this.calculateLine(prod);
   }
 
   lineSubtotal(prod: ProductToSale): number {
     return this.computeLineSubtotal(prod);
+  }
+
+  maxQuantityFor(prod: ProductToSale): number {
+    return Math.max(this.toAmount(prod.maxQuantity), 0);
+  }
+
+  formatCop(value: number | null | undefined): string {
+    const amount = this.toAmount(value);
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
   }
 
   switchDescuento(type: 'porc' | 'val', prod: ProductToSale): void {
@@ -230,8 +272,35 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
       this.messageService.add({ severity: 'warn', summary: 'Productos requeridos', detail: 'Agregue al menos un producto' });
       return;
     }
-    if (this.initialPayment > this.total) {
-      this.messageService.add({ severity: 'warn', summary: 'Abono inválido', detail: 'El abono no puede superar el total' });
+    const invalidQuantity = this.lstProducts.find((prod) => {
+      const max = this.maxQuantityFor(prod);
+      const amount = this.toAmount(prod.amount);
+      return max <= 0 || amount <= 0 || amount > max;
+    });
+    if (invalidQuantity) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Cantidad inválida',
+        detail: `El producto "${invalidQuantity.name}" no puede superar el inventario disponible (${this.maxQuantityFor(invalidQuantity)}).`,
+      });
+      return;
+    }
+    const paymentError = this.validateInitialPayment();
+    if (paymentError) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Abono inválido',
+        detail: paymentError,
+      });
+      return;
+    }
+    const dueDateError = this.validateDueDate();
+    if (dueDateError) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Vencimiento inválido',
+        detail: dueDateError,
+      });
       return;
     }
 
@@ -289,20 +358,43 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   }
 
   onPaymentTermChange(): void {
-    if (this.paymentTermDays < 0) {
-      this.paymentTermDays = 0;
-    }
-    if (this.dueDate) {
-      this.dueDate = this.addDays(this.currentDate, this.paymentTermDays);
-    }
-  }
-
-  onDueDateChange(): void {
-    if (!this.dueDate) {
+    if (this.syncingPaymentSchedule) {
       return;
     }
-    const diffMs = this.dueDate.getTime() - this.stripTime(this.currentDate).getTime();
-    this.paymentTermDays = Math.max(Math.round(diffMs / (1000 * 60 * 60 * 24)), 0);
+    this.syncingPaymentSchedule = true;
+    this.paymentTermDays = Math.max(this.toAmount(this.paymentTermDays, 1), 1);
+    this.dueDate = this.addDays(this.stripTime(this.currentDate), this.paymentTermDays);
+    this.releasePaymentScheduleSync();
+  }
+
+  onDueDateChange(selectedDate: Date | null): void {
+    if (this.syncingPaymentSchedule || !selectedDate) {
+      return;
+    }
+    this.syncingPaymentSchedule = true;
+    const previousDay = this.dueDate ? this.stripTime(this.dueDate).getTime() : null;
+    this.dueDate = selectedDate;
+    this.enforceDueDateLimit(previousDay !== this.stripTime(this.dueDate).getTime());
+    this.paymentTermDays = this.daysBetweenEmissionAndDue(this.dueDate);
+    this.releasePaymentScheduleSync();
+  }
+
+  private syncDueDateFromPaymentTerm(): void {
+    this.paymentTermDays = Math.max(this.toAmount(this.paymentTermDays, 30), 1);
+    this.dueDate = this.addDays(this.stripTime(this.currentDate), this.paymentTermDays);
+  }
+
+  private daysBetweenEmissionAndDue(due: Date): number {
+    const emission = this.stripTime(this.currentDate);
+    const dueDay = this.stripTime(due);
+    const diffMs = dueDay.getTime() - emission.getTime();
+    return Math.max(Math.round(diffMs / (1000 * 60 * 60 * 24)), 1);
+  }
+
+  private releasePaymentScheduleSync(): void {
+    setTimeout(() => {
+      this.syncingPaymentSchedule = false;
+    });
   }
 
   private buildProductLines(): PurchaseInvoiceProductLine[] {
@@ -329,15 +421,214 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   }
 
   private computeLineSubtotal(prod: ProductToSale): number {
-    const base = (prod.cost || 0) * (prod.amount || 0);
-    const discountPerc = prod.descuentos?.[0] || 0;
-    const discountVal = prod.descuentos?.[1] || 0;
-    return base - base * (discountPerc / 100) - discountVal;
+    const unitCost = this.toAmount(prod.cost);
+    const quantity = this.toAmount(prod.amount, 1);
+    const base = unitCost * quantity;
+    const discountPerc = this.toAmount(prod.descuentos?.[0]);
+    const discountVal = this.toAmount(prod.descuentos?.[1]);
+    return Math.max(base - base * (discountPerc / 100) - discountVal, 0);
+  }
+
+  private computeLineTax(prod: ProductToSale): number {
+    if (!this.impuestoCheck) {
+      return 0;
+    }
+    const lineSubtotal = this.computeLineSubtotal(prod);
+    const taxRate = this.toAmount(prod.IVA);
+    return lineSubtotal * (taxRate / 100);
+  }
+
+  private normalizeProductLine(prod: ProductToSale): ProductToSale {
+    prod.maxQuantity = this.toAmount(prod.maxQuantity, 0);
+    prod.minQuantity = Math.max(this.toAmount(prod.minQuantity, 1), 1);
+    prod.amount = this.toAmount(prod.amount, prod.maxQuantity > 0 ? 1 : 0);
+    this.enforceQuantityLimit(prod, false);
+    prod.cost = this.toAmount(prod.cost);
+    prod.IVA = this.toAmount(prod.IVA ?? prod.taxPercentage);
+    if (!prod.descuentos || prod.descuentos.length < 2) {
+      prod.descuentos = [0, 0];
+    }
+    prod.descuentos[0] = this.toAmount(prod.descuentos[0]);
+    prod.descuentos[1] = this.toAmount(prod.descuentos[1]);
+    return prod;
+  }
+
+  private enforceQuantityLimit(prod: ProductToSale, notify: boolean): void {
+    const max = this.maxQuantityFor(prod);
+    const current = this.toAmount(prod.amount);
+    if (max <= 0 && current > 0) {
+      prod.amount = 0;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Sin inventario',
+          detail: `El producto "${prod.name}" no tiene existencias disponibles.`,
+        });
+      }
+      return;
+    }
+    if (current > max) {
+      prod.amount = max;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Cantidad inválida',
+          detail: `La cantidad de "${prod.name}" no puede superar el inventario disponible (${max}).`,
+        });
+      }
+    }
+  }
+
+  private canRegisterPartialInitialPayment(): boolean {
+    return this.toAmount(this.total) >= PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP;
+  }
+
+  private validateDueDate(): string | null {
+    const due = this.dueDate ?? this.addDays(this.currentDate, Math.max(this.paymentTermDays, 1));
+    if (this.stripTime(due).getTime() < this.minDueDate.getTime()) {
+      return 'La fecha de vencimiento debe ser posterior a hoy (no puede ser hoy ni anterior).';
+    }
+    return null;
+  }
+
+  private enforceDueDateLimit(notify: boolean): void {
+    if (!this.dueDate) {
+      return;
+    }
+    const min = this.minDueDate;
+    if (this.stripTime(this.dueDate).getTime() < min.getTime()) {
+      this.dueDate = new Date(min);
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Vencimiento inválido',
+          detail: 'La fecha de vencimiento debe ser posterior a hoy.',
+        });
+      }
+    }
+  }
+
+  private validateInitialPayment(): string | null {
+    const total = this.toAmount(this.total);
+    const payment = this.toAmount(this.initialPayment);
+
+    if (payment <= 0) {
+      return null;
+    }
+
+    if (payment > total) {
+      return `El abono no puede superar el total de la factura (${this.formatCop(total)}).`;
+    }
+
+    if (!this.canRegisterPartialInitialPayment()) {
+      return `El total es menor a ${this.formatCop(PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP)}; deje el abono en 0 y pague en Tesorería si corresponde.`;
+    }
+
+    if (payment < PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP) {
+      return `El abono mínimo es ${this.formatCop(PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP)}.`;
+    }
+
+    if (payment >= total) {
+      return 'Si pagó el total de la factura, deje el abono en 0 y registre el pago en Tesorería (Comprobante de egreso). El abono inicial es solo para pagos parciales.';
+    }
+
+    return null;
+  }
+
+  private enforceInitialPaymentLimit(notify: boolean): void {
+    const total = this.toAmount(this.total);
+    let payment = this.toAmount(this.initialPayment);
+
+    if (payment <= 0) {
+      this.initialPayment = 0;
+      return;
+    }
+
+    if (!this.canRegisterPartialInitialPayment()) {
+      this.initialPayment = 0;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Abono no permitido',
+          detail: `El total es menor a ${this.formatCop(PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP)}. Deje el abono en 0.`,
+        });
+      }
+      return;
+    }
+
+    const maxPartial = total - 1;
+    if (maxPartial < PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP) {
+      this.initialPayment = 0;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Abono no permitido',
+          detail: 'No hay un abono parcial válido para este total. Deje el abono en 0.',
+        });
+      }
+      return;
+    }
+
+    if (payment > total) {
+      payment = total;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Abono inválido',
+          detail: `El abono no puede superar el total (${this.formatCop(total)}).`,
+        });
+      }
+    }
+
+    if (payment >= total) {
+      payment = maxPartial;
+      if (notify) {
+        this.messageService.add({
+          severity: 'info',
+          summary: 'Pago total en Tesorería',
+          detail: 'El abono inicial es parcial. Para pagar el total, deje el abono en 0 y use Comprobante de egreso en Tesorería.',
+          life: 6000,
+        });
+      }
+    }
+
+    if (payment < PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP) {
+      payment = PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP;
+      if (notify) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Abono mínimo',
+          detail: `El abono mínimo es ${this.formatCop(PurchaseInvoiceCreationComponent.MIN_INITIAL_PAYMENT_COP)}.`,
+        });
+      }
+    }
+
+    if (payment > maxPartial) {
+      payment = maxPartial;
+    }
+
+    this.initialPayment = payment;
+  }
+
+  private toAmount(value: unknown, fallback = 0): number {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : fallback;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.replace(/[^\d,-]/g, '').replace(',', '.');
+      const parsed = Number(normalized);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    }
+    return fallback;
+  }
+
+  private sumLineValues(selector: (prod: ProductToSale) => number): number {
+    return this.lstProducts.reduce((acc, prod) => acc + this.toAmount(selector(prod)), 0);
   }
 
   private resolveDueDate(): string | undefined {
-    const due = this.dueDate ?? this.addDays(this.currentDate, this.paymentTermDays || 30);
-    return due.toISOString().split('T')[0];
+    const due = this.dueDate ?? this.addDays(this.currentDate, Math.max(this.paymentTermDays, 1));
+    return this.stripTime(due).toISOString().split('T')[0];
   }
 
   private addDays(date: Date, days: number): Date {
@@ -370,7 +661,8 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
     this.initialPayment = 0;
     this.observations = '';
     this.paymentTermDays = 30;
-    this.dueDate = undefined;
+    this.minDueDate = this.addDays(this.stripTime(this.currentDate), 1);
+    this.syncDueDateFromPaymentTerm();
     this.calculateTotals();
   }
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
@@ -3,56 +3,70 @@
         <p-message severity="error" [text]="errorMessage"></p-message>
     }
 
-    <!-- CABECERA -->
     <div class="mb-8">
         <h1 class="font-['Titillium_Web'] font-bold text-3xl text-[var(--color-primary)] border-b-4 border-[var(--color-secondary)] inline-block pb-1">
             Contabilización del Comprobante
         </h1>
         <p class="mt-2 text-base text-gray-600">
-            Asientos contables generados para el comprobante {{ receiptCode }}
+            Asiento contable del comprobante {{ receiptCode }}
         </p>
     </div>
 
-    <!-- INFORMACIÓN DEL COMPROBANTE -->
     <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Información del Comprobante</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-                <span class="font-medium">Código:</span>
-                <span class="ml-2">{{ receiptCode }}</span>
-            </div>
-            <div>
-                <span class="font-medium">Fecha:</span>
-                <span class="ml-2">{{ issueDate | date:'dd/MM/yyyy' }}</span>
-            </div>
+        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Información del comprobante</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700">
+            @if (accountingEntryHeader.documentTypeLabel) {
+                <div><span class="font-medium">Origen:</span> <span class="ml-2">{{ accountingEntryHeader.documentTypeLabel }}</span></div>
+            }
+            @if (accountingEntryHeader.voucherNumber || receiptCode) {
+                <div><span class="font-medium">Comprobante:</span> <span class="ml-2">{{ accountingEntryHeader.voucherNumber || receiptCode }}</span></div>
+            }
+            @if (accountingEntryHeader.supplierLabel || supplierName) {
+                <div><span class="font-medium">Proveedor:</span> <span class="ml-2">{{ accountingEntryHeader.supplierLabel || supplierName }}</span></div>
+            }
+            @if (issueDate) {
+                <div><span class="font-medium">Fecha:</span> <span class="ml-2">{{ issueDate | date:'dd/MM/yyyy' }}</span></div>
+            }
+            @if (accountingEntryHeader.entryCode) {
+                <div><span class="font-medium">Asiento:</span> <span class="ml-2">{{ accountingEntryHeader.entryCode }}</span></div>
+            }
+            @if (accountingEntryHeader.entryStatus) {
+                <div><span class="font-medium">Estado:</span> <span class="ml-2">{{ accountingStatusLabel(accountingEntryHeader.entryStatus) }}</span></div>
+            }
         </div>
     </div>
 
-    <!-- ASIENTOS CONTABLES -->
     <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Asientos Contables</h2>
+        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Asiento contable</h2>
 
-        @if (accountingEntries && accountingEntries.length > 0) {
-            <p-table [value]="accountingEntries" [tableStyle]="{'min-width': '50rem'}" styleClass="p-datatable-striped">
+        @if (accountingMovements.length && !accountingIsBalanced) {
+            <p-message
+                severity="warn"
+                text="El asiento no está balanceado: el total débito difiere del total crédito."
+                styleClass="mb-4 w-full">
+            </p-message>
+        }
+
+        @if (accountingMovements.length > 0) {
+            <p-table [value]="accountingMovements" [tableStyle]="{'min-width': '50rem'}" styleClass="p-datatable-striped">
                 <ng-template pTemplate="header">
                     <tr>
-                        <th>Código de Cuenta</th>
-                        <th>Nombre de Cuenta</th>
-                        <th>Tercero</th>
+                        <th>Código cuenta</th>
+                        <th>Cuenta</th>
+                        <th>Detalle</th>
                         <th class="text-right">Débito</th>
                         <th class="text-right">Crédito</th>
-                        <th>Descripción</th>
                     </tr>
                 </ng-template>
                 <ng-template pTemplate="body" let-entry>
                     <tr>
                         <td class="font-mono">{{ entry.accountCode }}</td>
                         <td>{{ entry.accountName }}</td>
-                        <td>{{ entry.thirdPartyId || '-' }}</td>
+                        <td>{{ entry.detail }}</td>
                         <td class="text-right">
                             @if (entry.debit > 0) {
                                 <span class="text-red-600 font-semibold">
-                                    {{ entry.debit | currency:'COP':'symbol':'1.0-0':'es-CO' }}
+                                    {{ entry.debit | currency:'COP':'symbol':'1.0-2':'es-CO' }}
                                 </span>
                             } @else {
                                 <span class="text-gray-400">-</span>
@@ -61,34 +75,31 @@
                         <td class="text-right">
                             @if (entry.credit > 0) {
                                 <span class="text-green-600 font-semibold">
-                                    {{ entry.credit | currency:'COP':'symbol':'1.0-0':'es-CO' }}
+                                    {{ entry.credit | currency:'COP':'symbol':'1.0-2':'es-CO' }}
                                 </span>
                             } @else {
                                 <span class="text-gray-400">-</span>
                             }
                         </td>
-                        <td>{{ entry.description }}</td>
                     </tr>
                 </ng-template>
                 <ng-template pTemplate="summary">
                     <tr class="font-semibold bg-gray-50">
-                        <td colspan="3" class="text-right">TOTALES:</td>
+                        <td colspan="3" class="text-right">Totales</td>
                         <td class="text-right text-red-600">
-                            {{ getTotalDebit() | currency:'COP':'symbol':'1.0-0':'es-CO' }}
+                            {{ getTotalDebit() | currency:'COP':'symbol':'1.0-2':'es-CO' }}
                         </td>
                         <td class="text-right text-green-600">
-                            {{ getTotalCredit() | currency:'COP':'symbol':'1.0-0':'es-CO' }}
+                            {{ getTotalCredit() | currency:'COP':'symbol':'1.0-2':'es-CO' }}
                         </td>
-                        <td></td>
                     </tr>
                 </ng-template>
             </p-table>
         } @else {
-            <p-message severity="info" text="No se encontraron asientos contables para este comprobante."></p-message>
+            <p-message severity="info" text="No se encontraron movimientos contables para este comprobante."></p-message>
         }
     </div>
 
-    <!-- BOTONES DE ACCIÓN -->
     <div class="flex justify-center gap-4 mb-8">
         <p-button
             label="Ver Detalles del Comprobante"

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
@@ -4,13 +4,13 @@ import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { MessageModule } from 'primeng/message';
 import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
-import { AccountingEntryLine } from '../../Model/AccountingEntryLine';
 import { TableModule } from 'primeng/table';
-
-interface AugmentedAccountingEntryLine extends AccountingEntryLine {
-  invoiceCreditDetails?: { invoiceCode: string; amount: number }[];
-  isInvoiceCreditLine?: boolean;
-}
+import {
+  AccountingEntryViewHeader,
+  AccountingMovementViewRow,
+  accountingTotalsBalanced,
+} from '../../../Shared/treasury-accounting-display';
+import { accountingEntryStatusLabel } from '../../../Shared/treasury-status-labels';
 
 @Component({
   selector: 'app-expense-receipt-accounting',
@@ -28,11 +28,14 @@ interface AugmentedAccountingEntryLine extends AccountingEntryLine {
   styleUrls: ['./expense-receipt-accounting.component.css']
 })
 export class ExpenseReceiptAccountingComponent implements OnInit {
-  receiptId: number | null = null
+  receiptId: number | null = null;
   receiptCode: string | null = null;
   issueDate: Date | null = null;
-  accountingEntries: AccountingEntryLine[] = [];
+  supplierName: string | null = null;
+  accountingEntryHeader: AccountingEntryViewHeader = {};
+  accountingMovements: AccountingMovementViewRow[] = [];
   errorMessage: string | null = null;
+  accountingStatusLabel = accountingEntryStatusLabel;
 
   constructor(
     private route: ActivatedRoute,
@@ -53,18 +56,26 @@ export class ExpenseReceiptAccountingComponent implements OnInit {
   loadAccountingEntries(id: number): void {
     this.expenseReceiptService.getExpenseReceiptById(id).subscribe({
       next: (receipt) => {
-        if (receipt) {
-          this.receiptCode = receipt.receiptCode;
-          this.issueDate = receipt.issueDate;
-          this.expenseReceiptService.getAccountingEntry(id).subscribe({
-            next: entries => this.accountingEntries = entries,
-            error: () => this.errorMessage = 'El asiento aún no está disponible o fue rechazado.'
-          });
+        if (!receipt) {
+          return;
         }
+        this.receiptCode = receipt.receiptCode;
+        this.issueDate = receipt.issueDate;
+        this.supplierName = receipt.supplierName;
+        this.expenseReceiptService.getAccountingEntryView(id, {
+          voucherNumber: receipt.receiptCode,
+          supplierLabel: receipt.supplierName,
+        }).subscribe({
+          next: (view) => {
+            this.accountingEntryHeader = view.header;
+            this.accountingMovements = view.movements;
+          },
+          error: () => this.errorMessage = 'El asiento aún no está disponible o fue rechazado.',
+        });
       },
       error: (err) => {
         console.error(err);
-        this.accountingEntries = [];
+        this.accountingMovements = [];
         this.errorMessage = 'No se pudieron cargar los asientos contables.';
       }
     });
@@ -83,10 +94,14 @@ export class ExpenseReceiptAccountingComponent implements OnInit {
   }
 
   getTotalDebit(): number {
-    return this.accountingEntries.reduce((sum, entry) => sum + entry.debit, 0);
+    return this.accountingMovements.reduce((sum, entry) => sum + entry.debit, 0);
   }
 
   getTotalCredit(): number {
-    return this.accountingEntries.reduce((sum, entry) => sum + entry.credit, 0);
+    return this.accountingMovements.reduce((sum, entry) => sum + entry.credit, 0);
+  }
+
+  get accountingIsBalanced(): boolean {
+    return accountingTotalsBalanced(this.getTotalDebit(), this.getTotalCredit());
   }
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
@@ -142,29 +142,6 @@
                 </div>
             </div>
 
-            <!-- Post To (Cuenta de Débito - Cuentas por Pagar) -->
-            <div class="flex flex-col gap-2">
-                <label for="postToAccount" class="font-semibold text-[var(--color-primary)]">
-                    Cuenta por Pagar <span class="text-red-500">*</span>
-                </label>
-                <div class="w-full md:w-2/3">
-                    <p-dropdown
-                        id="postToAccount"
-                        formControlName="postToAccount"
-                        [options]="payableAccounts"
-                        optionLabel="fullName"
-                        optionValue="id"
-                        placeholder="Cuenta de cuentas por pagar"
-                        [styleClass]="'w-full'"
-                        [ngClass]="{'ng-invalid ng-dirty': expenseReceiptForm.get('postToAccount')?.invalid && expenseReceiptForm.get('postToAccount')?.touched}">
-                    </p-dropdown>
-                    @if (expenseReceiptForm.get('postToAccount')?.touched && expenseReceiptForm.get('postToAccount')?.invalid) {
-                        <small class="p-error error-message">La cuenta por pagar es requerida.</small>
-                    }
-                    <small class="text-gray-500">Solo cuentas de proveedores / pasivo corriente (CxP)</small>
-                </div>
-            </div>
-
             <!-- Transfer Account (Cuenta de Crédito - Método de Pago) -->
             <div class="flex flex-col gap-2">
                 <label for="transferAccount" class="font-semibold text-[var(--color-primary)]">
@@ -184,6 +161,9 @@
                     </p-dropdown>
                     @if (expenseReceiptForm.get('transferAccount')?.touched && expenseReceiptForm.get('transferAccount')?.invalid) {
                         <small class="p-error error-message">El método de pago es requerido.</small>
+                    }
+                    @if (paymentMethodOptions.length === 0) {
+                        <small class="text-orange-600">{{ noActivePaymentMethodsMessage }}</small>
                     }
                     <small class="text-gray-500">Métodos configurados en maestros de la empresa</small>
                 </div>
@@ -210,7 +190,7 @@
                             <small class="p-error error-message">La cuenta bancaria es requerida para este método.</small>
                         }
                         @if (bankAccountOptions.length === 0) {
-                            <small class="text-orange-600">No hay cuentas bancarias activas para esta empresa.</small>
+                            <small class="text-orange-600">{{ noAvailableBankAccountsMessage }}</small>
                         }
                     </div>
                 </div>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
@@ -33,6 +33,10 @@ import {
 import { translatePaymentMethodName } from '../../../Shared/treasury-status-labels';
 import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
+import {
+  NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+  NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE,
+} from '../../../Shared/treasury-payment-messages';
 
 // Modelos adicionales para el frontend
 interface DropdownOption {
@@ -84,6 +88,8 @@ export class ExpenseReceiptCreationComponent {
   auxiliaryAccounts: DropdownOption[] = [];
   requiresBankAccount = false;
   readonly help = TREASURY_HELP.makePayment;
+  readonly noActivePaymentMethodsMessage = NO_ACTIVE_PAYMENT_METHODS_MESSAGE;
+  readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
   readonly supplierEmptyMessage = 'No hay proveedores con facturas pendientes';
   readonly supplierFilterEmptyMessage = 'No se encontraron proveedores que coincidan con la búsqueda';
   supplierSearchQuery = '';
@@ -98,9 +104,6 @@ export class ExpenseReceiptCreationComponent {
 
   // Para selección múltiple de facturas
   selectedInvoices: any[] = [];
-
-  // Cuentas por pagar (Post To)
-  payableAccounts: any[] = [];
 
   // Detalles de la factura seleccionada
   selectedInvoiceDetails: any = null;
@@ -158,7 +161,6 @@ export class ExpenseReceiptCreationComponent {
   initializeForm(): void {
     this.expenseReceiptForm = this.fb.group({
       supplier: [null, Validators.required],
-      postToAccount: [null, Validators.required],
       transferAccount: [null, Validators.required],
       bankAccountId: [null],
       issueDate: [new Date(), Validators.required],
@@ -214,6 +216,14 @@ export class ExpenseReceiptCreationComponent {
           label: `${translatePaymentMethodName(method.name)} (${method.accountingAccount})`,
           requiresBankAccount: Boolean(method.requiresBankAccount),
         }));
+        if (this.paymentMethodOptions.length === 0) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Métodos de pago',
+            detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+            life: 8000,
+          });
+        }
       },
       error: (error) => {
         console.error('Error al cargar métodos de pago:', error);
@@ -241,22 +251,6 @@ export class ExpenseReceiptCreationComponent {
         this.bankAccounts = [];
         this.bankAccountOptions = [];
       }
-    });
-
-    // Las CxP disponibles son las que realmente están asociadas a obligaciones pendientes.
-    this.expenseReceiptService.getPayableAccounts().subscribe({
-      next: accounts => {
-        this.payableAccounts = accounts;
-      },
-      error: (error) => {
-        console.error('Error al cargar cuentas por pagar:', error);
-        this.payableAccounts = [];
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Cuentas por pagar',
-          detail: 'No se pudieron cargar las cuentas de las facturas pendientes.',
-        });
-      },
     });
 
     // Cargar cuentas auxiliares para gastos directos
@@ -394,7 +388,7 @@ export class ExpenseReceiptCreationComponent {
     // Limpiar selección anterior
     this.selectedInvoices = [];
     this.selectedInvoiceDetails = null;
-    this.expenseReceiptForm.patchValue({ totalAmount: 0, postToAccount: null });
+    this.expenseReceiptForm.patchValue({ totalAmount: 0 });
   }
 
   // Calcular el total de las facturas seleccionadas
@@ -406,16 +400,6 @@ export class ExpenseReceiptCreationComponent {
   onInvoiceSelectionChange(): void {
     const totalSelected = this.calculateSelectedTotal();
     this.expenseReceiptForm.get('totalAmount')?.setValue(totalSelected);
-
-    // Prefijar la CxP de la(s) factura(s) seleccionada(s)
-    const accountIds = [...new Set(
-      this.selectedInvoices
-        .map(inv => inv.payableAccountId)
-        .filter((id): id is number => !!id)
-    )];
-    if (accountIds.length === 1) {
-      this.expenseReceiptForm.get('postToAccount')?.setValue(accountIds[0]);
-    }
   }
 
   // Obtener el nombre del método de pago seleccionado
@@ -450,12 +434,19 @@ export class ExpenseReceiptCreationComponent {
       return false;
     }
 
+    if (this.paymentMethodOptions.length === 0) {
+      return false;
+    }
+
     if (!this.requiresBankAccount && this.expenseReceiptForm.get('bankAccountId')?.value) {
       return false;
     }
 
+    if (this.requiresBankAccount && this.bankAccountOptions.length === 0) {
+      return false;
+    }
+
     const basicValidation = this.expenseReceiptForm.get('supplier')?.valid &&
-                           this.expenseReceiptForm.get('postToAccount')?.valid &&
                            this.expenseReceiptForm.get('transferAccount')?.valid &&
                            this.expenseReceiptForm.get('issueDate')?.valid &&
                            this.expenseReceiptForm.get('totalAmount')?.valid &&
@@ -466,6 +457,15 @@ export class ExpenseReceiptCreationComponent {
 
   onSubmit(): void {
     this.expenseReceiptForm.markAllAsTouched();
+
+    if (this.paymentMethodOptions.length === 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Métodos de pago',
+        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+      });
+      return;
+    }
 
     // Validar selección de facturas
     if (this.selectedInvoices.length === 0) {
@@ -484,7 +484,9 @@ export class ExpenseReceiptCreationComponent {
     if (!this.isFormValidForSubmission()) {
       const bankValue = this.expenseReceiptForm.get('bankAccountId')?.value;
       let detail = 'Por favor, complete todos los campos requeridos.';
-      if (this.requiresBankAccount && !bankValue) {
+      if (this.requiresBankAccount && this.bankAccountOptions.length === 0) {
+        detail = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
+      } else if (this.requiresBankAccount && !bankValue) {
         detail = 'El método de pago exige una cuenta bancaria.';
       } else if (!this.requiresBankAccount && bankValue) {
         detail = 'El método seleccionado no admite cuenta bancaria.';
@@ -526,7 +528,6 @@ export class ExpenseReceiptCreationComponent {
       enterpriseId: enterpriseId,
       totalAmount: formValue.totalAmount,
       details: paymentDetails,
-      ledgerAccountId: formValue.postToAccount
     };
 
     // Mostrar resumen antes de enviar

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.html
@@ -8,7 +8,7 @@
         [summary]="help.summary"
         [helpCenterSlug]="help.slug">
       </app-contextual-help>
-      <p class="text-gray-600">Consulte y gestione los pagos realizados a proveedores</p>
+      <p class="text-gray-600">Consulte y gestione comprobantes generados por pagos a proveedores</p>
     </div>
     <div class="flex gap-2">
       <p-button
@@ -29,115 +29,79 @@
         [disabled]="!filteredReceipts.length"
         (onClick)="exportToCsv()">
       </p-button>
-      <p-button
-        label="Efectuar Pago"
-        icon="pi pi-plus"
-        (onClick)="goToCreateReceipt()">
-      </p-button>
     </div>
   </div>
 
   <p-card header="Filtros" class="mb-4">
-    <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-      <div class="flex flex-col gap-2">
-        <label for="supplierId" class="font-semibold text-[var(--color-primary)]">Proveedor</label>
-        <p-dropdown
-          id="supplierId"
-          formControlName="supplierId"
-          [options]="supplierOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todos los proveedores"
-          [showClear]="true"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
+    <form [formGroup]="filterForm" class="flex flex-col gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div class="flex flex-col gap-2">
+          <label for="supplierId" class="font-semibold text-[var(--color-primary)]">Proveedor</label>
+          <p-dropdown
+            id="supplierId"
+            formControlName="supplierId"
+            [options]="supplierOptions"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Todos los proveedores"
+            [showClear]="true"
+            [filter]="true"
+            filterBy="label"
+            styleClass="w-full">
+          </p-dropdown>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label for="status" class="font-semibold text-[var(--color-primary)]">Estado</label>
+          <p-dropdown
+            id="status"
+            formControlName="status"
+            [options]="statusOptions"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Todos los estados"
+            [showClear]="true"
+            styleClass="w-full">
+          </p-dropdown>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label for="startDate" class="font-semibold text-[var(--color-primary)]">Desde</label>
+          <p-calendar
+            id="startDate"
+            formControlName="startDate"
+            dateFormat="dd/mm/yy"
+            [showIcon]="true"
+            placeholder="Fecha desde"
+            styleClass="w-full">
+          </p-calendar>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <label for="endDate" class="font-semibold text-[var(--color-primary)]">Hasta</label>
+          <p-calendar
+            id="endDate"
+            formControlName="endDate"
+            dateFormat="dd/mm/yy"
+            [showIcon]="true"
+            placeholder="Fecha hasta"
+            styleClass="w-full">
+          </p-calendar>
+        </div>
       </div>
 
-      <div class="flex flex-col gap-2">
-        <label for="receiptCode" class="font-semibold text-[var(--color-primary)]">Código comprobante</label>
-        <p-dropdown
-          id="receiptCode"
-          formControlName="receiptCode"
-          [options]="receiptCodeOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todos los comprobantes"
-          [showClear]="true"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
-        <small class="text-gray-500">Solo códigos existentes en la empresa</small>
-      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
+        <div class="flex flex-col gap-2">
+          <label for="receiptCode" class="font-semibold text-[var(--color-primary)]">Código de comprobante</label>
+          <input
+            pInputText
+            id="receiptCode"
+            formControlName="receiptCode"
+            placeholder="Buscar por código..."
+            class="w-full" />
+        </div>
 
-      <div class="flex flex-col gap-2">
-        <label for="status" class="font-semibold text-[var(--color-primary)]">Estado</label>
-        <p-dropdown
-          id="status"
-          formControlName="status"
-          [options]="statusOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todos los estados"
-          [showClear]="true"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="startDate" class="font-semibold text-[var(--color-primary)]">Desde</label>
-        <p-calendar
-          id="startDate"
-          formControlName="startDate"
-          dateFormat="dd/mm/yy"
-          [showIcon]="true"
-          placeholder="Fecha desde"
-          styleClass="w-full">
-        </p-calendar>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="endDate" class="font-semibold text-[var(--color-primary)]">Hasta</label>
-        <p-calendar
-          id="endDate"
-          formControlName="endDate"
-          dateFormat="dd/mm/yy"
-          [showIcon]="true"
-          placeholder="Fecha hasta"
-          styleClass="w-full">
-        </p-calendar>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="minAmount" class="font-semibold text-[var(--color-primary)]">Monto mínimo</label>
-        <p-inputNumber
-          id="minAmount"
-          formControlName="minAmount"
-          mode="currency"
-          currency="COP"
-          locale="es-CO"
-          placeholder="0"
-          styleClass="w-full">
-        </p-inputNumber>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="maxAmount" class="font-semibold text-[var(--color-primary)]">Monto máximo</label>
-        <p-inputNumber
-          id="maxAmount"
-          formControlName="maxAmount"
-          mode="currency"
-          currency="COP"
-          locale="es-CO"
-          placeholder="Sin límite"
-          styleClass="w-full">
-        </p-inputNumber>
-      </div>
-
-      <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-4">
-        <div class="flex gap-2 justify-end">
+        <div class="flex justify-end">
           <p-button
             label="Limpiar filtros"
             icon="pi pi-filter-slash"
@@ -222,12 +186,13 @@
                 (onClick)="viewReceiptDetails(receipt)">
               </p-button>
               <p-button
-                icon="pi pi-print"
+                *ngIf="receipt.accountingEntryId || receipt.statusKey === 'POSTED'"
+                icon="pi pi-book"
                 size="small"
-                severity="secondary"
+                severity="help"
                 [text]="true"
-                pTooltip="Imprimir comprobante"
-                (onClick)="printReceipt(receipt)">
+                pTooltip="Ver asiento"
+                (onClick)="showAccounting(receipt)">
               </p-button>
               <p-button
                 icon="pi pi-times"
@@ -253,15 +218,9 @@
                 <p class="text-gray-500">
                   {{ allReceipts.length > 0
                     ? emptyFiltersMessage
-                    : 'Comience creando su primer comprobante de egreso' }}
+                    : 'Los comprobantes se generan al efectuar pagos desde Operaciones de Tesorería.' }}
                 </p>
               </div>
-              <p-button
-                *ngIf="allReceipts.length === 0"
-                label="Efectuar Primer Pago"
-                icon="pi pi-plus"
-                (onClick)="goToCreateReceipt()">
-              </p-button>
             </div>
           </td>
         </tr>
@@ -278,6 +237,67 @@
         </tr>
       </ng-template>
     </p-table>
+  </p-card>
+
+  <p-card *ngIf="accountingEntry" header="Asiento contable" class="mb-4">
+    <div class="mb-3 flex flex-wrap items-center justify-between gap-4">
+      <div class="flex flex-wrap gap-4 text-sm text-gray-700">
+        <span *ngIf="accountingEntryHeader.documentTypeLabel"><strong>Origen:</strong> {{ accountingEntryHeader.documentTypeLabel }}</span>
+        <span *ngIf="accountingEntryHeader.voucherNumber"><strong>Comprobante:</strong> {{ accountingEntryHeader.voucherNumber }}</span>
+        <span *ngIf="accountingEntryHeader.supplierLabel"><strong>Proveedor:</strong> {{ accountingEntryHeader.supplierLabel }}</span>
+        <span *ngIf="accountingEntryHeader.entryCode"><strong>Asiento:</strong> {{ accountingEntryHeader.entryCode }}</span>
+        <span *ngIf="accountingEntryHeader.entryDate"><strong>Fecha:</strong> {{ accountingEntryHeader.entryDate }}</span>
+        <span *ngIf="accountingEntryHeader.entryStatus"><strong>Estado:</strong> {{ accountingStatusLabel(accountingEntryHeader.entryStatus) }}</span>
+      </div>
+      <p-button
+        label="Cerrar"
+        icon="pi pi-times"
+        size="small"
+        severity="secondary"
+        [text]="true"
+        (onClick)="clearAccountingView()">
+      </p-button>
+    </div>
+    <p-message
+      *ngIf="accountingMovements.length && !accountingIsBalanced"
+      severity="warn"
+      text="El asiento no está balanceado: el total débito difiere del total crédito."
+      styleClass="mb-3 w-full">
+    </p-message>
+    <p-table
+      [value]="accountingMovements"
+      [loading]="loadingAccounting"
+      styleClass="p-datatable-sm p-datatable-striped"
+      *ngIf="accountingMovements.length">
+      <ng-template pTemplate="header">
+        <tr>
+          <th>Código cuenta</th>
+          <th>Cuenta</th>
+          <th>Detalle</th>
+          <th class="text-right">Débito</th>
+          <th class="text-right">Crédito</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-row>
+        <tr>
+          <td class="font-mono">{{ row.accountCode }}</td>
+          <td>{{ row.accountName }}</td>
+          <td>{{ row.detail }}</td>
+          <td class="text-right">{{ row.debit | currency:'COP':'symbol':'1.0-2' }}</td>
+          <td class="text-right">{{ row.credit | currency:'COP':'symbol':'1.0-2' }}</td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="footer">
+        <tr>
+          <td colspan="3" class="font-semibold text-right">Totales</td>
+          <td class="text-right font-semibold">{{ accountingDebitTotal | currency:'COP':'symbol':'1.0-2' }}</td>
+          <td class="text-right font-semibold">{{ accountingCreditTotal | currency:'COP':'symbol':'1.0-2' }}</td>
+        </tr>
+      </ng-template>
+    </p-table>
+    <p *ngIf="!loadingAccounting && !accountingMovements.length" class="text-gray-600">
+      El asiento no trae movimientos para mostrar.
+    </p>
   </p-card>
 
   <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.spec.ts
@@ -1,0 +1,173 @@
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { ExpenseReceiptsListComponent } from './expense-receipts-list.component';
+import { ExpenseReceiptView } from '../../Model/Models';
+
+describe('ExpenseReceiptsListComponent filters', () => {
+  function component() {
+    const expenseReceiptService = {
+      getAllExpenseReceipts: jasmine.createSpy('getAllExpenseReceipts').and.returnValue(of([])),
+      getAccountingEntryView: jasmine.createSpy('getAccountingEntryView'),
+    };
+    const messageService = { add: jasmine.createSpy('add') };
+    const exportService = {
+      datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
+      downloadCsv: jasmine.createSpy('downloadCsv'),
+      downloadPdf: jasmine.createSpy('downloadPdf'),
+    };
+    const value = new ExpenseReceiptsListComponent(
+      new FormBuilder(),
+      { navigate: jasmine.createSpy('navigate') } as any,
+      expenseReceiptService as any,
+      messageService as any,
+      exportService as any,
+    );
+    value.initializeForm();
+    value.allReceipts = sampleReceipts();
+    value.filteredReceipts = [...value.allReceipts];
+    return { value, exportService };
+  }
+
+  function sampleReceipts(): ExpenseReceiptView[] {
+    return [
+      {
+        id: 1,
+        receiptCode: 'CE-FB04BD89',
+        issueDate: new Date(2026, 7, 1),
+        thirdPartyId: 7,
+        supplierName: 'Proveedor A',
+        status: 'Contabilizado',
+        statusKey: 'POSTED',
+        totalAmount: 500,
+      },
+      {
+        id: 2,
+        receiptCode: 'CE-AB12CD34',
+        issueDate: new Date(2026, 7, 15),
+        thirdPartyId: 8,
+        supplierName: 'Proveedor B',
+        status: 'Borrador',
+        statusKey: 'DRAFT',
+        totalAmount: 200,
+      },
+      {
+        id: 3,
+        receiptCode: 'CE-FB99EE00',
+        issueDate: new Date(2026, 6, 20),
+        thirdPartyId: 7,
+        supplierName: 'Proveedor A',
+        status: 'Anulado',
+        statusKey: 'VOIDED',
+        totalAmount: 100,
+      },
+    ];
+  }
+
+  it('shows all receipts when no filters are applied', () => {
+    const { value } = component();
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(3);
+  });
+
+  it('filters by supplier', () => {
+    const { value } = component();
+    value.filterForm.patchValue({ supplierId: 7 });
+    value.applyFilters();
+    expect(value.filteredReceipts.map((r) => r.id)).toEqual([1, 3]);
+  });
+
+  it('filters by status', () => {
+    const { value } = component();
+    value.filterForm.patchValue({ status: 'DRAFT' });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+    expect(value.filteredReceipts[0].receiptCode).toBe('CE-AB12CD34');
+  });
+
+  it('filters by date range', () => {
+    const { value } = component();
+    value.filterForm.patchValue({
+      startDate: new Date(2026, 7, 10),
+      endDate: new Date(2026, 7, 20),
+    });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+    expect(value.filteredReceipts[0].id).toBe(2);
+  });
+
+  it('filters by partial receipt code', () => {
+    const { value } = component();
+    value.filterForm.patchValue({ receiptCode: 'FB04' });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+    expect(value.filteredReceipts[0].receiptCode).toBe('CE-FB04BD89');
+  });
+
+  it('filters by full receipt code', () => {
+    const { value } = component();
+    value.filterForm.patchValue({ receiptCode: 'CE-AB12CD34' });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+  });
+
+  it('combines supplier, status and code filters', () => {
+    const { value } = component();
+    value.filterForm.patchValue({
+      supplierId: 7,
+      status: 'POSTED',
+      receiptCode: 'FB04',
+    });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+    expect(value.filteredReceipts[0].receiptCode).toBe('CE-FB04BD89');
+  });
+
+  it('clears all filters and restores full list', () => {
+    const { value } = component();
+    value.filterForm.patchValue({
+      supplierId: 8,
+      status: 'DRAFT',
+      receiptCode: 'AB12',
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 31),
+    });
+    value.applyFilters();
+    expect(value.filteredReceipts.length).toBe(1);
+    value.clearFilters();
+    expect(value.filterForm.value).toEqual(jasmine.objectContaining({
+      supplierId: null,
+      receiptCode: '',
+      startDate: null,
+      endDate: null,
+      status: '',
+    }));
+    expect(value.filteredReceipts.length).toBe(3);
+  });
+
+  it('exports filtered receipts to CSV without amount filters', () => {
+    const { value, exportService } = component();
+    value.filterForm.patchValue({ receiptCode: 'FB' });
+    value.applyFilters();
+    value.exportToCsv();
+    expect(exportService.downloadCsv).toHaveBeenCalled();
+    const options = exportService.downloadCsv.calls.mostRecent().args[0];
+    expect(options.rows.length).toBe(2);
+  });
+
+  it('exports filtered receipts to PDF', () => {
+    const { value, exportService } = component();
+    value.filterForm.patchValue({ status: 'DRAFT' });
+    value.applyFilters();
+    value.exportToPdf();
+    expect(exportService.downloadPdf).toHaveBeenCalled();
+    const options = exportService.downloadPdf.calls.mostRecent().args[0];
+    expect(options.rows.length).toBe(1);
+  });
+
+  it('uses contextual help content for expense receipts consultation', () => {
+    const { value } = component();
+    expect(value.help.title).toBe('Comprobantes de Egreso');
+    expect(value.help.summary).toContain('Consulte y gestione');
+    expect(value.help.summary).not.toContain('efectuar pagos');
+  });
+});

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
@@ -6,16 +6,21 @@ import { ButtonModule } from 'primeng/button';
 import { CalendarModule } from 'primeng/calendar';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputTextModule } from 'primeng/inputtext';
-import { InputNumberModule } from 'primeng/inputnumber';
 import { TableModule } from 'primeng/table';
 import { TooltipModule } from 'primeng/tooltip';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
 import { TagModule } from 'primeng/tag';
+import { MessageModule } from 'primeng/message';
 import { MessageService } from 'primeng/api';
 import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
 import { DropdownOption, ExpenseReceiptView, ReceiptFilterOption } from '../../Model/Models';
-import { exportErrorDetail, exportSuccessDetail, reportEmptyFiltersMessage, voucherStatusFilterOptions } from '../../../Shared/treasury-status-labels';
+import { exportErrorDetail, exportSuccessDetail, reportEmptyFiltersMessage, voucherStatusFilterOptions, accountingEntryStatusLabel } from '../../../Shared/treasury-status-labels';
+import {
+  AccountingEntryViewHeader,
+  AccountingMovementViewRow,
+  accountingTotalsBalanced,
+} from '../../../Shared/treasury-accounting-display';
 import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
 import { TreasuryExportService } from '../../../Shared/treasury-export.service';
@@ -30,13 +35,13 @@ import { TreasuryExportService } from '../../../Shared/treasury-export.service';
     TableModule,
     ButtonModule,
     InputTextModule,
-    InputNumberModule,
     CalendarModule,
     DropdownModule,
     TooltipModule,
     CardModule,
     ToastModule,
     TagModule,
+    MessageModule,
     ContextualHelpComponent,
   ],
   templateUrl: './expense-receipts-list.component.html',
@@ -50,14 +55,21 @@ export class ExpenseReceiptsListComponent implements OnInit {
   loading = false;
 
   supplierOptions: ReceiptFilterOption[] = [];
-  receiptCodeOptions: ReceiptFilterOption[] = [];
-  allReceiptCodeOptions: ReceiptFilterOption[] = [];
 
   statusOptions: DropdownOption[] = voucherStatusFilterOptions();
   readonly emptyFiltersMessage = reportEmptyFiltersMessage();
   readonly help = TREASURY_HELP.expenseReceipts;
   exportingPdf = false;
   exportingCsv = false;
+  accountingEntry: any = null;
+  accountingEntryHeader: AccountingEntryViewHeader = {};
+  accountingMovements: AccountingMovementViewRow[] = [];
+  accountingDebitTotal = 0;
+  accountingCreditTotal = 0;
+  accountingReceiptCode = '';
+  loadingAccounting = false;
+
+  accountingStatusLabel = accountingEntryStatusLabel;
 
   constructor(
     private fb: FormBuilder,
@@ -76,17 +88,14 @@ export class ExpenseReceiptsListComponent implements OnInit {
   initializeForm(): void {
     this.filterForm = this.fb.group({
       supplierId: [null],
-      receiptCode: [null],
+      receiptCode: [''],
       startDate: [null],
       endDate: [null],
       status: [''],
-      minAmount: [null],
-      maxAmount: [null],
     });
   }
 
   setupFilterSubscriptions(): void {
-    this.filterForm.get('supplierId')?.valueChanges.subscribe(() => this.onSupplierFilterChange());
     this.filterForm.valueChanges.subscribe(() => this.applyFilters());
   }
 
@@ -118,29 +127,6 @@ export class ExpenseReceiptsListComponent implements OnInit {
         return { value: id, label: `${id} — ${name}` };
       })
       .sort((a, b) => a.label.localeCompare(b.label));
-
-    this.allReceiptCodeOptions = receipts
-      .map((r) => ({
-        value: r.receiptCode,
-        label: `${r.receiptCode} · ${r.supplierName}`,
-        supplierId: r.thirdPartyId,
-      }))
-      .sort((a, b) => String(a.label).localeCompare(String(b.label)));
-
-    this.receiptCodeOptions = [...this.allReceiptCodeOptions];
-  }
-
-  onSupplierFilterChange(): void {
-    const supplierId = this.filterForm.value.supplierId;
-    this.receiptCodeOptions =
-      supplierId == null
-        ? [...this.allReceiptCodeOptions]
-        : this.allReceiptCodeOptions.filter((opt) => opt.supplierId === Number(supplierId));
-
-    const selected = this.filterForm.value.receiptCode;
-    if (selected && !this.receiptCodeOptions.some((o) => o.value === selected)) {
-      this.filterForm.patchValue({ receiptCode: null }, { emitEvent: false });
-    }
   }
 
   applyFilters(): void {
@@ -151,8 +137,9 @@ export class ExpenseReceiptsListComponent implements OnInit {
       results = results.filter((r) => r.thirdPartyId === Number(filters.supplierId));
     }
 
-    if (filters.receiptCode) {
-      results = results.filter((r) => r.receiptCode === filters.receiptCode);
+    const receiptCodeTerm = String(filters.receiptCode ?? '').trim().toLowerCase();
+    if (receiptCodeTerm) {
+      results = results.filter((r) => String(r.receiptCode).toLowerCase().includes(receiptCodeTerm));
     }
 
     if (filters.status) {
@@ -171,37 +158,66 @@ export class ExpenseReceiptsListComponent implements OnInit {
       results = results.filter((r) => new Date(r.issueDate) <= endDate);
     }
 
-    if (filters.minAmount !== null && filters.minAmount !== undefined) {
-      results = results.filter((r) => r.totalAmount >= filters.minAmount);
-    }
-
-    if (filters.maxAmount !== null && filters.maxAmount !== undefined) {
-      results = results.filter((r) => r.totalAmount <= filters.maxAmount);
-    }
-
     this.filteredReceipts = results;
   }
 
   clearFilters(): void {
     this.filterForm.reset({
       supplierId: null,
-      receiptCode: null,
+      receiptCode: '',
       startDate: null,
       endDate: null,
       status: '',
-      minAmount: null,
-      maxAmount: null,
     });
-    this.receiptCodeOptions = [...this.allReceiptCodeOptions];
     this.filteredReceipts = [...this.allReceipts];
-  }
-
-  goToCreateReceipt(): void {
-    this.router.navigate(['/financial/treasury/expense-receipts/creation']);
   }
 
   viewReceiptDetails(receipt: ExpenseReceiptView): void {
     this.router.navigate(['/financial/treasury/expense-receipts/details', receipt.id]);
+  }
+
+  showAccounting(receipt: ExpenseReceiptView): void {
+    this.loadingAccounting = true;
+    this.accountingEntry = null;
+    this.accountingEntryHeader = {};
+    this.accountingMovements = [];
+    this.accountingDebitTotal = 0;
+    this.accountingCreditTotal = 0;
+    this.accountingReceiptCode = receipt.receiptCode;
+    this.expenseReceiptService.getAccountingEntryView(receipt.id, {
+      voucherNumber: receipt.receiptCode,
+      supplierLabel: receipt.supplierName,
+    }).subscribe({
+      next: (view) => {
+        this.accountingEntry = view.header;
+        this.accountingEntryHeader = view.header;
+        this.accountingMovements = view.movements;
+        this.accountingDebitTotal = this.accountingMovements.reduce((sum, row) => sum + row.debit, 0);
+        this.accountingCreditTotal = this.accountingMovements.reduce((sum, row) => sum + row.credit, 0);
+        this.loadingAccounting = false;
+      },
+      error: () => {
+        this.loadingAccounting = false;
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Asiento no disponible',
+          detail: 'No fue posible consultar el asiento del comprobante.',
+        });
+      },
+    });
+  }
+
+  get accountingIsBalanced(): boolean {
+    return accountingTotalsBalanced(this.accountingDebitTotal, this.accountingCreditTotal);
+  }
+
+  clearAccountingView(): void {
+    this.accountingEntry = null;
+    this.accountingEntryHeader = {};
+    this.accountingMovements = [];
+    this.accountingDebitTotal = 0;
+    this.accountingCreditTotal = 0;
+    this.accountingReceiptCode = '';
   }
 
   getTotalReceipts(): number {
@@ -241,14 +257,6 @@ export class ExpenseReceiptsListComponent implements OnInit {
       default:
         return 'info';
     }
-  }
-
-  printReceipt(receipt: ExpenseReceiptView): void {
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Imprimir',
-      detail: `Imprimiendo comprobante ${receipt.receiptCode}`,
-    });
   }
 
   cancelReceipt(receipt: ExpenseReceiptView): void {

--- a/src/app/Financial/Treasury/ExpenseReceipts/Model/ExpenseReceiptCreateRequest.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Model/ExpenseReceiptCreateRequest.ts
@@ -8,6 +8,5 @@ export interface ExpenseReceiptCreateRequest {
     observations: string,
     enterpriseId: string,
     totalAmount: number,
-    details: ExpenseReceiptDetail[],
-    ledgerAccountId: number
+    details: ExpenseReceiptDetail[];
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Model/Models.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Model/Models.ts
@@ -39,6 +39,7 @@ export interface ExpenseReceiptView {
     /** Estado crudo del voucher (DRAFT, POSTED, VOIDED, …) */
     statusKey?: string;
     totalAmount: number;
+    accountingEntryId?: number;
 }
 
 export interface ReceiptFilterOption {

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -11,8 +11,14 @@ import { ExpenseReceiptResponse } from '../Model/ExpenseReceiptResponse';
 import { ExpenseReceiptCreateRequest } from '../Model/ExpenseReceiptCreateRequest';
 import { AccountingEntryLine } from '../Model/AccountingEntryLine';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
-import { educationalDescription, translatePaymentMethodName, voucherStatusLabel } from '../../Shared/treasury-status-labels';
+import { educationalDescription, translatePaymentMethodName, voucherStatusLabel, accountingSourceDocumentTypeLabel } from '../../Shared/treasury-status-labels';
 import { buildThirdPartyNameMap, resolveSupplierName } from '../../Shared/treasury-third-party.integration';
+import {
+  AccountingEntryView,
+  buildAccountCatalogueLookup,
+  buildAccountingEntryView,
+  mapAccountingMovementsForView,
+} from '../../Shared/treasury-accounting-display';
 
 @Injectable({ providedIn: 'root' })
 export class ExpenseReceiptService {
@@ -146,6 +152,7 @@ export class ExpenseReceiptService {
             status: voucherStatusLabel(voucher.status),
             statusKey: voucher.status,
             totalAmount: voucher.total,
+            accountingEntryId: voucher.accountingEntryId,
           };
         });
       }),
@@ -210,10 +217,54 @@ export class ExpenseReceiptService {
   }
 
   getAccountingEntry(receiptId: number): Observable<AccountingEntryLine[]> {
-    return this.api.accountingEntry(receiptId).pipe(map(response => (response.data?.movements ?? []).map((movement: any) => ({
-      accountCode: String(movement.account), accountName: `Cuenta ${movement.account}`,
-      thirdPartyId: movement.thirdPartyId ?? 0, debit: Number(movement.debit ?? 0), credit: Number(movement.credit ?? 0),
-      description: movement.description ?? response.data.description,
-    }))));
+    return this.getAccountingEntryView(receiptId).pipe(
+      map((view) => view.movements.map((movement) => ({
+        accountCode: movement.accountCode,
+        accountName: movement.accountName,
+        thirdPartyId: movement.thirdPartyId ?? 0,
+        debit: movement.debit,
+        credit: movement.credit,
+        description: movement.detail,
+      }))),
+    );
+  }
+
+  getAccountingEntryView(
+    receiptId: number,
+    headerContext: { voucherNumber?: string; supplierLabel?: string } = {},
+  ): Observable<AccountingEntryView> {
+    const enterpriseId = this.enterpriseId();
+    return forkJoin({
+      entry: this.api.accountingEntry(receiptId),
+      accounts: this.accounts.getListAuxiliaryAccounts(enterpriseId),
+      voucher: this.api.voucher(receiptId, enterpriseId),
+      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(
+        catchError(() => of({ content: [] } as any)),
+      ),
+    }).pipe(
+      map(({ entry, accounts, voucher, thirds }) => {
+        const entryData = (entry as any)?.data ?? entry;
+        const lookup = buildAccountCatalogueLookup(
+          accounts.filter((account) => account.status !== false),
+        );
+        const movements = mapAccountingMovementsForView(entryData?.movements ?? [], lookup);
+        const thirdNames = buildThirdPartyNameMap(thirds?.content || []);
+        const supplierIds = [...new Set((voucher.details || []).map((detail) => detail.supplierId))];
+        const supplierLabel = headerContext.supplierLabel
+          ?? (supplierIds.length > 1
+            ? supplierIds.map((id) => resolveSupplierName(thirdNames, id)).join(', ')
+            : resolveSupplierName(thirdNames, supplierIds[0] ?? 0));
+
+        return buildAccountingEntryView(
+          entryData as Record<string, unknown>,
+          movements,
+          {
+            documentTypeLabel: accountingSourceDocumentTypeLabel('PAYMENT_VOUCHER'),
+            voucherNumber: headerContext.voucherNumber ?? voucher.voucherNumber,
+            supplierLabel,
+          },
+        );
+      }),
+    );
   }
 }

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.css
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.css
@@ -12,6 +12,18 @@
   margin: 0;
 }
 
+.treasury-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  margin-top: 0.5rem;
+}
+
+.treasury-sections > .treasury-fieldset,
+.treasury-sections > p-card {
+  display: block;
+}
+
 .accounting-json {
   margin: 0;
   padding: 1rem;
@@ -182,4 +194,117 @@
     flex-direction: column;
     align-items: stretch;
   }
+}
+
+::ng-deep .treasury-due-date-picker {
+  width: 100%;
+}
+
+::ng-deep .treasury-due-date-picker .p-datepicker-input {
+  width: 100%;
+}
+
+::ng-deep .p-datepicker-panel {
+  z-index: 1200;
+}
+
+.treasury-payment-card ::ng-deep .p-card-body {
+  padding-top: 1.25rem;
+  padding-bottom: 1.5rem;
+}
+
+.treasury-payment-hint {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  line-height: 1.5;
+}
+
+.treasury-edit-banner {
+  margin-bottom: 1.25rem;
+}
+
+::ng-deep .treasury-editing-row > td {
+  background-color: #e0e7ff !important;
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+}
+
+::ng-deep .treasury-editing-row:hover > td {
+  background-color: #dbeafe !important;
+}
+
+.treasury-pay-amount-cell ::ng-deep .p-button {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+::ng-deep .treasury-payment-mode-select {
+  width: 100%;
+}
+
+::ng-deep .treasury-payment-mode-select .p-togglebutton {
+  flex: 1 1 0;
+  justify-content: center;
+}
+
+::ng-deep .treasury-payment-mode-select .p-togglebutton-label {
+  font-weight: 600;
+}
+
+.treasury-dialog-payable-card {
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.treasury-payment-form {
+  padding-top: 0.5rem;
+}
+
+.treasury-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.treasury-field-label {
+  line-height: 1.25rem;
+  min-height: 1.25rem;
+}
+
+.treasury-control-slot {
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+}
+
+.treasury-control-slot ::ng-deep .p-dropdown,
+.treasury-control-slot ::ng-deep .p-inputtext,
+.treasury-control-slot ::ng-deep .treasury-due-date-picker {
+  width: 100%;
+}
+
+.treasury-control-slot ::ng-deep .p-dropdown,
+.treasury-control-slot ::ng-deep .p-inputtext,
+.treasury-control-slot ::ng-deep .treasury-due-date-picker .p-datepicker-input {
+  min-height: 2.75rem;
+}
+
+.treasury-field-hint {
+  display: block;
+  min-height: 1.125rem;
+  line-height: 1.125rem;
+  font-size: 0.8125rem;
+}
+
+.treasury-payment-actions {
+  margin-top: 1.75rem;
+  padding-top: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.treasury-payment-actions ::ng-deep .p-button {
+  min-height: 2.75rem;
+  padding: 0.65rem 1.25rem;
 }

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -9,7 +9,7 @@
         [summary]="help.summary"
         [helpCenterSlug]="help.slug">
       </app-contextual-help>
-      <p class="text-gray-600">Gestione obligaciones pendientes, borradores de pago, programaciones y bajas de CxP</p>
+      <p class="text-gray-600">Gestione obligaciones pendientes, comprobantes de pago, programaciones de pago y bajas de CxP</p>
     </div>
     <div class="flex gap-2">
       <p-button
@@ -43,46 +43,9 @@
 
   <p-message *ngIf="error" severity="error" [text]="error" styleClass="mb-4 w-full"></p-message>
 
-  <p-card header="Filtros de Comprobantes" class="mb-4">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
-      <div class="flex flex-col gap-2">
-        <label for="voucherNumber" class="font-semibold text-[var(--color-primary)]">Número de comprobante</label>
-        <input
-          pInputText
-          id="voucherNumber"
-          [(ngModel)]="voucherNumberFilter"
-          placeholder="Buscar por número...">
-      </div>
-      <div class="flex flex-col gap-2">
-        <label for="voucherStatus" class="font-semibold text-[var(--color-primary)]">Estado</label>
-        <p-dropdown
-          id="voucherStatus"
-          [(ngModel)]="voucherStatusFilter"
-          [options]="voucherStatusOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todos los estados"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-      <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-1">
-        <label class="font-semibold text-[var(--color-primary)]">Acciones</label>
-        <div class="filter-actions filter-buttons-container">
-          <p-button
-            label="Filtrar comprobantes"
-            icon="pi pi-filter"
-            size="small"
-            styleClass="w-full"
-            [disabled]="busy"
-            (onClick)="reload()">
-          </p-button>
-        </div>
-      </div>
-    </div>
-  </p-card>
-
+  <div class="treasury-sections">
   <fieldset [disabled]="busy" class="treasury-fieldset">
-    <p-card header="Obligaciones pendientes" class="mb-4">
+    <p-card header="Obligaciones pendientes">
       <p-table
         [value]="payables"
         [loading]="busy"
@@ -96,24 +59,16 @@
         scrollHeight="420px">
         <ng-template pTemplate="header">
           <tr>
-            <th style="width: 4rem"></th>
             <th>Proveedor</th>
             <th>Factura</th>
             <th>Vence</th>
             <th class="text-right">Disponible</th>
-            <th style="min-width: 10rem">Aplicar</th>
-            <th style="width: 8rem">Acciones</th>
+            <th>En programación</th>
+            <th style="min-width: 14rem">Acciones</th>
           </tr>
         </ng-template>
         <ng-template pTemplate="body" let-payable>
           <tr>
-            <td>
-              <p-checkbox
-                [binary]="true"
-                [ngModel]="selected.has(payable.id)"
-                (onChange)="toggle(payable.id, $event.checked)">
-              </p-checkbox>
-            </td>
             <td>
               <div class="flex items-center gap-2">
                 <i class="pi pi-building text-gray-500"></i>
@@ -126,31 +81,59 @@
               {{ payable.availableAmount | currency:'COP':'symbol':'1.0-2' }}
             </td>
             <td>
-              <p-inputNumber
-                [(ngModel)]="amounts[payable.id]"
-                mode="currency"
-                currency="COP"
-                locale="es-CO"
-                [min]="0.01"
-                [max]="payable.availableAmount"
-                styleClass="w-full">
-              </p-inputNumber>
+              <p-tag
+                *ngIf="scheduledLabelForPayable(payable) as scheduledLabel"
+                [value]="scheduledLabel"
+                severity="info"
+                icon="pi pi-clock">
+              </p-tag>
+              <span *ngIf="!scheduledLabelForPayable(payable)" class="text-gray-500">—</span>
             </td>
             <td>
-              <p-button
-                icon="pi pi-calendar"
-                size="small"
-                severity="secondary"
-                [text]="true"
-                pTooltip="Cambiar vencimiento"
-                (onClick)="changeDueDate(payable)">
-              </p-button>
+              <div class="flex flex-wrap gap-2 items-center">
+                <p-button
+                  label="Pagar"
+                  icon="pi pi-wallet"
+                  size="small"
+                  (onClick)="openPaymentDialog(payable)">
+                </p-button>
+                <p-button
+                  label="Programar pago"
+                  icon="pi pi-clock"
+                  size="small"
+                  severity="secondary"
+                  [outlined]="true"
+                  [disabled]="hasActiveFullSchedule(payable)"
+                  [pTooltip]="hasActiveFullSchedule(payable) ? 'Ya existe un pago programado por el saldo disponible. Cancele la programación para crear otra.' : undefined"
+                  tooltipPosition="top"
+                  (onClick)="openScheduleDialog(payable)">
+                </p-button>
+                <p-button
+                  label="Baja CxP"
+                  icon="pi pi-minus-circle"
+                  size="small"
+                  severity="danger"
+                  [outlined]="true"
+                  [disabled]="!canWriteOffPayable(payable)"
+                  [pTooltip]="!canWriteOffPayable(payable) ? 'La obligación no tiene saldo disponible para dar de baja.' : undefined"
+                  tooltipPosition="top"
+                  (onClick)="openWriteOffDialog(payable)">
+                </p-button>
+                <p-button
+                  label="Vencimiento"
+                  icon="pi pi-calendar"
+                  size="small"
+                  severity="secondary"
+                  [outlined]="true"
+                  (onClick)="openDueDateDialog(payable)">
+                </p-button>
+              </div>
             </td>
           </tr>
         </ng-template>
         <ng-template pTemplate="emptymessage">
           <tr>
-            <td colspan="7" class="text-center py-8">
+            <td colspan="6" class="text-center py-8">
               <div class="flex flex-col items-center gap-3">
                 <i class="pi pi-inbox text-4xl text-gray-400"></i>
                 <p class="text-gray-600">No hay obligaciones pendientes</p>
@@ -162,113 +145,104 @@
     </p-card>
   </fieldset>
 
-  <p-card header="Crear / programar pago" class="mb-4">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
-      <div class="flex flex-col gap-2">
-        <label for="paymentMethod" class="font-semibold text-[var(--color-primary)]">Método</label>
-        <p-dropdown
-          id="paymentMethod"
-          [(ngModel)]="paymentMethodId"
-          [options]="methodOptions"
-          optionLabel="label"
-          optionValue="id"
-          placeholder="Seleccione"
-          [showClear]="true"
-          styleClass="w-full"
-          (onChange)="paymentMethodChanged()">
-        </p-dropdown>
-      </div>
-      <div class="flex flex-col gap-2" *ngIf="requiresBankAccount">
-        <label for="bankAccount" class="font-semibold text-[var(--color-primary)]">Cuenta bancaria</label>
-        <p-dropdown
-          id="bankAccount"
-          [(ngModel)]="bankAccountId"
-          [options]="bankOptions"
-          optionLabel="label"
-          optionValue="id"
-          placeholder="Seleccione"
-          [showClear]="true"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-      <div class="flex flex-col gap-2">
-        <label for="executionDate" class="font-semibold text-[var(--color-primary)]">Fecha programada</label>
-        <input pInputText id="executionDate" type="date" [(ngModel)]="executionDate">
-      </div>
-      <div class="flex flex-col gap-2">
-        <label for="observations" class="font-semibold text-[var(--color-primary)]">Observaciones</label>
-        <input pInputText id="observations" [(ngModel)]="observations" placeholder="Observaciones...">
-      </div>
-      <div class="flex flex-wrap gap-2 md:col-span-2 lg:col-span-4">
-        <p-button
-          [label]="editingVoucherId ? 'Guardar borrador' : 'Crear borrador'"
-          icon="pi pi-save"
-          [disabled]="busy"
-          (onClick)="createVoucher()">
-        </p-button>
-        <p-button
-          label="Programar pago"
-          icon="pi pi-clock"
-          severity="success"
-          [outlined]="true"
-          [disabled]="busy"
-          (onClick)="schedule()">
-        </p-button>
-      </div>
-    </div>
-  </p-card>
-
-  <p-card header="Baja de CxP" class="mb-4">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
-      <div class="flex flex-col gap-2 lg:col-span-2">
-        <label for="counterpartAccount" class="font-semibold text-[var(--color-primary)]">Cuenta contrapartida</label>
-        <p-dropdown
-          id="counterpartAccount"
-          [(ngModel)]="counterpartAccountId"
-          [options]="accountOptions"
-          optionLabel="label"
-          optionValue="id"
-          placeholder="Seleccione cuenta"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-      <div class="flex flex-col gap-2">
-        <label for="writeOffReason" class="font-semibold text-[var(--color-primary)]">Motivo de baja</label>
-        <input pInputText id="writeOffReason" [(ngModel)]="writeOffReason" placeholder="Motivo...">
-      </div>
-      <div class="flex flex-col gap-2">
-        <label class="font-semibold text-[var(--color-primary)]">Acciones</label>
-        <p-button
-          label="Crear baja"
-          icon="pi pi-trash"
-          severity="danger"
-          [outlined]="true"
-          [disabled]="busy"
-          (onClick)="writeOff()">
-        </p-button>
+  <p-card header="Comprobantes de pago" class="treasury-vouchers-card">
+    <div class="treasury-voucher-filters mb-4 pb-4 border-b border-gray-200">
+      <h3 class="text-base font-semibold text-[var(--color-primary)] mb-3">Filtros de comprobantes de pago</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-end">
+        <div class="flex flex-col gap-2">
+          <label for="voucherNumber" class="font-semibold text-[var(--color-primary)]">Número de comprobante</label>
+          <input
+            pInputText
+            id="voucherNumber"
+            [ngModel]="voucherNumberFilter"
+            (ngModelChange)="onVoucherNumberFilterChange($event)"
+            placeholder="Buscar por número...">
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="voucherSupplier" class="font-semibold text-[var(--color-primary)]">Proveedor</label>
+          <p-autoComplete
+            id="voucherSupplier"
+            [(ngModel)]="voucherSupplierFilter"
+            [suggestions]="filteredVoucherSuppliers"
+            (completeMethod)="searchVoucherSupplier($event)"
+            field="name"
+            placeholder="Todos los proveedores"
+            [dropdown]="true"
+            [showClear]="true"
+            (onSelect)="onVoucherSupplierFilterChange()"
+            (onClear)="onVoucherSupplierFilterChange()"
+            styleClass="w-full">
+          </p-autoComplete>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="voucherStatus" class="font-semibold text-[var(--color-primary)]">Estado</label>
+          <p-dropdown
+            id="voucherStatus"
+            [(ngModel)]="voucherStatusFilter"
+            (ngModelChange)="onVoucherStatusFilterChange()"
+            [options]="voucherStatusOptions"
+            optionLabel="label"
+            optionValue="value"
+            placeholder="Todos los estados"
+            [showClear]="true"
+            styleClass="w-full">
+          </p-dropdown>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="voucherDateFrom" class="font-semibold text-[var(--color-primary)]">Desde</label>
+          <p-datePicker
+            inputId="voucherDateFrom"
+            [(ngModel)]="voucherDateFrom"
+            (ngModelChange)="onVoucherDateFilterChange()"
+            dateFormat="dd/mm/yy"
+            [showIcon]="true"
+            placeholder="Fecha desde"
+            styleClass="w-full">
+          </p-datePicker>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label for="voucherDateTo" class="font-semibold text-[var(--color-primary)]">Hasta</label>
+          <p-datePicker
+            inputId="voucherDateTo"
+            [(ngModel)]="voucherDateTo"
+            (ngModelChange)="onVoucherDateFilterChange()"
+            dateFormat="dd/mm/yy"
+            [showIcon]="true"
+            placeholder="Fecha hasta"
+            styleClass="w-full">
+          </p-datePicker>
+        </div>
+        <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-1">
+          <label class="font-semibold text-[var(--color-primary)] invisible md:visible">Limpiar</label>
+          <p-button
+            label="Limpiar filtros"
+            icon="pi pi-filter-slash"
+            severity="secondary"
+            [outlined]="true"
+            styleClass="w-full"
+            (onClick)="clearVoucherFilters()">
+          </p-button>
+        </div>
       </div>
     </div>
-  </p-card>
-
-  <p-card header="Comprobantes" class="mb-4">
     <p-table
       [value]="vouchers"
       [loading]="busy"
+      [first]="voucherTableFirst"
+      (onPage)="onVoucherTablePage($event)"
       styleClass="p-datatable-striped"
       [paginator]="true"
       [rows]="10"
       [rowsPerPageOptions]="[5, 10, 20]"
       [showCurrentPageReport]="true"
-      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} comprobantes">
+      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} comprobantes de pago">
       <ng-template pTemplate="header">
         <tr>
           <th>Número</th>
           <th>Fecha</th>
           <th>Estado</th>
           <th class="text-right">Total</th>
-          <th>Asiento</th>
+          <th>Asiento contable</th>
           <th style="min-width: 14rem">Acciones</th>
         </tr>
       </ng-template>
@@ -281,7 +255,7 @@
             <small *ngIf="voucher.failureReason" class="block text-red-600 mt-1">{{ voucher.failureReason }}</small>
           </td>
           <td class="text-right font-semibold">{{ voucher.total | currency:'COP' }}</td>
-          <td>{{ voucher.accountingEntryId || 'Pendiente' }}</td>
+          <td>{{ voucherAccountingEntryLabel(voucher) }}</td>
           <td>
             <div class="action-buttons flex flex-wrap gap-1">
               <p-button
@@ -338,7 +312,7 @@
           <td colspan="6" class="text-center py-8">
             <div class="flex flex-col items-center gap-3">
               <i class="pi pi-inbox text-4xl text-gray-400"></i>
-              <p class="text-gray-600">No hay comprobantes para mostrar</p>
+              <p class="text-gray-600">No hay comprobantes de pago para mostrar</p>
             </div>
           </td>
         </tr>
@@ -346,33 +320,43 @@
     </p-table>
   </p-card>
 
-  <p-card *ngIf="accountingEntry" header="Asiento contable" class="mb-4">
+  <p-card *ngIf="accountingEntry" header="Asiento contable">
     <div class="mb-3 flex flex-wrap gap-4 text-sm text-gray-700">
-      <span><strong>Código:</strong> {{ accountingEntry.code || accountingEntry.id }}</span>
-      <span *ngIf="accountingEntry.date"><strong>Fecha:</strong> {{ accountingEntry.date }}</span>
-      <span *ngIf="accountingEntry.description"><strong>Descripción:</strong> {{ accountingEntry.description }}</span>
-      <span *ngIf="accountingEntry.status"><strong>Estado:</strong> {{ accountingStatusLabel(accountingEntry.status) }}</span>
+      <span *ngIf="accountingEntryHeader.documentTypeLabel"><strong>Origen:</strong> {{ accountingEntryHeader.documentTypeLabel }}</span>
+      <span *ngIf="accountingEntryHeader.voucherNumber"><strong>Comprobante:</strong> {{ accountingEntryHeader.voucherNumber }}</span>
+      <span *ngIf="accountingEntryHeader.supplierLabel"><strong>Proveedor:</strong> {{ accountingEntryHeader.supplierLabel }}</span>
+      <span *ngIf="accountingEntryHeader.entryCode"><strong>Asiento:</strong> {{ accountingEntryHeader.entryCode }}</span>
+      <span *ngIf="accountingEntryHeader.entryDate"><strong>Fecha:</strong> {{ accountingEntryHeader.entryDate }}</span>
+      <span *ngIf="accountingEntryHeader.entryStatus"><strong>Estado:</strong> {{ accountingStatusLabel(accountingEntryHeader.entryStatus) }}</span>
     </div>
+    <p-message
+      *ngIf="accountingMovements.length && !accountingIsBalanced"
+      severity="warn"
+      text="El asiento no está balanceado: el total débito difiere del total crédito."
+      styleClass="mb-3 w-full">
+    </p-message>
     <p-table [value]="accountingMovements" styleClass="p-datatable-sm p-datatable-striped" *ngIf="accountingMovements.length">
       <ng-template pTemplate="header">
         <tr>
+          <th>Código cuenta</th>
           <th>Cuenta</th>
-          <th>Descripción</th>
+          <th>Detalle</th>
           <th class="text-right">Débito</th>
           <th class="text-right">Crédito</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-row>
         <tr>
-          <td class="font-mono">{{ row.account }}</td>
-          <td>{{ row.description }}</td>
+          <td class="font-mono">{{ row.accountCode }}</td>
+          <td>{{ row.accountName }}</td>
+          <td>{{ row.detail }}</td>
           <td class="text-right">{{ row.debit | currency:'COP':'symbol':'1.0-2' }}</td>
           <td class="text-right">{{ row.credit | currency:'COP':'symbol':'1.0-2' }}</td>
         </tr>
       </ng-template>
       <ng-template pTemplate="footer">
         <tr>
-          <td colspan="2" class="font-semibold text-right">Totales</td>
+          <td colspan="3" class="font-semibold text-right">Totales</td>
           <td class="text-right font-semibold">{{ accountingDebitTotal | currency:'COP':'symbol':'1.0-2' }}</td>
           <td class="text-right font-semibold">{{ accountingCreditTotal | currency:'COP':'symbol':'1.0-2' }}</td>
         </tr>
@@ -381,7 +365,7 @@
     <p *ngIf="!accountingMovements.length" class="text-gray-600">El asiento no trae movimientos para mostrar.</p>
   </p-card>
 
-  <p-card header="Programaciones" class="mb-4">
+  <p-card header="Programaciones de pago">
     <p-table
       [value]="schedules"
       [loading]="busy"
@@ -390,10 +374,13 @@
       [rows]="10"
       [rowsPerPageOptions]="[5, 10, 20]"
       [showCurrentPageReport]="true"
-      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} programaciones">
+      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} programaciones de pago">
       <ng-template pTemplate="header">
         <tr>
-          <th>Fecha</th>
+          <th>Fecha ejecución</th>
+          <th>Proveedor</th>
+          <th>Factura(s)</th>
+          <th>Método</th>
           <th>Estado</th>
           <th class="text-right">Total</th>
           <th>Reintentos</th>
@@ -404,10 +391,13 @@
       <ng-template pTemplate="body" let-item>
         <tr>
           <td>{{ item.executionDate }}</td>
+          <td>{{ scheduleSuppliersLabel(item) }}</td>
+          <td class="font-mono text-sm">{{ scheduleInvoicesLabel(item) }}</td>
+          <td>{{ scheduleMethodLabel(item) }}</td>
           <td>
             <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
           </td>
-          <td class="text-right font-semibold">{{ item.total | currency:'COP' }}</td>
+          <td class="text-right font-semibold">{{ scheduleTotal(item) | currency:'COP':'symbol':'1.0-2' }}</td>
           <td>{{ item.retryCount }}</td>
           <td>{{ item.voucherId || '-' }}</td>
           <td>
@@ -434,10 +424,10 @@
       </ng-template>
       <ng-template pTemplate="emptymessage">
         <tr>
-          <td colspan="6" class="text-center py-8">
+          <td colspan="9" class="text-center py-8">
             <div class="flex flex-col items-center gap-3">
               <i class="pi pi-calendar text-4xl text-gray-400"></i>
-              <p class="text-gray-600">No hay programaciones</p>
+              <p class="text-gray-600">No hay programaciones de pago</p>
             </div>
           </td>
         </tr>
@@ -445,7 +435,7 @@
     </p-table>
   </p-card>
 
-  <p-card header="Bajas de CxP" class="mb-4">
+  <p-card header="Bajas de CxP">
     <p-table
       [value]="writeOffs"
       [loading]="busy"
@@ -476,7 +466,7 @@
             <div class="action-buttons flex flex-wrap gap-1">
               <p-button
                 *ngIf="item.status === 'DRAFT' || item.status === 'FAILED'"
-                [label]="item.status === 'FAILED' ? 'Reintentar' : 'Confirmar'"
+                [label]="item.status === 'FAILED' ? 'Reintentar' : 'Contabilizar'"
                 icon="pi pi-check"
                 size="small"
                 (onClick)="confirmWriteOff(item)">
@@ -506,4 +496,458 @@
       </ng-template>
     </p-table>
   </p-card>
+  </div>
 </div>
+
+<p-dialog
+  [header]="paymentDialogHeader"
+  [(visible)]="paymentDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(560px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelPaymentDialog()">
+  <div class="flex flex-col gap-4" *ngIf="dialogLines.length">
+    <div class="treasury-dialog-payables flex flex-col gap-3">
+      <div
+        *ngFor="let line of dialogLines"
+        class="treasury-dialog-payable-card rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div class="flex justify-between items-start gap-4 mb-3">
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Proveedor</p>
+            <span class="font-semibold text-gray-800">{{ supplierName(line.supplierId) }}</span>
+          </div>
+          <div class="text-right">
+            <p class="text-xs text-gray-500 mb-1 m-0">Disponible</p>
+            <span class="font-semibold text-green-600">{{ line.maxAmount | currency:'COP':'symbol':'1.0-2' }}</span>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3 text-sm">
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Factura</p>
+            <span class="font-mono font-semibold text-blue-600">{{ line.reference }}</span>
+          </div>
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Cuenta por pagar</p>
+            <span class="font-mono font-semibold text-gray-800">{{ line.payableAccountCode || '—' }}</span>
+            <small class="block text-gray-500">Definida en la factura de compra</small>
+          </div>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label class="font-semibold text-sm text-[var(--color-primary)]">Monto a pagar</label>
+          <p-selectButton
+            [options]="paymentAmountOptions"
+            optionLabel="label"
+            optionValue="value"
+            [ngModel]="line.paymentMode"
+            (ngModelChange)="setDialogLinePaymentMode(line, $event)"
+            styleClass="treasury-payment-mode-select">
+          </p-selectButton>
+          <p-inputNumber
+            *ngIf="line.paymentMode === 'partial'"
+            [(ngModel)]="line.amount"
+            (ngModelChange)="onDialogLineAmountChange(line)"
+            mode="currency"
+            currency="COP"
+            locale="es-CO"
+            [min]="0.01"
+            [max]="line.maxAmount"
+            placeholder="Ingrese monto parcial"
+            styleClass="w-full">
+          </p-inputNumber>
+          <p *ngIf="line.paymentMode === 'full'" class="text-sm text-gray-600 m-0">
+            Se pagará el total:
+            <strong>{{ line.maxAmount | currency:'COP':'symbol':'1.0-2' }}</strong>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="flex justify-between text-sm font-semibold border-t border-gray-200 pt-2">
+      <span>Total</span>
+      <span>{{ dialogPaymentTotal | currency:'COP' }}</span>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="flex flex-col gap-2">
+        <label for="dialogPaymentMethod" class="font-semibold text-[var(--color-primary)]">Método</label>
+        <p-dropdown
+          inputId="dialogPaymentMethod"
+          [(ngModel)]="dialogPaymentMethodId"
+          [options]="methodOptions"
+          optionLabel="label"
+          optionValue="id"
+          placeholder="Seleccione"
+          [showClear]="true"
+          styleClass="w-full"
+          appendTo="body"
+          (onChange)="dialogPaymentMethodChanged()">
+        </p-dropdown>
+        <p *ngIf="noActivePaymentMethods" class="text-orange-600 text-sm m-0">
+          {{ noActivePaymentMethodsMessage }}
+        </p>
+      </div>
+      <div class="flex flex-col gap-2" *ngIf="dialogRequiresBankAccount">
+        <label for="dialogBankAccount" class="font-semibold text-[var(--color-primary)]">Cuenta bancaria</label>
+        <p-dropdown
+          inputId="dialogBankAccount"
+          [(ngModel)]="dialogBankAccountId"
+          [options]="bankOptions"
+          optionLabel="label"
+          optionValue="id"
+          placeholder="Seleccione"
+          [showClear]="true"
+          styleClass="w-full"
+          appendTo="body">
+        </p-dropdown>
+        <p *ngIf="dialogBankAccountsUnavailable" class="text-orange-600 text-sm m-0">
+          {{ noAvailableBankAccountsMessage }}
+        </p>
+      </div>
+      <div class="flex flex-col gap-2 md:col-span-2">
+        <label for="dialogObservations" class="font-semibold text-[var(--color-primary)]">Observaciones</label>
+        <textarea
+          pInputTextarea
+          id="dialogObservations"
+          rows="2"
+          [(ngModel)]="dialogObservations"
+          placeholder="Observaciones..."
+          class="w-full">
+        </textarea>
+      </div>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cancelar"
+        severity="secondary"
+        [outlined]="true"
+        [disabled]="busy"
+        (onClick)="cancelPaymentDialog()">
+      </p-button>
+      <p-button
+        [label]="isEditingVoucher ? 'Guardar borrador' : 'Crear borrador'"
+        icon="pi pi-save"
+        severity="secondary"
+        [outlined]="true"
+        [loading]="busy"
+        [disabled]="cannotConfirmPaymentDialog"
+        (onClick)="confirmCreateFromDialog()">
+      </p-button>
+      <p-button
+        *ngIf="!isEditingVoucher"
+        [label]="dialogPayButtonLabel"
+        icon="pi pi-wallet"
+        severity="success"
+        [loading]="busy"
+        [disabled]="cannotConfirmPaymentDialog"
+        (onClick)="confirmPayFromDialog()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Programar pago"
+  [(visible)]="scheduleDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(560px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelScheduleDialog()">
+  <div class="flex flex-col gap-4" *ngIf="scheduleLines.length">
+    <div class="treasury-dialog-payables flex flex-col gap-3">
+      <div
+        *ngFor="let line of scheduleLines"
+        class="treasury-dialog-payable-card rounded-lg border border-gray-200 bg-gray-50 p-4">
+        <div class="flex justify-between items-start gap-4 mb-3">
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Proveedor</p>
+            <span class="font-semibold text-gray-800">{{ supplierName(line.supplierId) }}</span>
+          </div>
+          <div class="text-right">
+            <p class="text-xs text-gray-500 mb-1 m-0">Disponible</p>
+            <span class="font-semibold text-green-600">{{ line.maxAmount | currency:'COP':'symbol':'1.0-2' }}</span>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3 text-sm">
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Factura</p>
+            <span class="font-mono font-semibold text-blue-600">{{ line.reference }}</span>
+          </div>
+          <div>
+            <p class="text-xs text-gray-500 mb-1 m-0">Cuenta por pagar</p>
+            <span class="font-mono font-semibold text-gray-800">{{ line.payableAccountCode || '—' }}</span>
+            <small class="block text-gray-500">Definida en la factura de compra</small>
+          </div>
+        </div>
+        <div class="flex flex-col gap-2">
+          <label class="font-semibold text-sm text-[var(--color-primary)]">Monto a programar</label>
+          <p-selectButton
+            [options]="paymentAmountOptions"
+            optionLabel="label"
+            optionValue="value"
+            [ngModel]="line.paymentMode"
+            (ngModelChange)="setDialogLinePaymentMode(line, $event)"
+            styleClass="treasury-payment-mode-select">
+          </p-selectButton>
+          <p-inputNumber
+            *ngIf="line.paymentMode === 'partial'"
+            [(ngModel)]="line.amount"
+            (ngModelChange)="onDialogLineAmountChange(line)"
+            mode="currency"
+            currency="COP"
+            locale="es-CO"
+            [min]="0.01"
+            [max]="line.maxAmount"
+            placeholder="Ingrese monto parcial"
+            styleClass="w-full">
+          </p-inputNumber>
+          <p *ngIf="line.paymentMode === 'full'" class="text-sm text-gray-600 m-0">
+            Se programará el total:
+            <strong>{{ line.maxAmount | currency:'COP':'symbol':'1.0-2' }}</strong>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="flex justify-between text-sm font-semibold border-t border-gray-200 pt-2">
+      <span>Total programado</span>
+      <span>{{ scheduleDialogTotal | currency:'COP' }}</span>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="flex flex-col gap-2">
+        <label for="schedulePaymentMethod" class="font-semibold text-[var(--color-primary)]">Método</label>
+        <p-dropdown
+          inputId="schedulePaymentMethod"
+          [(ngModel)]="schedulePaymentMethodId"
+          [options]="methodOptions"
+          optionLabel="label"
+          optionValue="id"
+          placeholder="Seleccione"
+          [showClear]="true"
+          styleClass="w-full"
+          appendTo="body"
+          (onChange)="schedulePaymentMethodChanged()">
+        </p-dropdown>
+        <p *ngIf="noActivePaymentMethods" class="text-orange-600 text-sm m-0">
+          {{ noActivePaymentMethodsMessage }}
+        </p>
+      </div>
+      <div class="flex flex-col gap-2" *ngIf="scheduleRequiresBankAccount">
+        <label for="scheduleBankAccount" class="font-semibold text-[var(--color-primary)]">Cuenta bancaria</label>
+        <p-dropdown
+          inputId="scheduleBankAccount"
+          [(ngModel)]="scheduleBankAccountId"
+          [options]="bankOptions"
+          optionLabel="label"
+          optionValue="id"
+          placeholder="Seleccione"
+          [showClear]="true"
+          styleClass="w-full"
+          appendTo="body">
+        </p-dropdown>
+        <p *ngIf="scheduleBankAccountsUnavailable" class="text-orange-600 text-sm m-0">
+          {{ noAvailableBankAccountsMessage }}
+        </p>
+      </div>
+      <div class="flex flex-col gap-2">
+        <label for="scheduleExecutionDate" class="font-semibold text-[var(--color-primary)]">Fecha programada</label>
+        <p-datePicker
+          inputId="scheduleExecutionDate"
+          [(ngModel)]="scheduleExecutionDate"
+          (ngModelChange)="onScheduleExecutionDateChange($event)"
+          dateFormat="dd/mm/yy"
+          [showIcon]="true"
+          iconDisplay="input"
+          [minDate]="minExecutionDate"
+          appendTo="body"
+          [readonlyInput]="false"
+          [showOnFocus]="true"
+          placeholder="Seleccione fecha"
+          styleClass="w-full treasury-due-date-picker">
+        </p-datePicker>
+        <small class="text-gray-500">Puede ser hoy o una fecha futura.</small>
+      </div>
+      <div class="flex flex-col gap-2 md:col-span-2">
+        <label for="scheduleObservations" class="font-semibold text-[var(--color-primary)]">Observaciones</label>
+        <textarea
+          pInputTextarea
+          id="scheduleObservations"
+          rows="2"
+          [(ngModel)]="scheduleObservations"
+          placeholder="Observaciones..."
+          class="w-full">
+        </textarea>
+      </div>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cancelar"
+        severity="secondary"
+        [outlined]="true"
+        [disabled]="busy"
+        (onClick)="cancelScheduleDialog()">
+      </p-button>
+      <p-button
+        label="Programar pago"
+        icon="pi pi-clock"
+        severity="success"
+        [loading]="busy"
+        [disabled]="cannotConfirmScheduleDialog"
+        (onClick)="confirmScheduleFromDialog()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Cambiar vencimiento"
+  [(visible)]="dueDateDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(440px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelDueDateDialog()">
+  <div class="flex flex-col gap-4" *ngIf="dueDateTarget">
+    <p class="text-sm text-gray-600 m-0">
+      Factura <span class="font-mono font-semibold text-blue-600">{{ dueDateTarget.reference }}</span>
+      — vence actualmente <strong>{{ dueDateTarget.dueDate }}</strong>
+    </p>
+    <div class="flex flex-col gap-2">
+      <label for="newDueDate" class="font-semibold text-[var(--color-primary)]">Nuevo vencimiento</label>
+      <p-datePicker
+        inputId="newDueDate"
+        [(ngModel)]="newDueDate"
+        (ngModelChange)="onDueDatePickerChange($event)"
+        dateFormat="dd/mm/yy"
+        [showIcon]="true"
+        iconDisplay="input"
+        [minDate]="minDueDate"
+        appendTo="body"
+        [readonlyInput]="false"
+        [showOnFocus]="true"
+        placeholder="Seleccione fecha"
+        styleClass="w-full treasury-due-date-picker">
+      </p-datePicker>
+      <small class="text-gray-500">No puede ser hoy ni una fecha anterior.</small>
+    </div>
+    <div class="flex flex-col gap-2">
+      <label for="dueDateReason" class="font-semibold text-[var(--color-primary)]">Motivo del cambio</label>
+      <textarea
+        pInputTextarea
+        id="dueDateReason"
+        rows="3"
+        [(ngModel)]="dueDateReason"
+        placeholder="Indique el motivo del cambio"
+        class="w-full">
+      </textarea>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cancelar"
+        severity="secondary"
+        [outlined]="true"
+        (onClick)="cancelDueDateDialog()">
+      </p-button>
+      <p-button
+        label="Guardar"
+        icon="pi pi-check"
+        [disabled]="busy"
+        (onClick)="confirmDueDateChange()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Baja de CxP"
+  [(visible)]="writeOffDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(520px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelWriteOffDialog()">
+  <div class="flex flex-col gap-4" *ngIf="writeOffTarget">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+      <div>
+        <p class="text-xs text-gray-500 mb-1 m-0">Proveedor</p>
+        <p class="font-semibold m-0">{{ supplierName(writeOffTarget.supplierId) }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-gray-500 mb-1 m-0">Factura / referencia</p>
+        <p class="font-mono font-semibold text-blue-600 m-0">{{ writeOffTarget.reference }}</p>
+      </div>
+      <div>
+        <p class="text-xs text-gray-500 mb-1 m-0">Saldo disponible</p>
+        <p class="font-semibold text-green-600 m-0">
+          {{ writeOffTarget.availableAmount | currency:'COP':'symbol':'1.0-2' }}
+        </p>
+      </div>
+      <div>
+        <p class="text-xs text-gray-500 mb-1 m-0">Cuenta por pagar (CxP)</p>
+        <p class="font-semibold m-0">{{ payableAccountLabel(writeOffTarget) }}</p>
+      </div>
+    </div>
+    <div class="flex flex-col gap-2">
+      <label for="writeOffAmount" class="font-semibold text-[var(--color-primary)]">Monto de baja *</label>
+      <p-inputNumber
+        inputId="writeOffAmount"
+        [(ngModel)]="writeOffAmount"
+        mode="currency"
+        currency="COP"
+        locale="es-CO"
+        [min]="0.01"
+        [max]="writeOffTarget.availableAmount"
+        styleClass="w-full">
+      </p-inputNumber>
+    </div>
+    <div class="flex flex-col gap-2">
+      <label for="writeOffCounterpartAccount" class="font-semibold text-[var(--color-primary)]">Cuenta contrapartida *</label>
+      <p-dropdown
+        inputId="writeOffCounterpartAccount"
+        [(ngModel)]="writeOffCounterpartAccountId"
+        [options]="accountOptions"
+        optionLabel="label"
+        optionValue="id"
+        placeholder="Seleccione cuenta"
+        [filter]="true"
+        filterBy="label"
+        styleClass="w-full"
+        appendTo="body">
+      </p-dropdown>
+    </div>
+    <div class="flex flex-col gap-2">
+      <label for="writeOffReasonModal" class="font-semibold text-[var(--color-primary)]">Motivo *</label>
+      <textarea
+        pInputTextarea
+        id="writeOffReasonModal"
+        rows="3"
+        [(ngModel)]="writeOffReason"
+        placeholder="Indique el motivo de la baja"
+        class="w-full">
+      </textarea>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cancelar"
+        severity="secondary"
+        [outlined]="true"
+        [disabled]="busy"
+        (onClick)="cancelWriteOffDialog()">
+      </p-button>
+      <p-button
+        label="Crear baja"
+        icon="pi pi-check"
+        severity="danger"
+        [loading]="busy"
+        [disabled]="busy"
+        (onClick)="confirmWriteOffFromDialog()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -1,32 +1,28 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { NEVER, of, TimeoutError } from 'rxjs';
+import { NEVER, of } from 'rxjs';
 import { TreasuryOperationsComponent } from './treasury-operations.component';
+import {
+  WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
+  WRITE_OFF_AMOUNT_INVALID_MESSAGE,
+  WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
+  WRITE_OFF_CREATE_SUCCESS_MESSAGE,
+  WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+  WRITE_OFF_REASON_REQUIRED_MESSAGE,
+} from '../Shared/treasury-writeoff-messages';
 
 describe('TreasuryOperationsComponent PP8', () => {
   function component() {
     const api = {
       createVoucher: jasmine.createSpy('createVoucher').and.returnValue(NEVER),
-      postVoucher: jasmine.createSpy('postVoucher').and.returnValue(of({
-        id: 9,
-        voucherNumber: 'CE-9',
-        status: 'POSTING',
-        enterpriseId: 'enterprise-a',
-        paymentMethodId: 1,
-        total: 25,
-        version: 0,
-        details: [],
-      })),
-      voucher: jasmine.createSpy('voucher').and.returnValue(of({
-        id: 9,
-        voucherNumber: 'CE-9',
-        status: 'POSTED',
-        accountingEntryId: 100,
-        enterpriseId: 'enterprise-a',
-        paymentMethodId: 1,
-        total: 25,
-        version: 1,
-        details: [],
-      })),
+      createSchedule: jasmine.createSpy('createSchedule').and.returnValue(NEVER),
+      createWriteOff: jasmine.createSpy('createWriteOff').and.returnValue(NEVER),
+      confirmWriteOff: jasmine.createSpy('confirmWriteOff').and.returnValue(NEVER),
+      voidWriteOff: jasmine.createSpy('voidWriteOff').and.returnValue(NEVER),
+      changeDueDate: jasmine.createSpy('changeDueDate').and.returnValue(of({})),
+      pending: jasmine.createSpy('pending').and.returnValue(of([])),
+      vouchers: jasmine.createSpy('vouchers').and.returnValue(of({ content: [] })),
+      schedules: jasmine.createSpy('schedules').and.returnValue(of([])),
+      writeOffs: jasmine.createSpy('writeOffs').and.returnValue(of([])),
     };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const exportService = {
@@ -35,15 +31,23 @@ describe('TreasuryOperationsComponent PP8', () => {
       downloadPdfSections: jasmine.createSpy('downloadPdfSections'),
     };
     const messageService = { add: jasmine.createSpy('add') };
+    const paymentMethods = { findAllActive: () => of({ content: [] }) };
+    const chart = { getListAuxiliaryAccounts: () => of([]) };
+    const bankAccountsService = { findAllActive: () => of({ content: [] }) };
+    const thirds = { getThirdParties: () => of({ content: [] }) };
+    const expenseReceiptService = {
+      getSuppliers: jasmine.createSpy('getSuppliers').and.returnValue(of([])),
+    };
     const value = new TreasuryOperationsComponent(
       api as any,
       storage as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
+      paymentMethods as any,
+      chart as any,
+      bankAccountsService as any,
+      thirds as any,
       exportService as any,
       messageService as any,
+      expenseReceiptService as any,
     );
     value.payables = [{
       id: 11, sourceInvoiceId: 50, reference: 'FC-50', enterpriseId: 'enterprise-a', supplierId: 7,
@@ -51,29 +55,104 @@ describe('TreasuryOperationsComponent PP8', () => {
       issueDate: '2026-08-01', originalDueDate: '2026-08-30', dueDate: '2026-08-30',
       payableAccountId: 2205, payableAccountCode: '2205', active: true, version: 0
     }];
-    value.selected.add(11);
-    value.amounts[11] = 25;
-    value.paymentMethodId = 1;
+    value.minExecutionDate = new Date();
+    value.minExecutionDate.setHours(0, 0, 0, 0);
     value.methods = [{ id: 1, requiresBankAccount: true, accountingAccountId: 10 }];
-    value.accounts = [{ id: 100, code: '519999', description: 'Gasto', status: true }];
-    value.accountOptions = [{ id: 100, label: '519999 - Gasto' }];
-    return { value, api };
+    value.methodOptions = [{ id: 1, label: 'Transferencia' }];
+    value.bankOptions = [{ id: 33, label: 'Banco - 123' }];
+    value.accounts = [
+      { id: 100, code: '519999', description: 'Gasto', status: true },
+      { id: 4295, code: '429501', description: 'Ingresos diversos', status: true },
+      { id: 2205, code: '220501', description: 'CxP proveedores', status: true },
+    ];
+    value.accountOptions = value.accounts.map((account: any) => ({
+      id: account.id,
+      label: `${account.code} - ${account.description}`,
+    }));
+    (value as any).supplierNames = new Map<number, string>([[7, 'Proveedor Demo']]);
+    return { value, api, expenseReceiptService };
   }
 
-  it('does not submit when the payment method requires a bank and none was selected', () => {
-    const { value, api } = component();
-    value.createVoucher();
-    expect(api.createVoucher).not.toHaveBeenCalled();
-    expect(value.error).toContain('exige una cuenta bancaria');
+  function payable(overrides: Partial<any> = {}) {
+    return {
+      id: 11,
+      sourceInvoiceId: 50,
+      reference: 'FC-50',
+      enterpriseId: 'enterprise-a',
+      supplierId: 7,
+      originalAmount: 500,
+      paidAmount: 0,
+      pendingAmount: 500,
+      reservedAmount: 0,
+      availableAmount: 500,
+      issueDate: '2026-08-01',
+      originalDueDate: '2026-08-30',
+      dueDate: '2026-08-30',
+      payableAccountId: 2205,
+      payableAccountCode: '220501',
+      active: true,
+      version: 0,
+      ...overrides,
+    };
+  }
+
+  it('blocks payment dialog when no active payment methods are available', () => {
+    const { value } = component();
+    value.methodOptions = [];
+    const messageService = (value as any).messageService;
+    value.openPaymentDialog(value.payables[0]);
+    expect(value.paymentDialogVisible).toBeFalse();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      summary: 'Métodos de pago',
+    }));
   });
 
-  it('submits supplier, invoice and selected bank when the rule is satisfied', () => {
+  it('blocks payment when method requires bank but no bank accounts are available', () => {
+    const { value } = component();
+    value.bankOptions = [];
+    value.openPaymentDialog(value.payables[0]);
+    value.dialogPaymentMethodId = 1;
+    value.confirmPayFromDialog();
+    const messageService = (value as any).messageService;
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: 'El método de pago seleccionado requiere una cuenta bancaria activa.',
+    }));
+  });
+
+  it('does not create draft from dialog when bank account is required but missing', () => {
     const { value, api } = component();
-    value.bankAccountId = 33;
-    value.createVoucher();
+    value.openPaymentDialog(value.payables[0]);
+    value.dialogLines[0].paymentMode = 'partial';
+    value.dialogLines[0].amount = 25;
+    value.dialogPaymentMethodId = 1;
+    value.confirmCreateFromDialog();
+    expect(api.createVoucher).not.toHaveBeenCalled();
+    expect((value as any).messageService.add).toHaveBeenCalled();
+  });
+
+  it('creates draft from dialog when payment rules are satisfied', () => {
+    const { value, api } = component();
+    api.createVoucher.and.returnValue(of({
+      id: 1,
+      voucherNumber: 'CE-1',
+      status: 'DRAFT',
+      enterpriseId: 'enterprise-a',
+      paymentMethodId: 1,
+      total: 25,
+      version: 0,
+      details: [],
+    }));
+    value.openPaymentDialog(value.payables[0]);
+    value.dialogLines[0].paymentMode = 'partial';
+    value.dialogLines[0].amount = 25;
+    value.dialogPaymentMethodId = 1;
+    value.dialogBankAccountId = 33;
+    value.confirmCreateFromDialog();
     expect(api.createVoucher).toHaveBeenCalledWith(jasmine.objectContaining({
-      enterpriseId: 'enterprise-a', paymentMethodId: 1, bankAccountId: 33,
-      details: [{ supplierId: 7, invoiceId: 11, amount: 25 }]
+      enterpriseId: 'enterprise-a',
+      paymentMethodId: 1,
+      bankAccountId: 33,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 25 }],
     }));
   });
 
@@ -94,74 +173,422 @@ describe('TreasuryOperationsComponent PP8', () => {
   it('exports operations to csv when data is available', () => {
     const { value } = component();
     const exportService = (value as any).exportService;
-    value.vouchers = [{
+    value.schedules = [{
       id: 1,
-      voucherNumber: 'CE-1',
-      issueDate: '2026-08-01',
-      status: 'POSTED',
+      executionDate: '2026-08-20',
+      status: 'SCHEDULED',
       total: 25,
+      retryCount: 0,
       paymentMethodId: 1,
       enterpriseId: 'enterprise-a',
-      version: 0,
       details: [],
     }];
     value.exportToCsv();
     expect(exportService.downloadCsvSections).toHaveBeenCalled();
   });
 
-  it('posts a draft voucher and shows success when accounting completes', fakeAsync(() => {
+  it('rejects due dates on or before today in the change dialog', () => {
     const { value, api } = component();
     const messageService = (value as any).messageService;
-    spyOn(value, 'reload');
+    const payable = value.payables[0];
 
-    value.post({
-      id: 9,
-      voucherNumber: 'CE-9',
-      issueDate: '2026-08-13',
-      status: 'DRAFT',
-      total: 25,
-      paymentMethodId: 1,
-      enterpriseId: 'enterprise-a',
-      version: 0,
-      details: [],
-    });
+    value.openDueDateDialog(payable);
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    value.onDueDatePickerChange(today);
 
-    tick();
-
-    expect(api.postVoucher).toHaveBeenCalledWith(9, 'enterprise-a');
-    expect(api.voucher).toHaveBeenCalledWith(9, 'enterprise-a');
-    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
-      severity: 'success',
-      summary: 'Contabilizado',
-    }));
-    expect(value.reload).toHaveBeenCalled();
-    expect(value.busy).toBeFalse();
-    expect(value.postingVoucherId).toBeUndefined();
-  }));
-
-  it('shows timeout feedback when posting hangs', fakeAsync(() => {
-    const { value, api } = component();
-    const messageService = (value as any).messageService;
-    api.postVoucher.and.returnValue(NEVER);
-
-    value.post({
-      id: 9,
-      voucherNumber: 'CE-9',
-      issueDate: '2026-08-13',
-      status: 'DRAFT',
-      total: 25,
-      paymentMethodId: 1,
-      enterpriseId: 'enterprise-a',
-      version: 0,
-      details: [],
-    });
-
-    tick(20_001);
-
+    expect(value.newDueDate?.toDateString()).toBe(value.minDueDate.toDateString());
     expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
       severity: 'warn',
-      summary: 'Respuesta demorada',
+      summary: 'Vencimiento inválido',
     }));
-    expect(value.busy).toBeFalse();
+    expect(api.changeDueDate).not.toHaveBeenCalled();
+  });
+
+  it('submits due date change with reason through the API', () => {
+    const { value, api } = component();
+    const payable = value.payables[0];
+
+    value.openDueDateDialog(payable);
+    const nextDueDate = new Date(value.minDueDate);
+    nextDueDate.setDate(nextDueDate.getDate() + 5);
+    value.newDueDate = nextDueDate;
+    value.dueDateReason = 'Acuerdo con proveedor';
+    value.confirmDueDateChange();
+
+    expect(api.changeDueDate).toHaveBeenCalledWith(
+      payable.id,
+      'enterprise-a',
+      (value as any).formatIsoDate(nextDueDate),
+      'Acuerdo con proveedor',
+    );
+  });
+
+  it('labels pay button for partial vs total payment', () => {
+    const { value } = component();
+    value.openPaymentDialog(value.payables[0]);
+    expect(value.dialogPayButtonLabel).toBe('Pagar total');
+
+    value.setDialogLinePaymentMode(value.dialogLines[0], 'partial');
+    value.dialogLines[0].amount = 25;
+    expect(value.dialogPayButtonLabel).toBe('Pagar parcialmente');
+  });
+
+  it('schedules payment from dialog when date is provided', () => {
+    const { value, api } = component();
+    api.createSchedule.and.returnValue(of({
+      id: 3,
+      executionDate: '2026-08-20',
+      total: 25,
+      status: 'SCHEDULED',
+      enterpriseId: 'enterprise-a',
+      paymentMethodId: 1,
+      retryCount: 0,
+      version: 0,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 25 }],
+    }));
+    value.openScheduleDialog(value.payables[0]);
+    value.scheduleLines[0].paymentMode = 'partial';
+    value.scheduleLines[0].amount = 25;
+    value.schedulePaymentMethodId = 1;
+    value.scheduleBankAccountId = 33;
+    value.scheduleExecutionDate = new Date(value.minExecutionDate);
+    value.confirmScheduleFromDialog();
+    expect(api.createSchedule).toHaveBeenCalled();
+    expect(api.createVoucher).not.toHaveBeenCalled();
+  });
+
+  it('enables write-off action when payable has available balance', () => {
+    const { value } = component();
+    expect(value.canWriteOffPayable(value.payables[0])).toBeTrue();
+  });
+
+  it('disables write-off action when payable has zero available balance', () => {
+    const { value } = component();
+    const zeroBalance = payable({ availableAmount: 0, pendingAmount: 0 });
+    expect(value.canWriteOffPayable(zeroBalance)).toBeFalse();
+  });
+
+  it('opens write-off dialog with obligation context and readonly labels', () => {
+    const { value } = component();
+    const target = payable({ availableAmount: 500, pendingAmount: 500, originalAmount: 500 });
+    value.openWriteOffDialog(target);
+    expect(value.writeOffDialogVisible).toBeTrue();
+    expect(value.writeOffTarget).toEqual(target);
+    expect(value.writeOffAmount).toBe(500);
+    expect(value.payableAccountLabel(target)).toBe('220501 - CxP proveedores');
+    expect(value.supplierName(target.supplierId)).toBe('Proveedor Demo');
+  });
+
+  it('warns when opening write-off dialog without available balance', () => {
+    const { value } = component();
+    const messageService = (value as any).messageService;
+    const target = payable({ availableAmount: 0, pendingAmount: 0 });
+    value.openWriteOffDialog(target);
+    expect(value.writeOffDialogVisible).toBeFalse();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+    }));
+  });
+
+  it('creates partial write-off with supplier invoice and amount in request', () => {
+    const { value, api } = component();
+    api.createWriteOff.and.returnValue(of({ id: 9, status: 'DRAFT', total: 200 }));
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 200;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Condonación parcial';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).toHaveBeenCalledWith(jasmine.objectContaining({
+      enterpriseId: 'enterprise-a',
+      reason: 'Condonación parcial',
+      counterpartAccountId: 4295,
+      counterpartAccountCode: '429501',
+      details: [{ supplierId: 7, invoiceId: 11, amount: 200 }],
+    }));
+    expect(value.writeOffDialogVisible).toBeFalse();
+  });
+
+  it('creates total write-off when amount equals available balance', () => {
+    const { value, api } = component();
+    api.createWriteOff.and.returnValue(of({ id: 10, status: 'DRAFT', total: 500 }));
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 500;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Condonación total';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).toHaveBeenCalledWith(jasmine.objectContaining({
+      details: [{ supplierId: 7, invoiceId: 11, amount: 500 }],
+    }));
+  });
+
+  it('blocks write-off when amount exceeds available balance', () => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 600;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Exceso';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
+    }));
+  });
+
+  it('blocks write-off when amount is zero', () => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 0;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Cero';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_AMOUNT_INVALID_MESSAGE,
+    }));
+  });
+
+  it('requires counterpart account before creating write-off', () => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 100;
+    value.writeOffReason = 'Sin contrapartida';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
+    }));
+  });
+
+  it('requires reason before creating write-off', () => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 100;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = '   ';
+    value.confirmWriteOffFromDialog();
+    expect(api.createWriteOff).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_REASON_REQUIRED_MESSAGE,
+    }));
+  });
+
+  it('does not send payable account in write-off request payload', () => {
+    const { value, api } = component();
+    api.createWriteOff.and.returnValue(of({ id: 11, status: 'DRAFT', total: 100 }));
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 100;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Motivo';
+    value.confirmWriteOffFromDialog();
+    const payload = api.createWriteOff.calls.mostRecent().args[0];
+    expect(payload.payableAccountId).toBeUndefined();
+    expect(payload.payableAccountCode).toBeUndefined();
+    expect(payload.details[0].payableAccountId).toBeUndefined();
+    expect(payload.details[0].payableAccountCode).toBeUndefined();
+  });
+
+  it('shows success message and reloads write-offs after creation', () => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    api.createWriteOff.and.returnValue(of({ id: 12, status: 'DRAFT', total: 100 }));
+    api.writeOffs.and.returnValue(of([{ id: 12, status: 'DRAFT', total: 100, reason: 'Motivo' }]));
+    const target = payable();
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 100;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Motivo';
+    value.confirmWriteOffFromDialog();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_CREATE_SUCCESS_MESSAGE,
+    }));
+    expect(api.writeOffs).toHaveBeenCalledWith('enterprise-a');
+  });
+
+  it('shows accounting entry code from API in voucher table label', () => {
+    const { value } = component();
+    const label = value.voucherAccountingEntryLabel({
+      id: 1,
+      voucherNumber: 'CE-FB04BD89',
+      enterpriseId: 'enterprise-a',
+      issueDate: '2026-08-14',
+      status: 'POSTED',
+      paymentMethodId: 1,
+      total: 22323,
+      accountingEntryId: 37,
+      accountingEntryCode: 'AE-PV-42',
+      version: 0,
+      details: [],
+    });
+    expect(label).toBe('AE-PV-42');
+  });
+
+  it('shows em dash when voucher has no accounting entry code', () => {
+    const { value } = component();
+    const label = value.voucherAccountingEntryLabel({
+      id: 1,
+      voucherNumber: 'CE-FB04BD89',
+      enterpriseId: 'enterprise-a',
+      issueDate: '2026-08-14',
+      status: 'DRAFT',
+      paymentMethodId: 1,
+      total: 22323,
+      version: 0,
+      details: [],
+    });
+    expect(label).toBe('—');
+  });
+
+  it('keeps internal accounting entry id on voucher model for actions', () => {
+    const { value } = component();
+    const voucher = {
+      id: 1,
+      voucherNumber: 'CE-FB04BD89',
+      enterpriseId: 'enterprise-a',
+      issueDate: '2026-08-14',
+      status: 'POSTED' as const,
+      paymentMethodId: 1,
+      total: 22323,
+      accountingEntryId: 37,
+      accountingEntryCode: 'AE-PV-42',
+      version: 0,
+      details: [],
+    };
+    value.vouchers = [voucher];
+    expect(value.vouchers[0].accountingEntryId).toBe(37);
+    expect(value.voucherAccountingEntryLabel(voucher)).not.toContain('37');
+  });
+
+  it('uses contextual help content for treasury operations', () => {
+    const { value } = component();
+    expect(value.help.title).toBe('Operaciones de Tesorería');
+    expect(value.help.summary).toContain('Pagar');
+    expect(value.help.summary).toContain('Programar');
+    expect(value.help.summary).toContain('Baja CxP');
+  });
+
+  function sampleVoucher(overrides: Partial<any> = {}) {
+    return {
+      id: 1,
+      voucherNumber: 'CE-FB04BD89',
+      enterpriseId: 'enterprise-a',
+      issueDate: '2026-08-14',
+      status: 'POSTED' as const,
+      paymentMethodId: 1,
+      total: 500,
+      version: 0,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 500 }],
+      ...overrides,
+    };
+  }
+
+  function sampleSupplier(id = 7, name = 'PEPSI') {
+    return {
+      id,
+      name,
+      accountsPayableAccount: { id: 2205, code: '2205', name: '2205' },
+    };
+  }
+
+  it('filters vouchers locally by number with debounce', fakeAsync(() => {
+    const { value } = component();
+    value.allVouchers = [
+      sampleVoucher(),
+      sampleVoucher({ id: 2, voucherNumber: 'CE-AB12CD34', status: 'DRAFT' }),
+    ] as any;
+    value.applyVoucherFilters();
+    (value as any).setupVoucherFilterSubscriptions();
+    value.onVoucherNumberFilterChange('FB04');
+    tick(299);
+    expect(value.vouchers.length).toBe(2);
+    tick(1);
+    expect(value.vouchers.length).toBe(1);
+    expect(value.vouchers[0].voucherNumber).toBe('CE-FB04BD89');
+    expect(value.voucherTableFirst).toBe(0);
   }));
+
+  it('filters vouchers immediately by status', () => {
+    const { value } = component();
+    value.allVouchers = [
+      sampleVoucher(),
+      sampleVoucher({ id: 2, voucherNumber: 'CE-AB12CD34', status: 'DRAFT' }),
+    ] as any;
+    value.voucherStatusFilter = 'DRAFT';
+    value.onVoucherStatusFilterChange();
+    expect(value.vouchers.length).toBe(1);
+    expect(value.vouchers[0].status).toBe('DRAFT');
+    expect(value.voucherTableFirst).toBe(0);
+  });
+
+  it('filters vouchers immediately by supplier', () => {
+    const { value } = component();
+    value.allVouchers = [
+      sampleVoucher(),
+      sampleVoucher({
+        id: 2,
+        voucherNumber: 'CE-AB12CD34',
+        details: [{ supplierId: 8, invoiceId: 12, amount: 200 }],
+      }),
+    ] as any;
+    value.voucherSupplierFilter = sampleSupplier();
+    value.onVoucherSupplierFilterChange();
+    expect(value.vouchers.length).toBe(1);
+    expect(value.vouchers[0].id).toBe(1);
+  });
+
+  it('combines voucher filters', () => {
+    const { value } = component();
+    value.allVouchers = [
+      sampleVoucher(),
+      sampleVoucher({ id: 2, voucherNumber: 'CE-FB99EE00', status: 'POSTED', details: [{ supplierId: 7, invoiceId: 13, amount: 100 }] }),
+      sampleVoucher({ id: 3, voucherNumber: 'CE-AB12CD34', status: 'DRAFT', details: [{ supplierId: 7, invoiceId: 14, amount: 200 }] }),
+    ] as any;
+    value.voucherNumberFilter = 'FB';
+    value.voucherStatusFilter = 'POSTED';
+    value.voucherSupplierFilter = sampleSupplier();
+    value.applyVoucherFilters();
+    expect(value.vouchers.map((item) => item.id)).toEqual([1, 2]);
+  });
+
+  it('clears voucher filters reactively', () => {
+    const { value } = component();
+    value.allVouchers = [
+      sampleVoucher(),
+      sampleVoucher({ id: 2, voucherNumber: 'CE-AB12CD34', status: 'DRAFT' }),
+    ] as any;
+    value.voucherNumberFilter = 'AB12';
+    value.voucherStatusFilter = 'DRAFT';
+    value.voucherSupplierFilter = sampleSupplier();
+    value.voucherDateFrom = new Date(2026, 7, 1);
+    value.voucherDateTo = new Date(2026, 7, 31);
+    value.applyVoucherFilters();
+    expect(value.vouchers.length).toBe(1);
+    value.clearVoucherFilters();
+    expect(value.vouchers.length).toBe(2);
+    expect(value.voucherNumberFilter).toBe('');
+    expect(value.voucherStatusFilter).toBe('');
+    expect(value.voucherSupplierFilter).toBeNull();
+  });
+
+  it('searches voucher suppliers through expense receipt service', () => {
+    const { value, expenseReceiptService } = component();
+    expenseReceiptService.getSuppliers.and.returnValue(of([
+      sampleSupplier(7, 'PEPSI'),
+      sampleSupplier(8, 'Papelería Central'),
+    ]));
+    value.searchVoucherSupplier({ query: 'Pep' });
+    expect(expenseReceiptService.getSuppliers).toHaveBeenCalledWith('pep');
+    expect(value.filteredVoucherSuppliers).toEqual([sampleSupplier(7, 'PEPSI')]);
+  });
 });

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1,17 +1,21 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { forkJoin, of, timer, TimeoutError } from 'rxjs';
-import { catchError, finalize, switchMap, take, takeWhile, timeout } from 'rxjs/operators';
+import { forkJoin, Observable, of, Subject, timer, TimeoutError } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, switchMap, take, takeUntil, takeWhile, timeout } from 'rxjs/operators';
+import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
-import { CheckboxModule } from 'primeng/checkbox';
+import { DatePickerModule } from 'primeng/datepicker';
+import { DialogModule } from 'primeng/dialog';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputNumberModule } from 'primeng/inputnumber';
 import { InputTextModule } from 'primeng/inputtext';
+import { InputTextarea } from 'primeng/inputtextarea';
 import { MessageModule } from 'primeng/message';
 import { TableModule } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
+import { SelectButtonModule } from 'primeng/selectbutton';
 import { TooltipModule } from 'primeng/tooltip';
 import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
@@ -24,6 +28,7 @@ import { TreasuryApiService } from '../Shared/treasury-api.service';
 import { Payable, PaymentSchedule, PaymentVoucher } from '../Shared/treasury-api.models';
 import {
   accountingEntryStatusLabel,
+  accountingSourceDocumentTypeLabel,
   exportErrorDetail,
   exportSuccessDetail,
   scheduleStatusLabel,
@@ -36,9 +41,37 @@ import {
   buildActiveAccountIdSet,
   filterSelectablePaymentMethods,
 } from '../Shared/treasury-account.integration';
+import {
+  scheduleInvoicesLabel,
+  scheduleMethodLabel,
+  scheduleSuppliersLabel,
+  scheduleTotal,
+} from '../Shared/treasury-schedule-display';
 import { buildThirdPartyNameMap, resolveSupplierName } from '../Shared/treasury-third-party.integration';
+import {
+  AccountingEntryViewHeader,
+  AccountingMovementViewRow,
+  accountingTotalsBalanced,
+  buildAccountCatalogueLookup,
+  buildAccountingEntryView,
+  mapAccountingMovementsForView,
+} from '../Shared/treasury-accounting-display';
 import { ContextualHelpComponent } from '../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../Shared/treasury-help-content';
+import {
+  NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+  NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE,
+} from '../Shared/treasury-payment-messages';
+import {
+  WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
+  WRITE_OFF_AMOUNT_INVALID_MESSAGE,
+  WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
+  WRITE_OFF_CREATE_SUCCESS_MESSAGE,
+  WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+  WRITE_OFF_REASON_REQUIRED_MESSAGE,
+} from '../Shared/treasury-writeoff-messages';
+import { ExpenseReceiptService } from '../ExpenseReceipts/Service/expense-receipt.service';
+import { Supplier } from '../ExpenseReceipts/Model/Models';
 
 @Component({
   selector: 'app-treasury-operations',
@@ -48,28 +81,36 @@ import { TREASURY_HELP } from '../Shared/treasury-help-content';
     FormsModule,
     ButtonModule,
     CardModule,
-    CheckboxModule,
+    DatePickerModule,
+    DialogModule,
     DropdownModule,
     InputNumberModule,
     InputTextModule,
+    InputTextarea,
     MessageModule,
     TableModule,
     TagModule,
+    SelectButtonModule,
     TooltipModule,
     ToastModule,
     ContextualHelpComponent,
+    AutoCompleteModule,
   ],
   templateUrl: './treasury-operations.component.html',
   styleUrl: './treasury-operations.component.css',
   providers: [MessageService],
 })
-export class TreasuryOperationsComponent implements OnInit {
+export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   private static readonly OPERATION_TIMEOUT_MS = 20_000;
   private static readonly POST_POLL_INTERVAL_MS = 2_000;
   private static readonly POST_POLL_MAX_ATTEMPTS = 15;
+  private static readonly VOUCHER_FILTER_DEBOUNCE_MS = 300;
+  private readonly destroy$ = new Subject<void>();
+  private readonly voucherNumberFilter$ = new Subject<string>();
 
   payables: Payable[] = [];
   vouchers: PaymentVoucher[] = [];
+  allVouchers: PaymentVoucher[] = [];
   schedules: PaymentSchedule[] = [];
   writeOffs: any[] = [];
   methods: any[] = [];
@@ -78,32 +119,71 @@ export class TreasuryOperationsComponent implements OnInit {
   accounts: any[] = [];
   bankOptions: { id: number; label: string }[] = [];
   accountOptions: { id: number; label: string }[] = [];
-  selected = new Set<number>();
-  amounts: Record<number, number> = {};
-  paymentMethodId?: number;
-  bankAccountId?: number;
-  executionDate = '';
-  observations = '';
-  editingVoucherId?: number;
-  counterpartAccountId?: number;
+  readonly paymentAmountOptions = [
+    { label: 'Total', value: 'full' as const },
+    { label: 'Parcial', value: 'partial' as const },
+  ];
+  minExecutionDate!: Date;
+  writeOffDialogVisible = false;
+  writeOffTarget?: Payable;
+  writeOffAmount?: number;
+  writeOffCounterpartAccountId?: number;
   writeOffReason = '';
-  busy = false;
+  paymentDialogVisible = false;
+  dialogLines: {
+    invoiceId: number;
+    supplierId: number;
+    reference: string;
+    amount: number;
+    maxAmount: number;
+    paymentMode: 'full' | 'partial';
+    payableAccountId?: number;
+    payableAccountCode?: string;
+  }[] = [];
+  dialogPaymentMethodId?: number;
+  dialogBankAccountId?: number;
+  dialogObservations = '';
+  scheduleDialogVisible = false;
+  scheduleLines: TreasuryOperationsComponent['dialogLines'] = [];
+  schedulePaymentMethodId?: number;
+  scheduleBankAccountId?: number;
+  scheduleExecutionDate?: Date;
+  scheduleObservations = '';
+  editingVoucherId?: number;
   postingVoucherId?: number;
-  error = '';
   voucherNumberFilter = '';
   voucherStatusFilter = '';
+  voucherSupplierFilter: Supplier | null = null;
+  voucherDateFrom?: Date;
+  voucherDateTo?: Date;
+  filteredVoucherSuppliers: Supplier[] = [];
+  voucherTableFirst = 0;
   accountingEntry: any = null;
-  accountingMovements: { account: string; description: string; debit: number; credit: number }[] = [];
+  accountingEntryHeader: AccountingEntryViewHeader = {};
+  accountingMovements: AccountingMovementViewRow[] = [];
   accountingDebitTotal = 0;
   accountingCreditTotal = 0;
+  busy = false;
+  error = '';
   exportingPdf = false;
   exportingCsv = false;
+  dueDateDialogVisible = false;
+  dueDateTarget?: Payable;
+  newDueDate?: Date;
+  dueDateReason = '';
+  minDueDate!: Date;
   readonly help = TREASURY_HELP.operations;
+  readonly noActivePaymentMethodsMessage = NO_ACTIVE_PAYMENT_METHODS_MESSAGE;
+  readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
+  readonly voucherStatusOptions = voucherStatusFilterOptions();
   private supplierNames = new Map<number, string>();
 
-  readonly voucherStatusOptions = voucherStatusFilterOptions();
-
   statusLabel = voucherStatusLabel;
+
+  voucherAccountingEntryLabel(voucher: PaymentVoucher): string {
+    const code = voucher.accountingEntryCode?.trim();
+    return code ? code : '—';
+  }
   scheduleLabel = scheduleStatusLabel;
   writeOffLabel = voucherStatusLabel;
   accountingStatusLabel = accountingEntryStatusLabel;
@@ -120,11 +200,119 @@ export class TreasuryOperationsComponent implements OnInit {
     private readonly thirds: ThirdService,
     private readonly exportService: TreasuryExportService,
     private readonly messageService: MessageService,
+    private readonly expenseReceiptService: ExpenseReceiptService,
   ) {
     this.enterpriseId = this.storage.getIdEnterprise();
   }
 
-  ngOnInit() { this.reload(); }
+  ngOnInit() {
+    const today = this.stripTime(new Date());
+    this.minDueDate = this.addDays(today, 1);
+    this.minExecutionDate = today;
+    this.setupVoucherFilterSubscriptions();
+    this.reload();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private setupVoucherFilterSubscriptions(): void {
+    this.voucherNumberFilter$
+      .pipe(
+        debounceTime(TreasuryOperationsComponent.VOUCHER_FILTER_DEBOUNCE_MS),
+        distinctUntilChanged(),
+        takeUntil(this.destroy$),
+      )
+      .subscribe(() => {
+        this.resetVoucherTablePage();
+        this.applyVoucherFilters();
+      });
+  }
+
+  onVoucherNumberFilterChange(value: string): void {
+    this.voucherNumberFilter = value ?? '';
+    this.voucherNumberFilter$.next(this.voucherNumberFilter);
+  }
+
+  onVoucherStatusFilterChange(): void {
+    this.resetVoucherTablePage();
+    this.applyVoucherFilters();
+  }
+
+  onVoucherSupplierFilterChange(): void {
+    this.resetVoucherTablePage();
+    this.applyVoucherFilters();
+  }
+
+  onVoucherDateFilterChange(): void {
+    this.resetVoucherTablePage();
+    this.applyVoucherFilters();
+  }
+
+  searchVoucherSupplier(event: { query?: string }): void {
+    const query = String(event.query ?? '').trim().toLowerCase();
+    this.expenseReceiptService.getSuppliers(query).subscribe((suppliers) => {
+      this.filteredVoucherSuppliers = query
+        ? suppliers.filter((supplier) => supplier.name.toLowerCase().startsWith(query))
+        : suppliers;
+    });
+  }
+
+  clearVoucherFilters(): void {
+    this.voucherNumberFilter = '';
+    this.voucherStatusFilter = '';
+    this.voucherSupplierFilter = null;
+    this.voucherDateFrom = undefined;
+    this.voucherDateTo = undefined;
+    this.filteredVoucherSuppliers = [];
+    this.resetVoucherTablePage();
+    this.applyVoucherFilters();
+  }
+
+  onVoucherTablePage(event: { first?: number }): void {
+    this.voucherTableFirst = event.first ?? 0;
+  }
+
+  private resetVoucherTablePage(): void {
+    this.voucherTableFirst = 0;
+  }
+
+  applyVoucherFilters(): void {
+    const numberQuery = this.voucherNumberFilter.trim().toLowerCase();
+    const status = this.voucherStatusFilter;
+    const supplierId = this.voucherSupplierFilter?.id;
+
+    this.vouchers = this.allVouchers.filter((voucher) => {
+      if (numberQuery && !voucher.voucherNumber?.toLowerCase().includes(numberQuery)) {
+        return false;
+      }
+      if (status && voucher.status !== status) {
+        return false;
+      }
+      if (supplierId != null) {
+        const supplierIds = [...new Set((voucher.details ?? []).map((detail) => detail.supplierId))];
+        if (!supplierIds.includes(supplierId)) {
+          return false;
+        }
+      }
+      if (this.voucherDateFrom) {
+        const from = this.stripTime(this.voucherDateFrom);
+        if (new Date(voucher.issueDate) < from) {
+          return false;
+        }
+      }
+      if (this.voucherDateTo) {
+        const to = this.stripTime(this.voucherDateTo);
+        to.setHours(23, 59, 59, 999);
+        if (new Date(voucher.issueDate) > to) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
 
   reload() {
     if (!this.enterpriseId) {
@@ -135,10 +323,7 @@ export class TreasuryOperationsComponent implements OnInit {
     this.error = '';
     forkJoin({
       payables: this.api.pending(this.enterpriseId),
-      vouchers: this.api.vouchers(this.enterpriseId, {
-        voucherNumber: this.voucherNumberFilter,
-        status: this.voucherStatusFilter
-      }),
+      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }),
       schedules: this.api.schedules(this.enterpriseId),
       writeOffs: this.api.writeOffs(this.enterpriseId),
       methods: this.paymentMethods.findAllActive(this.enterpriseId),
@@ -151,7 +336,8 @@ export class TreasuryOperationsComponent implements OnInit {
       next: data => {
         this.payables = data.payables;
         this.supplierNames = buildThirdPartyNameMap(data.thirds?.content || []);
-        this.vouchers = data.vouchers.content;
+        this.allVouchers = data.vouchers.content;
+        this.applyVoucherFilters();
         this.schedules = data.schedules;
         this.writeOffs = data.writeOffs;
         this.banks = data.banks.content;
@@ -168,17 +354,12 @@ export class TreasuryOperationsComponent implements OnInit {
         this.methods = filterSelectablePaymentMethods(
           data.methods.content,
           activeAccountIds,
-          this.paymentMethodId ?? null,
+          null,
         );
-        if (this.paymentMethodId && !this.methods.some((method) => method.id === this.paymentMethodId)) {
-          const preserved = data.methods.content.find((method: any) => method.id === this.paymentMethodId);
-          if (preserved) this.methods = [preserved, ...this.methods];
-        }
         this.methodOptions = this.methods.map((method) => ({
           id: method.id,
           label: translatePaymentMethodName(method.name),
         }));
-        this.payables.forEach(p => this.amounts[p.id] ??= p.availableAmount);
         this.busy = false;
       },
       error: err => {
@@ -188,8 +369,20 @@ export class TreasuryOperationsComponent implements OnInit {
     });
   }
 
-  toggle(id: number, checked: boolean) {
-    checked ? this.selected.add(id) : this.selected.delete(id);
+  setDialogLinePaymentMode(line: TreasuryOperationsComponent['dialogLines'][number], mode: 'full' | 'partial') {
+    line.paymentMode = mode;
+    if (mode === 'full') {
+      line.amount = line.maxAmount;
+    }
+  }
+
+  onDialogLineAmountChange(line: TreasuryOperationsComponent['dialogLines'][number]) {
+    if (Number(line.amount) >= line.maxAmount) {
+      line.paymentMode = 'full';
+      line.amount = line.maxAmount;
+    } else {
+      line.paymentMode = 'partial';
+    }
   }
 
   getStatusSeverity(status: string): 'success' | 'info' | 'warning' | 'danger' | 'secondary' | 'contrast' {
@@ -212,107 +405,626 @@ export class TreasuryOperationsComponent implements OnInit {
     }
   }
 
-  private details() {
-    return this.payables
-      .filter(p => this.selected.has(p.id))
-      .map(p => ({ supplierId: p.supplierId, invoiceId: p.id, amount: Number(this.amounts[p.id]) }));
+  canWriteOffPayable(payable: Payable): boolean {
+    return payable.active && Number(payable.availableAmount) > 0;
   }
 
-  get selectedMethod(): any {
-    return this.methods.find(method => method.id === Number(this.paymentMethodId));
-  }
-
-  get requiresBankAccount(): boolean {
-    return Boolean(this.selectedMethod?.requiresBankAccount);
-  }
-
-  paymentMethodChanged() {
-    if (!this.requiresBankAccount) this.bankAccountId = undefined;
-  }
-
-  private paymentSelectionValid(): boolean {
-    if (!this.paymentMethodId) {
-      this.error = 'Seleccione un método de pago activo.';
-      return false;
+  payableAccountLabel(payable: Payable): string {
+    const account = this.accounts.find(
+      (item) => item.id === payable.payableAccountId || item.code === payable.payableAccountCode,
+    );
+    if (account) {
+      return `${account.code} - ${account.description}`;
     }
-    if (this.requiresBankAccount && !this.bankAccountId) {
-      this.error = 'El método seleccionado exige una cuenta bancaria.';
-      return false;
-    }
-    if (!this.requiresBankAccount && this.bankAccountId) {
-      this.error = 'El método seleccionado no admite cuenta bancaria.';
-      return false;
-    }
-    return true;
+    return payable.payableAccountCode ?? '—';
   }
 
-  createVoucher() {
-    if (!this.paymentSelectionValid() || !this.details().length) return;
-    if (!this.amountsWithinAvailable()) return;
-    const paymentMethodId = this.paymentMethodId!;
-    const request = {
-      enterpriseId: this.enterpriseId,
-      issueDate: new Date().toISOString().slice(0, 10),
-      paymentMethodId,
-      bankAccountId: this.bankAccountId,
-      observations: this.observations,
-      details: this.details()
+  openWriteOffDialog(payable: Payable) {
+    if (!this.canWriteOffPayable(payable)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sin saldo',
+        detail: WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    this.writeOffTarget = payable;
+    this.writeOffAmount = Number(payable.availableAmount);
+    this.writeOffCounterpartAccountId = undefined;
+    this.writeOffReason = '';
+    this.writeOffDialogVisible = true;
+  }
+
+  cancelWriteOffDialog() {
+    this.writeOffDialogVisible = false;
+    this.writeOffTarget = undefined;
+    this.writeOffAmount = undefined;
+    this.writeOffCounterpartAccountId = undefined;
+    this.writeOffReason = '';
+  }
+
+  confirmWriteOffFromDialog() {
+    if (!this.writeOffTarget) {
+      return;
+    }
+    if (!this.canWriteOffPayable(this.writeOffTarget)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sin saldo',
+        detail: WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    const amount = Number(this.writeOffAmount ?? 0);
+    const maxAmount = Number(this.writeOffTarget.availableAmount);
+    if (amount <= 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Monto inválido',
+        detail: WRITE_OFF_AMOUNT_INVALID_MESSAGE,
+        life: 5000,
+      });
+      return;
+    }
+    if (amount > maxAmount) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Monto excedido',
+        detail: WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    const account = this.accounts.find((item) => item.id === Number(this.writeOffCounterpartAccountId));
+    if (!account) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Cuenta contrapartida',
+        detail: WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
+        life: 5000,
+      });
+      return;
+    }
+    const reason = (this.writeOffReason ?? '').trim();
+    if (!reason) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Motivo requerido',
+        detail: WRITE_OFF_REASON_REQUIRED_MESSAGE,
+        life: 5000,
+      });
+      return;
+    }
+    const payable = this.writeOffTarget;
+    this.run(
+      this.api.createWriteOff({
+        enterpriseId: this.enterpriseId,
+        reason,
+        counterpartAccountId: account.id,
+        counterpartAccountCode: account.code,
+        details: [{
+          supplierId: payable.supplierId,
+          invoiceId: payable.id,
+          amount,
+        }],
+      }),
+      () => {
+        this.cancelWriteOffDialog();
+        return {
+          summary: 'Baja de CxP',
+          detail: WRITE_OFF_CREATE_SUCCESS_MESSAGE,
+          life: 8000,
+        };
+      },
+    );
+  }
+
+  get dialogSelectedMethod(): any {
+    return this.methods.find((method) => method.id === Number(this.dialogPaymentMethodId));
+  }
+
+  get dialogRequiresBankAccount(): boolean {
+    return Boolean(this.dialogSelectedMethod?.requiresBankAccount);
+  }
+
+  get paymentDialogHeader(): string {
+    return this.editingVoucherId ? 'Editar borrador' : 'Registrar pago';
+  }
+
+  get isEditingVoucher(): boolean {
+    return this.editingVoucherId != null;
+  }
+
+  get dialogPaymentTotal(): number {
+    return this.dialogLines.reduce((sum, line) => sum + Number(line.amount ?? 0), 0);
+  }
+
+  get dialogIsPartialPayment(): boolean {
+    return this.dialogLines.some((line) => line.paymentMode === 'partial');
+  }
+
+  get dialogPayButtonLabel(): string {
+    return this.dialogIsPartialPayment ? 'Pagar parcialmente' : 'Pagar total';
+  }
+
+  get dialogPaySuccessSummary(): string {
+    return this.dialogIsPartialPayment ? 'Pago parcial registrado' : 'Pago total registrado';
+  }
+
+  get scheduleSelectedMethod(): any {
+    return this.methods.find((method) => method.id === Number(this.schedulePaymentMethodId));
+  }
+
+  get scheduleRequiresBankAccount(): boolean {
+    return Boolean(this.scheduleSelectedMethod?.requiresBankAccount);
+  }
+
+  get noActivePaymentMethods(): boolean {
+    return this.methodOptions.length === 0;
+  }
+
+  get dialogBankAccountsUnavailable(): boolean {
+    return this.dialogRequiresBankAccount && this.bankOptions.length === 0;
+  }
+
+  get scheduleBankAccountsUnavailable(): boolean {
+    return this.scheduleRequiresBankAccount && this.bankOptions.length === 0;
+  }
+
+  get cannotConfirmPaymentDialog(): boolean {
+    return this.busy || this.noActivePaymentMethods || this.dialogBankAccountsUnavailable;
+  }
+
+  get cannotConfirmScheduleDialog(): boolean {
+    return this.busy || this.noActivePaymentMethods || this.scheduleBankAccountsUnavailable;
+  }
+
+  get scheduleDialogTotal(): number {
+    return this.scheduleLines.reduce((sum, line) => sum + Number(line.amount ?? 0), 0);
+  }
+
+  private buildPaymentLineFromPayable(payable: Payable): TreasuryOperationsComponent['dialogLines'][number] {
+    return {
+      invoiceId: payable.id,
+      supplierId: payable.supplierId,
+      reference: payable.reference,
+      amount: Number(payable.availableAmount),
+      maxAmount: Number(payable.availableAmount),
+      paymentMode: 'full',
+      payableAccountId: payable.payableAccountId,
+      payableAccountCode: payable.payableAccountCode,
     };
-    this.run(this.editingVoucherId
-      ? this.api.updateVoucher(this.editingVoucherId, request)
-      : this.api.createVoucher(request));
+  }
+
+  openPaymentDialog(payable: Payable) {
+    if (this.noActivePaymentMethods) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Métodos de pago',
+        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    this.editingVoucherId = undefined;
+    this.dialogPaymentMethodId = undefined;
+    this.dialogBankAccountId = undefined;
+    this.dialogObservations = '';
+    this.dialogLines = [this.buildPaymentLineFromPayable(payable)];
+    this.paymentDialogVisible = true;
   }
 
   edit(voucher: PaymentVoucher) {
     this.editingVoucherId = voucher.id;
-    this.paymentMethodId = voucher.paymentMethodId;
-    this.bankAccountId = voucher.bankAccountId;
-    this.observations = voucher.observations ?? '';
-    this.selected.clear();
-    voucher.details.forEach(detail => {
-      this.selected.add(detail.invoiceId);
-      this.amounts[detail.invoiceId] = detail.amountPaid;
+    this.dialogPaymentMethodId = voucher.paymentMethodId;
+    this.dialogBankAccountId = voucher.bankAccountId;
+    this.dialogObservations = voucher.observations ?? '';
+    this.dialogLines = voucher.details.map((detail) => {
+      const payable = this.payables.find((item) => item.id === detail.invoiceId);
+      const maxAmount = payable
+        ? Number(payable.availableAmount) + Number(detail.amountPaid)
+        : Number(detail.amountPaid);
+      const amountPaid = Number(detail.amountPaid);
+      return {
+        invoiceId: detail.invoiceId,
+        supplierId: detail.supplierId,
+        reference: detail.invoiceReference,
+        amount: amountPaid,
+        maxAmount,
+        paymentMode: amountPaid >= maxAmount ? 'full' as const : 'partial' as const,
+        payableAccountId: detail.payableAccountId,
+        payableAccountCode: detail.payableAccountCode,
+      };
+    });
+    this.paymentDialogVisible = true;
+  }
+
+  openScheduleDialog(payable: Payable) {
+    if (this.noActivePaymentMethods) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Métodos de pago',
+        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    this.schedulePaymentMethodId = undefined;
+    this.scheduleBankAccountId = undefined;
+    this.scheduleObservations = '';
+    this.scheduleExecutionDate = new Date(this.minExecutionDate);
+    this.scheduleLines = [this.buildPaymentLineFromPayable(payable)];
+    this.scheduleDialogVisible = true;
+  }
+
+  cancelScheduleDialog() {
+    this.scheduleDialogVisible = false;
+    this.scheduleLines = [];
+    this.schedulePaymentMethodId = undefined;
+    this.scheduleBankAccountId = undefined;
+    this.scheduleExecutionDate = undefined;
+    this.scheduleObservations = '';
+  }
+
+  schedulePaymentMethodChanged() {
+    if (!this.scheduleRequiresBankAccount) {
+      this.scheduleBankAccountId = undefined;
+    }
+  }
+
+  onScheduleExecutionDateChange(selectedDate: Date | null) {
+    if (!selectedDate) {
+      return;
+    }
+    if (this.stripTime(selectedDate).getTime() < this.minExecutionDate.getTime()) {
+      this.scheduleExecutionDate = new Date(this.minExecutionDate);
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Fecha inválida',
+        detail: 'La fecha programada no puede ser anterior a hoy.',
+        life: 4000,
+      });
+    }
+  }
+
+  cancelPaymentDialog() {
+    this.paymentDialogVisible = false;
+    this.editingVoucherId = undefined;
+    this.dialogLines = [];
+    this.dialogPaymentMethodId = undefined;
+    this.dialogBankAccountId = undefined;
+    this.dialogObservations = '';
+  }
+
+  dialogPaymentMethodChanged() {
+    if (!this.dialogRequiresBankAccount) {
+      this.dialogBankAccountId = undefined;
+    }
+  }
+
+  confirmCreateFromDialog() {
+    if (!this.validatePaymentAction(this.dialogLines, this.dialogPaymentMethodId, this.dialogBankAccountId)) {
+      return;
+    }
+    const request = {
+      enterpriseId: this.enterpriseId,
+      issueDate: new Date().toISOString().slice(0, 10),
+      paymentMethodId: this.dialogPaymentMethodId!,
+      bankAccountId: this.dialogBankAccountId,
+      observations: this.dialogObservations,
+      details: this.getDialogDetails(),
+    };
+    const request$ = this.editingVoucherId
+      ? this.api.updateVoucher(this.editingVoucherId, request)
+      : this.api.createVoucher(request);
+    this.run(
+      request$,
+      (result) => {
+        const wasEditing = this.editingVoucherId != null;
+        this.cancelPaymentDialog();
+        return {
+          summary: wasEditing ? 'Borrador actualizado' : 'Borrador creado',
+          detail: `Comprobante ${result.voucherNumber} en borrador.`,
+        };
+      },
+    );
+  }
+
+  confirmPayFromDialog() {
+    if (!this.validatePaymentAction(this.dialogLines, this.dialogPaymentMethodId, this.dialogBankAccountId)) {
+      return;
+    }
+    this.busy = true;
+    this.error = '';
+    this.api.createVoucher({
+      enterpriseId: this.enterpriseId,
+      issueDate: new Date().toISOString().slice(0, 10),
+      paymentMethodId: this.dialogPaymentMethodId!,
+      bankAccountId: this.dialogBankAccountId,
+      observations: this.dialogObservations,
+      details: this.getDialogDetails(),
+    }).pipe(
+      switchMap((voucher) => this.api.postVoucher(voucher.id, this.enterpriseId)),
+      switchMap((posted) => this.waitForAccounting(posted.id)),
+      timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
+      finalize(() => {
+        this.busy = false;
+      }),
+    ).subscribe({
+      next: (updated) => {
+        this.cancelPaymentDialog();
+        if (updated.status === 'POSTED') {
+          this.messageService.add({
+            severity: 'success',
+            summary: this.dialogPaySuccessSummary,
+            detail: `${this.dialogPayButtonLabel} registrado. Comprobante ${updated.voucherNumber} contabilizado.`,
+            life: 6000,
+          });
+        } else if (updated.status === 'FAILED') {
+          this.error = updated.failureReason || 'No se pudo contabilizar el pago.';
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Pago fallido',
+            detail: this.error,
+            life: 8000,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Pago en proceso',
+            detail: `El comprobante ${updated.voucherNumber} sigue en estado ${this.statusLabel(updated.status)}. Actualice en unos segundos.`,
+            life: 8000,
+          });
+        }
+        this.reload();
+      },
+      error: (err) => this.handleOperationError(err, 'registrar el pago'),
     });
   }
 
-  schedule() {
-    if (!this.paymentSelectionValid() || !this.executionDate || !this.details().length) return;
-    if (!this.amountsWithinAvailable()) return;
-    const paymentMethodId = this.paymentMethodId!;
-    this.run(this.api.createSchedule({
-      enterpriseId: this.enterpriseId,
-      issueDate: new Date().toISOString().slice(0, 10),
-      executionDate: this.executionDate,
-      paymentMethodId,
-      bankAccountId: this.bankAccountId,
-      observations: this.observations,
-      details: this.details()
+  confirmScheduleFromDialog() {
+    if (!this.validatePaymentAction(
+      this.scheduleLines,
+      this.schedulePaymentMethodId,
+      this.scheduleBankAccountId,
+      { requireScheduleDate: true, executionDate: this.scheduleExecutionDate },
+    )) {
+      return;
+    }
+    this.run(
+      this.api.createSchedule({
+        enterpriseId: this.enterpriseId,
+        executionDate: this.formatIsoDate(this.scheduleExecutionDate!),
+        paymentMethodId: this.schedulePaymentMethodId!,
+        bankAccountId: this.scheduleBankAccountId,
+        observations: this.scheduleObservations,
+        details: this.getScheduleDetails(),
+      }),
+      (result) => {
+        const detail = this.buildScheduleSuccessDetail(result, this.scheduleLines);
+        this.cancelScheduleDialog();
+        return {
+          summary: 'Pago programado',
+          detail,
+          life: 8000,
+        };
+      },
+    );
+  }
+
+  private getDialogDetails() {
+    return this.dialogLines.map((line) => ({
+      supplierId: line.supplierId,
+      invoiceId: line.invoiceId,
+      amount: Number(line.amount),
     }));
   }
 
-  /** Evita enviar montos mayores al saldo disponible (el backend también rechaza). */
-  private amountsWithinAvailable(): boolean {
-    for (const payable of this.payables) {
-      if (!this.selected.has(payable.id)) continue;
-      const amount = Number(this.amounts[payable.id] ?? 0);
-      if (amount > Number(payable.availableAmount)) {
-        this.error = `El pago de la factura ${payable.reference} (${amount}) supera el saldo disponible (${payable.availableAmount}).`;
+  private getScheduleDetails() {
+    return this.scheduleLines.map((line) => ({
+      supplierId: line.supplierId,
+      invoiceId: line.invoiceId,
+      amount: Number(line.amount),
+    }));
+  }
+
+  scheduleTotal = scheduleTotal;
+
+  scheduleSuppliersLabel(item: PaymentSchedule): string {
+    return scheduleSuppliersLabel(item, this.supplierNames);
+  }
+
+  scheduleInvoicesLabel(item: PaymentSchedule): string {
+    return scheduleInvoicesLabel(item, this.payableReferenceMap(), this.formatMoney);
+  }
+
+  scheduleMethodLabel(item: PaymentSchedule): string {
+    return scheduleMethodLabel(item, this.methods);
+  }
+
+  private payableReferenceMap(): Map<number, string> {
+    return new Map(this.payables.map((payable) => [payable.id, payable.reference]));
+  }
+
+  scheduledAmountForPayable(payable: Payable): number {
+    return this.activeSchedules()
+      .flatMap((schedule) => schedule.details ?? [])
+      .filter((detail) => detail.invoiceId === payable.id)
+      .reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
+  }
+
+  scheduledLabelForPayable(payable: Payable): string | null {
+    const linked = this.activeSchedules().filter((schedule) =>
+      (schedule.details ?? []).some((detail) => detail.invoiceId === payable.id),
+    );
+    if (!linked.length) {
+      return null;
+    }
+    const amount = this.scheduledAmountForPayable(payable);
+    const dates = [...new Set(linked.map((schedule) => schedule.executionDate))].join(', ');
+    return `${this.formatMoney(amount)} · ${dates}`;
+  }
+
+  hasActiveFullSchedule(payable: Payable): boolean {
+    const scheduled = this.scheduledAmountForPayable(payable);
+    return scheduled > 0 && scheduled >= Number(payable.availableAmount);
+  }
+
+  payableReference(invoiceId: number): string {
+    const payable = this.payables.find((item) => item.id === invoiceId);
+    return payable?.reference ?? `ID ${invoiceId}`;
+  }
+
+  private activeSchedules(): PaymentSchedule[] {
+    return this.schedules.filter((schedule) => schedule.status === 'SCHEDULED');
+  }
+
+  private buildScheduleSuccessDetail(
+    result: PaymentSchedule,
+    lines: TreasuryOperationsComponent['scheduleLines'],
+  ): string {
+    const total = this.resolveScheduleTotal(result, lines);
+    const refs = lines.map((line) => line.reference).join(', ');
+    const supplier = lines.length ? this.supplierName(lines[0].supplierId) : '—';
+    const method = this.methods.find((item) => item.id === Number(result.paymentMethodId));
+    const methodLabel = method ? translatePaymentMethodName(method.name) : `#${result.paymentMethodId}`;
+    return [
+      `Programación #${result.id} registrada.`,
+      `Fecha: ${result.executionDate}.`,
+      `Proveedor: ${supplier}.`,
+      `Factura(s): ${refs || '—'}.`,
+      `Método: ${methodLabel}.`,
+      `Total: ${this.formatMoney(total)}.`,
+      'Estado: PROGRAMADO.',
+    ].join(' ');
+  }
+
+  private resolveScheduleTotal(
+    result: PaymentSchedule,
+    lines: TreasuryOperationsComponent['scheduleLines'],
+  ): number {
+    const apiTotal = result.total != null ? Number(result.total) : NaN;
+    if (!Number.isNaN(apiTotal) && apiTotal > 0) {
+      return apiTotal;
+    }
+    const detailsTotal = (result.details ?? []).reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
+    if (detailsTotal > 0) {
+      return detailsTotal;
+    }
+    return lines.reduce((sum, line) => sum + Number(line.amount ?? 0), 0);
+  }
+
+  private formatMoney(amount: number): string {
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
+
+  private validatePaymentAction(
+    lines: TreasuryOperationsComponent['dialogLines'],
+    paymentMethodId?: number,
+    bankAccountId?: number,
+    options?: { requireScheduleDate?: boolean; executionDate?: Date },
+  ): boolean {
+    if (!lines.length) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Sin obligaciones',
+        detail: 'No hay obligaciones para procesar.',
+        life: 5000,
+      });
+      return false;
+    }
+    for (const line of lines) {
+      const amount = Number(line.amount ?? 0);
+      if (amount <= 0) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Monto inválido',
+          detail: `Indique un monto mayor a cero para ${line.reference}.`,
+          life: 5000,
+        });
         return false;
       }
+      if (amount > line.maxAmount) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Saldo insuficiente',
+          detail: `El monto para ${line.reference} supera el saldo disponible (${line.maxAmount}).`,
+          life: 6000,
+        });
+        return false;
+      }
+    }
+    if (this.methodOptions.length === 0) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Métodos de pago',
+        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+        life: 6000,
+      });
+      return false;
+    }
+    const selectedMethod = this.methods.find((method) => method.id === Number(paymentMethodId));
+    if (!paymentMethodId) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Método requerido',
+        detail: 'Seleccione un método de pago activo.',
+        life: 5000,
+      });
+      return false;
+    }
+    const requiresBankAccount = Boolean(selectedMethod?.requiresBankAccount);
+    if (requiresBankAccount && !bankAccountId) {
+      if (this.bankOptions.length === 0) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Cuenta bancaria',
+          detail: NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE,
+          life: 6000,
+        });
+        return false;
+      }
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Cuenta bancaria requerida',
+        detail: 'El método seleccionado exige una cuenta bancaria.',
+        life: 5000,
+      });
+      return false;
+    }
+    if (!requiresBankAccount && bankAccountId) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Cuenta bancaria no permitida',
+        detail: 'El método seleccionado no admite cuenta bancaria.',
+        life: 5000,
+      });
+      return false;
+    }
+    if (options?.requireScheduleDate && !options.executionDate) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Fecha requerida',
+        detail: 'Seleccione la fecha programada del pago.',
+        life: 5000,
+      });
+      return false;
     }
     return true;
   }
 
-  writeOff() {
-    const account = this.accounts.find(a => a.id === Number(this.counterpartAccountId));
-    if (!account || !this.writeOffReason || !this.details().length) return;
-    this.run(this.api.createWriteOff({
-      enterpriseId: this.enterpriseId,
-      reason: this.writeOffReason,
-      counterpartAccountId: account.id,
-      counterpartAccountCode: account.code,
-      details: this.details()
-    }));
+  private waitForAccounting(voucherId: number) {
+    return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
+      take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
+      switchMap(() => this.api.voucher(voucherId, this.enterpriseId)),
+      takeWhile((voucher) => voucher.status === 'POSTING', true),
+    );
   }
 
   post(voucher: PaymentVoucher) {
@@ -363,57 +1075,157 @@ export class TreasuryOperationsComponent implements OnInit {
     });
   }
 
-  private waitForAccounting(voucherId: number) {
-    return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
-      take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
-      switchMap(() => this.api.voucher(voucherId, this.enterpriseId)),
-      takeWhile((voucher) => voucher.status === 'POSTING', true),
-    );
+  remove(voucher: PaymentVoucher) {
+    this.run(this.api.deleteVoucher(voucher.id, this.enterpriseId));
   }
 
-  remove(voucher: PaymentVoucher) { this.run(this.api.deleteVoucher(voucher.id, this.enterpriseId)); }
   void(voucher: PaymentVoucher) {
     const reason = window.prompt('Motivo de anulación');
-    if (reason) this.run(this.api.voidVoucher(voucher.id, this.enterpriseId, reason));
+    if (reason) {
+      this.run(this.api.voidVoucher(voucher.id, this.enterpriseId, reason));
+    }
   }
+
+  get accountingIsBalanced(): boolean {
+    return accountingTotalsBalanced(this.accountingDebitTotal, this.accountingCreditTotal);
+  }
+
   showAccounting(voucher: PaymentVoucher) {
     this.busy = true;
     this.accountingEntry = null;
+    this.accountingEntryHeader = {};
     this.accountingMovements = [];
     this.accountingDebitTotal = 0;
     this.accountingCreditTotal = 0;
+    const accountLookup = buildAccountCatalogueLookup(this.accounts);
+    const supplierIds = [...new Set(voucher.details.map((detail) => detail.supplierId))];
+    const supplierLabel = supplierIds.map((id) => this.supplierName(id)).join(', ');
+
     this.api.accountingEntry(voucher.id).subscribe({
-      next: value => {
+      next: (value) => {
         const entry = value?.data ?? value;
+        const view = buildAccountingEntryView(
+          entry as Record<string, unknown>,
+          mapAccountingMovementsForView(entry?.movements ?? entry?.details ?? [], accountLookup),
+          {
+            documentTypeLabel: accountingSourceDocumentTypeLabel('PAYMENT_VOUCHER'),
+            voucherNumber: voucher.voucherNumber,
+            supplierLabel,
+          },
+        );
         this.accountingEntry = entry;
-        const movements = entry?.movements ?? entry?.details ?? [];
-        this.accountingMovements = (movements as any[]).map((m: any) => ({
-          account: String(m.accountCode ?? m.account ?? m.accountId ?? ''),
-          description: String(m.description ?? ''),
-          debit: Number(m.debit ?? 0),
-          credit: Number(m.credit ?? 0),
-        }));
-        this.accountingDebitTotal = this.accountingMovements.reduce((s, m) => s + m.debit, 0);
-        this.accountingCreditTotal = this.accountingMovements.reduce((s, m) => s + m.credit, 0);
+        this.accountingEntryHeader = view.header;
+        this.accountingMovements = view.movements;
+        this.accountingDebitTotal = this.accountingMovements.reduce((sum, row) => sum + row.debit, 0);
+        this.accountingCreditTotal = this.accountingMovements.reduce((sum, row) => sum + row.credit, 0);
         this.busy = false;
       },
-      error: err => {
+      error: (err) => {
         this.error = err?.error?.message ?? 'No fue posible consultar el asiento.';
         this.busy = false;
-      }
+      },
     });
   }
+
   cancel(schedule: PaymentSchedule) { this.run(this.api.cancelSchedule(schedule.id)); }
   retry(schedule: PaymentSchedule) { this.run(this.api.retrySchedule(schedule.id)); }
-  confirmWriteOff(item: any) { this.run(this.api.confirmWriteOff(item.id)); }
+  confirmWriteOff(item: any) {
+    this.run(this.api.confirmWriteOff(item.id), () => ({
+      summary: 'Baja contabilizada',
+      detail: 'La baja de CxP fue enviada a contabilización.',
+      life: 6000,
+    }));
+  }
   voidWriteOff(item: any) { this.run(this.api.voidWriteOff(item.id)); }
-  changeDueDate(payable: Payable) {
-    const dueDate = window.prompt('Nuevo vencimiento (AAAA-MM-DD)', payable.dueDate);
-    const reason = dueDate && window.prompt('Motivo del cambio');
-    if (dueDate && reason) this.run(this.api.changeDueDate(payable.id, this.enterpriseId, dueDate, reason));
+
+  openDueDateDialog(payable: Payable) {
+    this.dueDateTarget = payable;
+    this.newDueDate = this.parseIsoDate(payable.dueDate);
+    this.dueDateReason = '';
+    this.minDueDate = this.addDays(this.stripTime(new Date()), 1);
+    if (this.newDueDate && this.stripTime(this.newDueDate).getTime() < this.minDueDate.getTime()) {
+      this.newDueDate = new Date(this.minDueDate);
+    }
+    this.dueDateDialogVisible = true;
   }
 
-  private run(request: any) {
+  cancelDueDateDialog() {
+    this.dueDateDialogVisible = false;
+    this.dueDateTarget = undefined;
+    this.newDueDate = undefined;
+    this.dueDateReason = '';
+  }
+
+  onDueDatePickerChange(selectedDate: Date | null) {
+    if (!selectedDate) {
+      return;
+    }
+    if (this.stripTime(selectedDate).getTime() < this.minDueDate.getTime()) {
+      this.newDueDate = new Date(this.minDueDate);
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Vencimiento inválido',
+        detail: 'La fecha debe ser posterior a hoy.',
+        life: 4000,
+      });
+    }
+  }
+
+  confirmDueDateChange() {
+    if (!this.dueDateTarget || !this.newDueDate) {
+      return;
+    }
+    const reason = this.dueDateReason.trim();
+    if (!reason) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Motivo requerido',
+        detail: 'Indique el motivo del cambio de vencimiento.',
+        life: 4000,
+      });
+      return;
+    }
+    if (this.stripTime(this.newDueDate).getTime() < this.minDueDate.getTime()) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Vencimiento inválido',
+        detail: 'La fecha debe ser posterior a hoy.',
+        life: 4000,
+      });
+      return;
+    }
+    const payable = this.dueDateTarget;
+    const dueDate = this.formatIsoDate(this.newDueDate);
+    this.cancelDueDateDialog();
+    this.run(this.api.changeDueDate(payable.id, this.enterpriseId, dueDate, reason));
+  }
+
+  private parseIsoDate(value: string): Date {
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
+  }
+
+  private formatIsoDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private stripTime(date: Date): Date {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  private addDays(date: Date, days: number): Date {
+    const copy = new Date(date);
+    copy.setDate(copy.getDate() + days);
+    return copy;
+  }
+
+  private run(
+    request: Observable<unknown>,
+    onSuccess?: (result: any) => { summary: string; detail: string; life?: number },
+  ) {
     this.busy = true;
     this.error = '';
     request.pipe(
@@ -422,12 +1234,19 @@ export class TreasuryOperationsComponent implements OnInit {
         this.busy = false;
       }),
     ).subscribe({
-      next: () => {
-        this.selected.clear();
-        this.editingVoucherId = undefined;
+      next: (result: any) => {
+        if (onSuccess) {
+          const message = onSuccess(result);
+          this.messageService.add({
+            severity: 'success',
+            summary: message.summary,
+            detail: message.detail,
+            life: message.life ?? 6000,
+          });
+        }
         this.reload();
       },
-      error: (err: any) => this.handleOperationError(err, 'completar la operación'),
+      error: (err: unknown) => this.handleOperationError(err, 'completar la operación'),
     });
   }
 
@@ -503,32 +1322,36 @@ export class TreasuryOperationsComponent implements OnInit {
     return [
       {
         title: 'Obligaciones pendientes',
-        headers: ['Proveedor', 'Factura', 'Vence', 'Disponible'],
+        headers: ['Proveedor', 'Factura', 'Vence', 'Disponible', 'En programación'],
         rows: this.payables.map((item) => [
           resolveSupplierName(this.supplierNames, item.supplierId),
           item.reference,
           item.dueDate,
           item.availableAmount,
+          this.scheduledLabelForPayable(item) ?? '-',
         ]),
       },
       {
-        title: 'Comprobantes',
-        headers: ['Número', 'Fecha', 'Estado', 'Total', 'Asiento'],
+        title: 'Comprobantes de pago',
+        headers: ['Número', 'Fecha', 'Estado', 'Total', 'Asiento contable'],
         rows: this.vouchers.map((item) => [
           item.voucherNumber,
           item.issueDate,
           this.statusLabel(item.status),
           item.total,
-          item.accountingEntryId || 'Pendiente',
+          this.voucherAccountingEntryLabel(item),
         ]),
       },
       {
-        title: 'Programaciones',
-        headers: ['Fecha', 'Estado', 'Total', 'Reintentos', 'Comprobante'],
+        title: 'Programaciones de pago',
+        headers: ['Fecha ejecución', 'Proveedor', 'Factura(s)', 'Método', 'Estado', 'Total', 'Reintentos', 'Comprobante'],
         rows: this.schedules.map((item) => [
           item.executionDate,
+          this.scheduleSuppliersLabel(item),
+          this.scheduleInvoicesLabel(item),
+          this.scheduleMethodLabel(item),
           this.scheduleLabel(item.status),
-          item.total,
+          this.scheduleTotal(item),
           item.retryCount,
           item.voucherId || '-',
         ]),

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
@@ -1,14 +1,14 @@
 <div class="container-fluid p-4">
   <div class="flex justify-between items-center mb-6">
     <div>
-      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Programación Pagos de Factura</h1>
+      <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Programación de Pagos</h1>
       <app-contextual-help
         class="ml-2 inline-flex align-middle"
         [title]="help.title"
         [summary]="help.summary"
         [helpCenterSlug]="help.slug">
       </app-contextual-help>
-      <p class="text-gray-600">Organiza y controla los pagos pendientes a proveedores</p>
+      <p class="text-gray-600">Consulte y gestione pagos programados desde Operaciones de Tesorería</p>
     </div>
     <div class="flex gap-2">
       <p-button
@@ -17,7 +17,7 @@
         severity="danger"
         [outlined]="true"
         [loading]="exportingPdf"
-        [disabled]="!filteredBills.length"
+        [disabled]="!filteredSchedules.length"
         (onClick)="exportToPdf()">
       </p-button>
       <p-button
@@ -26,23 +26,13 @@
         severity="success"
         [outlined]="true"
         [loading]="exportingCsv"
-        [disabled]="!filteredBills.length"
+        [disabled]="!filteredSchedules.length"
         (onClick)="exportToCsv()">
       </p-button>
     </div>
   </div>
 
   <p-card header="Filtros" class="mb-4">
-    <div *ngIf="showCutoffDateSelector" class="bg-blue-50 border-l-4 border-blue-500 p-3 mb-4 rounded">
-      <div class="flex items-center gap-2">
-        <i class="pi pi-info-circle text-blue-600"></i>
-        <div class="text-sm">
-          <p class="font-semibold text-blue-800">Rango de fechas activo</p>
-          <p class="text-blue-700">Use un período predefinido o elija fechas Desde / Hasta.</p>
-        </div>
-      </div>
-    </div>
-
     <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
       <div class="flex flex-col gap-2">
         <label for="supplierId" class="font-semibold text-[var(--color-primary)]">Proveedor</label>
@@ -61,23 +51,6 @@
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="billId" class="font-semibold text-[var(--color-primary)]">Número de factura</label>
-        <p-dropdown
-          id="billId"
-          formControlName="billId"
-          [options]="billIdOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todas las facturas pendientes"
-          [showClear]="true"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
-        <small class="text-gray-500">Solo facturas con saldo pendiente</small>
-      </div>
-
-      <div class="flex flex-col gap-2">
         <label for="status" class="font-semibold text-[var(--color-primary)]">Estado</label>
         <p-dropdown
           id="status"
@@ -91,76 +64,28 @@
         </p-dropdown>
       </div>
 
-      <div class="flex flex-col gap-2" *ngIf="showCutoffDateSelector">
-        <label for="cutoffDateRange" class="font-semibold text-[var(--color-primary)]">Período</label>
-        <p-dropdown
-          id="cutoffDateRange"
-          formControlName="cutoffDateRange"
-          [options]="cutoffDateOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Seleccione un rango"
-          [showClear]="true"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-
       <div class="flex flex-col gap-2">
-        <label for="dateFrom" class="font-semibold text-[var(--color-primary)]">
-          Desde
-          <span *ngIf="showCutoffDateSelector" class="text-xs text-gray-500 font-normal">(opcional)</span>
-        </label>
+        <label for="dateFrom" class="font-semibold text-[var(--color-primary)]">Desde</label>
         <p-calendar
           id="dateFrom"
           formControlName="dateFrom"
           dateFormat="dd/mm/yy"
           [showIcon]="true"
-          [disabled]="showCutoffDateSelector && filterForm.get('cutoffDateRange')?.value && filterForm.get('cutoffDateRange')?.value !== 'CUSTOM'"
           placeholder="Fecha desde"
           styleClass="w-full">
         </p-calendar>
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="dateTo" class="font-semibold text-[var(--color-primary)]">
-          Hasta
-          <span *ngIf="showCutoffDateSelector" class="text-xs text-gray-500 font-normal">(opcional)</span>
-        </label>
+        <label for="dateTo" class="font-semibold text-[var(--color-primary)]">Hasta</label>
         <p-calendar
           id="dateTo"
           formControlName="dateTo"
           dateFormat="dd/mm/yy"
           [showIcon]="true"
-          [disabled]="showCutoffDateSelector && filterForm.get('cutoffDateRange')?.value && filterForm.get('cutoffDateRange')?.value !== 'CUSTOM'"
           placeholder="Fecha hasta"
           styleClass="w-full">
         </p-calendar>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="minAmount" class="font-semibold text-[var(--color-primary)]">Monto mínimo</label>
-        <p-inputNumber
-          id="minAmount"
-          formControlName="minAmount"
-          mode="currency"
-          currency="COP"
-          locale="es-CO"
-          placeholder="0"
-          styleClass="w-full">
-        </p-inputNumber>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="maxAmount" class="font-semibold text-[var(--color-primary)]">Monto máximo</label>
-        <p-inputNumber
-          id="maxAmount"
-          formControlName="maxAmount"
-          mode="currency"
-          currency="COP"
-          locale="es-CO"
-          placeholder="Sin límite"
-          styleClass="w-full">
-        </p-inputNumber>
       </div>
 
       <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-4">
@@ -177,9 +102,9 @@
     </form>
   </p-card>
 
-  <p-card header="Programación de Pagos" class="mb-4">
+  <p-card header="Programaciones de pago" class="mb-4">
     <p-table
-      [value]="filteredBills"
+      [value]="filteredSchedules"
       [loading]="loading"
       [paginator]="true"
       [rows]="10"
@@ -191,70 +116,56 @@
       <ng-template pTemplate="caption">
         <div class="flex justify-between items-center">
           <span class="text-lg font-semibold">
-            Total: {{ filteredBills.length }} programaciones
+            Total: {{ filteredSchedules.length }} programaciones
           </span>
         </div>
       </ng-template>
 
       <ng-template pTemplate="header">
         <tr>
-          <th pSortableColumn="billId" style="width: 150px">
-            Número de factura <p-sortIcon field="billId"></p-sortIcon>
-          </th>
-          <th pSortableColumn="dateOpened" style="width: 120px">
-            Fecha <p-sortIcon field="dateOpened"></p-sortIcon>
-          </th>
-          <th pSortableColumn="supplierName" style="width: 200px">
-            Proveedor <p-sortIcon field="supplierName"></p-sortIcon>
-          </th>
-          <th pSortableColumn="total" style="width: 150px" class="text-right">
-            Total <p-sortIcon field="total"></p-sortIcon>
-          </th>
-          <th pSortableColumn="status" style="width: 140px">
-            Estado <p-sortIcon field="status"></p-sortIcon>
-          </th>
-          <th style="width: 160px">Acciones</th>
+          <th>Fecha ejecución</th>
+          <th>Proveedor</th>
+          <th>Factura(s)</th>
+          <th>Método</th>
+          <th>Estado</th>
+          <th class="text-right">Total</th>
+          <th>Reintentos</th>
+          <th>Comprobante</th>
+          <th style="min-width: 10rem">Acciones</th>
         </tr>
       </ng-template>
 
-      <ng-template pTemplate="body" let-bill>
+      <ng-template pTemplate="body" let-item>
         <tr>
+          <td>{{ formatDate(item.executionDate) }}</td>
+          <td>{{ suppliersLabel(item) }}</td>
+          <td class="font-mono text-sm">{{ invoicesLabel(item) }}</td>
+          <td>{{ methodLabel(item) }}</td>
           <td>
-            <span class="font-mono font-semibold text-blue-600">{{ bill.billId }}</span>
+            <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
           </td>
-          <td>{{ formatDate(bill.dateOpened) }}</td>
+          <td class="text-right font-semibold">{{ formatCurrency(scheduleTotalFn(item)) }}</td>
+          <td>{{ item.retryCount }}</td>
+          <td>{{ item.voucherId || '—' }}</td>
           <td>
-            <div class="flex items-center gap-2">
-              <i class="pi pi-building text-gray-500"></i>
-              <span>{{ bill.supplierName }}</span>
-            </div>
-          </td>
-          <td class="text-right">
-            <span class="font-semibold text-green-600">{{ formatCurrency(bill.total) }}</span>
-          </td>
-          <td>
-            <p-tag
-              [value]="bill.statusDisplay"
-              [severity]="getStatusSeverity(bill.status)">
-            </p-tag>
-          </td>
-          <td>
-            <div class="flex gap-2 flex-wrap">
+            <div class="flex flex-wrap gap-1">
               <p-button
-                label="Pagar"
-                icon="pi pi-wallet"
+                *ngIf="item.status === 'SCHEDULED'"
+                label="Cancelar"
+                icon="pi pi-ban"
                 size="small"
-                severity="success"
-                pTooltip="Programar / registrar pago"
-                (onClick)="onPayBill(bill)">
+                severity="secondary"
+                [outlined]="true"
+                [disabled]="actionBusy"
+                (onClick)="cancelSchedule(item)">
               </p-button>
               <p-button
-                icon="pi pi-eye"
+                *ngIf="item.status === 'FAILED'"
+                label="Reintentar"
+                icon="pi pi-refresh"
                 size="small"
-                severity="info"
-                [text]="true"
-                pTooltip="Ver detalles"
-                (onClick)="onViewBill(bill)">
+                [disabled]="actionBusy"
+                (onClick)="retrySchedule(item)">
               </p-button>
             </div>
           </td>
@@ -263,15 +174,15 @@
 
       <ng-template pTemplate="emptymessage">
         <tr>
-          <td colspan="6" class="text-center py-8">
+          <td colspan="9" class="text-center py-8">
             <div class="flex flex-col items-center gap-4">
-              <i class="pi pi-inbox text-4xl text-gray-400"></i>
+              <i class="pi pi-calendar text-4xl text-gray-400"></i>
               <div>
                 <p class="text-lg font-semibold text-gray-600 mb-2">No se encontraron programaciones</p>
                 <p class="text-gray-500">
-                  {{ filteredBills.length === 0 && allBills.length > 0
+                  {{ allSchedules.length > 0
                     ? emptyFiltersMessage
-                    : 'No hay obligaciones pendientes actualmente' }}
+                    : 'Las programaciones se crean desde Operaciones de Tesorería al programar una obligación pendiente.' }}
                 </p>
               </div>
             </div>
@@ -281,10 +192,10 @@
 
       <ng-template pTemplate="loadingbody">
         <tr>
-          <td colspan="6" class="text-center py-8">
+          <td colspan="9" class="text-center py-8">
             <div class="flex flex-col items-center gap-4">
               <i class="pi pi-spin pi-spinner text-3xl text-blue-500"></i>
-              <p class="text-lg text-gray-600">Cargando facturas...</p>
+              <p class="text-lg text-gray-600">Cargando programaciones...</p>
             </div>
           </td>
         </tr>
@@ -295,118 +206,36 @@
   <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
     <p-card>
       <div class="text-center">
-        <i class="pi pi-file-o text-3xl text-blue-500 mb-2"></i>
-        <h3 class="text-2xl font-bold text-gray-800">{{ allBills.length }}</h3>
-        <p class="text-gray-600">Total obligaciones</p>
+        <i class="pi pi-clock text-3xl text-orange-500 mb-2"></i>
+        <h3 class="text-2xl font-bold text-gray-800">{{ getScheduledCount() }}</h3>
+        <p class="text-gray-600">Programadas</p>
       </div>
     </p-card>
 
     <p-card>
-      <div class="text-center">
-        <i class="pi pi-clock text-3xl text-orange-500 mb-2"></i>
-        <h3 class="text-2xl font-bold text-gray-800">{{ getPartialCount() }}</h3>
-        <p class="text-gray-600">Abono parcial</p>
-      </div>
-    </p-card>
-
-    <p-card [ngClass]="{'border-2 border-green-400': showCutoffDateSelector}">
       <div class="text-center">
         <i class="pi pi-check-circle text-3xl text-green-500 mb-2"></i>
-        <h3 class="text-2xl font-bold text-gray-800">{{ getPostedCount() }}</h3>
-        <p class="text-gray-600">Pendientes</p>
+        <h3 class="text-2xl font-bold text-gray-800">{{ getExecutedCount() }}</h3>
+        <p class="text-gray-600">Ejecutadas</p>
       </div>
     </p-card>
 
     <p-card>
       <div class="text-center">
-        <i class="pi pi-money-bill text-3xl text-purple-500 mb-2"></i>
-        <h3 class="text-2xl font-bold text-gray-800">{{ getPaidCount() }}</h3>
-        <p class="text-gray-600">Pagadas</p>
+        <i class="pi pi-exclamation-triangle text-3xl text-red-500 mb-2"></i>
+        <h3 class="text-2xl font-bold text-gray-800">{{ getFailedCount() }}</h3>
+        <p class="text-gray-600">Fallidas</p>
+      </div>
+    </p-card>
+
+    <p-card>
+      <div class="text-center">
+        <i class="pi pi-ban text-3xl text-gray-500 mb-2"></i>
+        <h3 class="text-2xl font-bold text-gray-800">{{ getCanceledCount() }}</h3>
+        <p class="text-gray-600">Canceladas</p>
       </div>
     </p-card>
   </div>
 
-  <p-card
-    *ngIf="showCutoffDateSelector && filterForm.get('cutoffDateRange')?.value"
-    class="mb-4 border-l-4 border-green-500">
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="text-center">
-        <i class="pi pi-filter text-2xl text-green-600 mb-2"></i>
-        <h4 class="text-lg font-bold text-gray-800">{{ filteredBills.length }}</h4>
-        <p class="text-sm text-gray-600">Facturas en rango</p>
-      </div>
-      <div class="text-center">
-        <i class="pi pi-calendar text-2xl text-blue-600 mb-2"></i>
-        <h4 class="text-lg font-bold text-gray-800">{{ getCutoffDateLabel() }}</h4>
-        <p class="text-sm text-gray-600">Período seleccionado</p>
-      </div>
-      <div class="text-center">
-        <i class="pi pi-dollar text-2xl text-purple-600 mb-2"></i>
-        <h4 class="text-lg font-bold text-gray-800">{{ getTotalFilteredAmount() }}</h4>
-        <p class="text-sm text-gray-600">Total del período</p>
-      </div>
-    </div>
-  </p-card>
-
-  <p-dialog
-    header="Detalle de la obligación"
-    [(visible)]="detailVisible"
-    [modal]="true"
-    [style]="{ width: '520px' }"
-    [draggable]="false"
-    [resizable]="false">
-    <div *ngIf="selectedBill" class="flex flex-col gap-3 text-sm">
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Factura</span>
-        <span class="font-mono font-semibold text-blue-600">{{ selectedBill.billId }}</span>
-      </div>
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Proveedor</span>
-        <span class="font-semibold text-right">{{ selectedBill.supplierName }}</span>
-      </div>
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Fecha</span>
-        <span>{{ formatDate(selectedBill.dateOpened) }}</span>
-      </div>
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Total</span>
-        <span class="font-semibold text-green-700">{{ formatCurrency(selectedBill.total) }}</span>
-      </div>
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Pagado</span>
-        <span>{{ formatCurrency(selectedBill.paidAmount || 0) }}</span>
-      </div>
-      <div class="flex justify-between gap-4">
-        <span class="text-gray-600">Saldo pendiente</span>
-        <span class="font-semibold text-orange-600">{{ formatCurrency(selectedBill.pendingBalance || 0) }}</span>
-      </div>
-      <div class="flex justify-between gap-4 items-center">
-        <span class="text-gray-600">Estado</span>
-        <p-tag
-          [value]="selectedBill.statusDisplay"
-          [severity]="getStatusSeverity(selectedBill.status)">
-        </p-tag>
-      </div>
-    </div>
-    <ng-template pTemplate="footer">
-      <div class="flex gap-2 justify-end">
-        <p-button
-          label="Cerrar"
-          severity="secondary"
-          [outlined]="true"
-          (onClick)="detailVisible = false">
-        </p-button>
-        <p-button
-          *ngIf="selectedBill && selectedBill.status !== 'PAID'"
-          label="Pagar"
-          icon="pi pi-wallet"
-          severity="success"
-          (onClick)="detailVisible = false; onPayBill(selectedBill!)">
-        </p-button>
-      </div>
-    </ng-template>
-  </p-dialog>
-
   <p-toast></p-toast>
-  <p-confirmDialog></p-confirmDialog>
 </div>

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.spec.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.spec.ts
@@ -1,0 +1,89 @@
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { LocalStorageMethods } from '../../../../../Shared/Methods/local-storage.method';
+import { PaymentSchedule } from '../../../Shared/treasury-api.models';
+import { BillListComponent } from './bill-list.component';
+
+describe('BillListComponent schedules', () => {
+  beforeEach(() => {
+    spyOn(LocalStorageMethods.prototype, 'getIdEnterprise').and.returnValue('enterprise-a');
+  });
+  function component() {
+    const api = {
+      schedules: jasmine.createSpy('schedules').and.returnValue(of([])),
+      pending: jasmine.createSpy('pending').and.returnValue(of([])),
+      cancelSchedule: jasmine.createSpy('cancelSchedule'),
+      retrySchedule: jasmine.createSpy('retrySchedule'),
+    };
+    const paymentMethods = {
+      findAllActive: jasmine.createSpy('findAllActive').and.returnValue(of({ content: [] })),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(of({ content: [] })),
+    };
+    const messageService = { add: jasmine.createSpy('add') };
+    const exportService = {
+      datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
+      downloadCsv: jasmine.createSpy('downloadCsv'),
+      downloadPdf: jasmine.createSpy('downloadPdf'),
+    };
+    const value = new BillListComponent(
+      new FormBuilder(),
+      api as any,
+      paymentMethods as any,
+      thirds as any,
+      messageService as any,
+      exportService as any,
+    );
+    value.ngOnInit();
+    return { value, api, messageService };
+  }
+
+  function sampleSchedule(status: PaymentSchedule['status'] = 'SCHEDULED'): PaymentSchedule {
+    return {
+      id: 10,
+      enterpriseId: 'enterprise-a',
+      executionDate: '2026-08-20',
+      status,
+      paymentMethodId: 1,
+      retryCount: 0,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 500 }],
+    };
+  }
+
+  it('loads schedules instead of purchase bills', () => {
+    const { api } = component();
+    expect(api.schedules).toHaveBeenCalledWith('enterprise-a');
+    expect(api.pending).toHaveBeenCalledWith('enterprise-a');
+  });
+
+  it('filters schedules by status', () => {
+    const { value } = component();
+    value.allSchedules = [sampleSchedule('SCHEDULED'), sampleSchedule('FAILED')];
+    value.filteredSchedules = [...value.allSchedules];
+    value.filterForm.patchValue({ status: 'FAILED' });
+    value.applyFilters();
+    expect(value.filteredSchedules.length).toBe(1);
+    expect(value.filteredSchedules[0].status).toBe('FAILED');
+  });
+
+  it('calls cancelSchedule for scheduled items', () => {
+    const { value, api } = component();
+    api.cancelSchedule.and.returnValue(of(sampleSchedule('CANCELED')));
+    value.cancelSchedule(sampleSchedule());
+    expect(api.cancelSchedule).toHaveBeenCalledWith(10);
+  });
+
+  it('calls retrySchedule for failed items', () => {
+    const { value, api } = component();
+    api.retrySchedule.and.returnValue(of(sampleSchedule('PROCESSING')));
+    value.retrySchedule(sampleSchedule('FAILED'));
+    expect(api.retrySchedule).toHaveBeenCalledWith(10);
+  });
+
+  it('uses contextual help content for payment schedules', () => {
+    const { value } = component();
+    expect(value.help.title).toBe('Programación de Pagos');
+    expect(value.help.summary).toContain('Operaciones de Tesorería');
+  });
+});

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
@@ -1,43 +1,45 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router, RouterModule } from '@angular/router';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { InputNumberModule } from 'primeng/inputnumber';
 import { CalendarModule } from 'primeng/calendar';
 import { DropdownModule } from 'primeng/dropdown';
 import { TooltipModule } from 'primeng/tooltip';
 import { TagModule } from 'primeng/tag';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { DialogModule } from 'primeng/dialog';
 
-import { PurchaseBillService } from '../../Services/purchase-bill.service';
-import { BillFilterOption, PurchaseBillListView } from '../../Models/PurchaseBill';
 import { LocalStorageMethods } from '../../../../../Shared/Methods/local-storage.method';
-import { MessageService, ConfirmationService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { TreasuryExportService } from '../../../Shared/treasury-export.service';
 import {
   exportErrorDetail,
   exportSuccessDetail,
   reportEmptyFiltersMessage,
+  scheduleStatusFilterOptions,
+  scheduleStatusLabel,
 } from '../../../Shared/treasury-status-labels';
 import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
+import { TreasuryApiService } from '../../../Shared/treasury-api.service';
+import { Payable, PaymentSchedule } from '../../../Shared/treasury-api.models';
+import { PaymentMethodsServiceService } from '../../../../../GeneralMasters/PaymentMethods/services/payment-methods-service.service';
+import { ThirdService } from '../../../../../GeneralMasters/ThirdParties/Services/third.service';
+import { buildThirdPartyNameMap } from '../../../Shared/treasury-third-party.integration';
+import {
+  scheduleInvoicesLabel,
+  scheduleMethodLabel,
+  scheduleSuppliersLabel,
+  scheduleTotal,
+} from '../../../Shared/treasury-schedule-display';
 
-interface StatusOption {
+interface SupplierFilterOption {
   label: string;
-  value: string;
-}
-
-interface CutoffDateOption {
-  label: string;
-  value: string;
-  days?: number;
+  value: number;
 }
 
 @Component({
@@ -46,356 +48,227 @@ interface CutoffDateOption {
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    RouterModule,
     TableModule,
     ButtonModule,
-    InputTextModule,
-    InputNumberModule,
     CalendarModule,
     DropdownModule,
     TooltipModule,
     TagModule,
     CardModule,
     ToastModule,
-    ConfirmDialogModule,
-    DialogModule,
     ContextualHelpComponent,
   ],
   templateUrl: './bill-list.component.html',
   styleUrls: ['./bill-list.component.css'],
-  providers: [MessageService, ConfirmationService],
+  providers: [MessageService],
 })
 export class BillListComponent implements OnInit {
-  localStorageMethods = new LocalStorageMethods();
+  private readonly localStorageMethods = new LocalStorageMethods();
 
-  allBills: PurchaseBillListView[] = [];
-  filteredBills: PurchaseBillListView[] = [];
-
+  allSchedules: PaymentSchedule[] = [];
+  filteredSchedules: PaymentSchedule[] = [];
   filterForm!: FormGroup;
+  supplierOptions: SupplierFilterOption[] = [];
+  statusOptions = scheduleStatusFilterOptions();
+  supplierNames = new Map<number, string>();
+  payableReferences = new Map<number, string>();
+  methods: any[] = [];
 
-  billIdOptions: BillFilterOption[] = [];
-  allBillIdOptions: BillFilterOption[] = [];
-  supplierOptions: BillFilterOption[] = [];
-
-  statusOptions: StatusOption[] = [
-    { label: 'Todos los estados', value: '' },
-    { label: 'Pendiente de pago', value: 'POSTED' },
-    { label: 'Abono parcial', value: 'PARTIALLY_PAID' },
-    { label: 'Pagada', value: 'PAID' },
-  ];
-
-  cutoffDateOptions: CutoffDateOption[] = [
-    { label: 'Todos', value: '' },
-    { label: 'Últimos 7 días', value: 'LAST_7_DAYS', days: 7 },
-    { label: 'Últimos 15 días', value: 'LAST_15_DAYS', days: 15 },
-    { label: 'Último mes (30 días)', value: 'LAST_MONTH', days: 30 },
-    { label: 'Últimos 3 meses', value: 'LAST_3_MONTHS', days: 90 },
-    { label: 'Últimos 6 meses', value: 'LAST_6_MONTHS', days: 180 },
-    { label: 'Último año', value: 'LAST_YEAR', days: 365 },
-    { label: 'Rango personalizado', value: 'CUSTOM' },
-  ];
-
-  showCutoffDateSelector = false;
   loading = false;
-  detailVisible = false;
-  selectedBill: PurchaseBillListView | null = null;
+  actionBusy = false;
   exportingPdf = false;
   exportingCsv = false;
   readonly emptyFiltersMessage = reportEmptyFiltersMessage();
   readonly help = TREASURY_HELP.paymentSchedule;
+  readonly scheduleLabel = scheduleStatusLabel;
+  readonly scheduleTotalFn = scheduleTotal;
 
   constructor(
-    private fb: FormBuilder,
-    private router: Router,
-    private purchaseBillService: PurchaseBillService,
-    private messageService: MessageService,
-    private confirmationService: ConfirmationService,
-    private exportService: TreasuryExportService,
+    private readonly fb: FormBuilder,
+    private readonly api: TreasuryApiService,
+    private readonly paymentMethods: PaymentMethodsServiceService,
+    private readonly thirds: ThirdService,
+    private readonly messageService: MessageService,
+    private readonly exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
-    this.initializeFilterForm();
-    this.loadBills();
-    this.setupFilterSubscriptions();
-  }
-
-  initializeFilterForm(): void {
     this.filterForm = this.fb.group({
-      billId: [null],
       supplierId: [null],
+      status: [''],
       dateFrom: [null],
       dateTo: [null],
-      status: [''],
-      cutoffDateRange: [''],
-      minAmount: [null],
-      maxAmount: [null],
     });
+    this.filterForm.valueChanges.subscribe(() => this.applyFilters());
+    this.loadSchedules();
   }
 
-  setupFilterSubscriptions(): void {
-    this.filterForm.get('status')?.valueChanges.subscribe((status) => {
-      this.showCutoffDateSelector = status === 'POSTED' || status === 'PARTIALLY_PAID';
-
-      if (!this.showCutoffDateSelector) {
-        this.filterForm.patchValue(
-          {
-            cutoffDateRange: '',
-            dateFrom: null,
-            dateTo: null,
-          },
-          { emitEvent: false },
-        );
-      }
-    });
-
-    this.filterForm.get('cutoffDateRange')?.valueChanges.subscribe((range) => {
-      if (range && range !== 'CUSTOM') {
-        this.applyCutoffDateRange(range);
-      } else if (range === 'CUSTOM' || range === '') {
-        this.filterForm.patchValue(
-          {
-            dateFrom: null,
-            dateTo: null,
-          },
-          { emitEvent: false },
-        );
-      }
-    });
-
-    this.filterForm.get('supplierId')?.valueChanges.subscribe(() => this.onSupplierFilterChange());
-
-    this.filterForm.valueChanges.subscribe(() => {
-      this.applyFilters();
-    });
-  }
-
-  loadBills(): void {
-    this.loading = true;
+  loadSchedules(): void {
     const enterpriseId = this.localStorageMethods.getIdEnterprise();
     if (!enterpriseId) {
-      this.loading = false;
       this.messageService.add({
         severity: 'warn',
         summary: 'Empresa requerida',
-        detail: 'Seleccione una empresa activa para ver las facturas.',
+        detail: 'Seleccione una empresa activa para ver las programaciones.',
       });
       return;
     }
 
-    this.purchaseBillService.getAllPurchaseBills(enterpriseId).subscribe({
-      next: (bills) => {
-        this.allBills = bills;
-        this.buildFilterOptions(bills);
-        this.filteredBills = [...bills];
+    this.loading = true;
+    forkJoin({
+      schedules: this.api.schedules(enterpriseId),
+      methods: this.paymentMethods.findAllActive(enterpriseId),
+      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
+      payables: this.api.pending(enterpriseId),
+    }).subscribe({
+      next: (data) => {
+        this.allSchedules = data.schedules ?? [];
+        this.methods = data.methods?.content ?? [];
+        this.supplierNames = buildThirdPartyNameMap(data.thirds?.content || []);
+        this.payableReferences = new Map(
+          (data.payables ?? []).map((payable: Payable) => [payable.id, payable.reference]),
+        );
+        this.buildSupplierOptions();
+        this.filteredSchedules = [...this.allSchedules];
         this.applyFilters();
         this.loading = false;
       },
       error: (error) => {
-        console.error('Error al cargar facturas:', error);
+        console.error('Error al cargar programaciones:', error);
         this.messageService.add({
           severity: 'error',
           summary: 'Error',
-          detail: 'No se pudieron cargar las facturas. Intente nuevamente.',
+          detail: 'No se pudieron cargar las programaciones. Intente nuevamente.',
         });
         this.loading = false;
       },
     });
   }
 
-  buildFilterOptions(bills: PurchaseBillListView[]): void {
-    this.supplierOptions = [...new Set(bills.map((b) => b.supplierId))]
-      .map((id) => {
-        const name = bills.find((b) => b.supplierId === id)?.supplierName || `Proveedor ${id}`;
-        return { value: id, label: `${id} — ${name}` };
-      })
-      .sort((a, b) => a.label.localeCompare(b.label));
-
-    this.allBillIdOptions = bills
-      .map((b) => ({
-        value: b.billId,
-        label: `${b.billId} · Proveedor ${b.supplierId}`,
-        supplierId: b.supplierId,
+  buildSupplierOptions(): void {
+    const supplierIds = new Set<number>();
+    this.allSchedules.forEach((schedule) => {
+      (schedule.details ?? []).forEach((detail) => supplierIds.add(detail.supplierId));
+    });
+    this.supplierOptions = [...supplierIds]
+      .map((id) => ({
+        value: id,
+        label: this.supplierNames.get(id) ?? `Proveedor ${id}`,
       }))
-      .sort((a, b) => String(a.label).localeCompare(String(b.label)));
-
-    this.billIdOptions = [...this.allBillIdOptions];
-  }
-
-  onSupplierFilterChange(): void {
-    const supplierId = this.filterForm.value.supplierId;
-    this.billIdOptions =
-      supplierId == null
-        ? [...this.allBillIdOptions]
-        : this.allBillIdOptions.filter((opt) => opt.supplierId === Number(supplierId));
-
-    const selectedBill = this.filterForm.value.billId;
-    if (selectedBill && !this.billIdOptions.some((b) => b.value === selectedBill)) {
-      this.filterForm.patchValue({ billId: null }, { emitEvent: false });
-    }
+      .sort((a, b) => a.label.localeCompare(b.label));
   }
 
   applyFilters(): void {
     const filters = this.filterForm.value;
-
-    this.filteredBills = this.allBills.filter((bill) => {
-      if (filters.billId && bill.billId !== filters.billId) {
+    this.filteredSchedules = this.allSchedules.filter((schedule) => {
+      if (filters.status && schedule.status !== filters.status) {
         return false;
       }
 
-      if (filters.supplierId != null && bill.supplierId !== Number(filters.supplierId)) {
-        return false;
+      if (filters.supplierId != null) {
+        const supplierId = Number(filters.supplierId);
+        const matchesSupplier = (schedule.details ?? []).some((detail) => detail.supplierId === supplierId);
+        if (!matchesSupplier) {
+          return false;
+        }
       }
 
       if (filters.dateFrom) {
         const from = new Date(filters.dateFrom);
         from.setHours(0, 0, 0, 0);
-        if (new Date(bill.dateOpened) < from) return false;
+        if (new Date(schedule.executionDate) < from) {
+          return false;
+        }
       }
+
       if (filters.dateTo) {
         const to = new Date(filters.dateTo);
         to.setHours(23, 59, 59, 999);
-        if (new Date(bill.dateOpened) > to) return false;
-      }
-
-      if (filters.status && bill.status !== filters.status) {
-        return false;
-      }
-
-      if (filters.minAmount != null && bill.total < filters.minAmount) {
-        return false;
-      }
-      if (filters.maxAmount != null && bill.total > filters.maxAmount) {
-        return false;
+        if (new Date(schedule.executionDate) > to) {
+          return false;
+        }
       }
 
       return true;
     });
   }
 
-  applyCutoffDateRange(rangeValue: string): void {
-    const option = this.cutoffDateOptions.find((opt) => opt.value === rangeValue);
-
-    if (option?.days) {
-      const today = new Date();
-      today.setHours(23, 59, 59, 999);
-
-      const startDate = new Date();
-      startDate.setDate(today.getDate() - option.days);
-      startDate.setHours(0, 0, 0, 0);
-
-      this.filterForm.patchValue(
-        {
-          dateFrom: startDate,
-          dateTo: today,
-        },
-        { emitEvent: false },
-      );
-
-      this.applyFilters();
-    }
-  }
-
   clearFilters(): void {
     this.filterForm.reset({
-      billId: null,
       supplierId: null,
+      status: '',
       dateFrom: null,
       dateTo: null,
-      status: '',
-      cutoffDateRange: '',
-      minAmount: null,
-      maxAmount: null,
     });
-    this.showCutoffDateSelector = false;
-    this.billIdOptions = [...this.allBillIdOptions];
-    this.filteredBills = [...this.allBills];
+    this.filteredSchedules = [...this.allSchedules];
   }
 
-  onCreateBill(): void {
-    this.router.navigate(['/financial/treasury/purchase-bills/create']);
+  suppliersLabel(item: PaymentSchedule): string {
+    return scheduleSuppliersLabel(item, this.supplierNames);
   }
 
-  onViewBill(bill: PurchaseBillListView): void {
-    this.selectedBill = bill;
-    this.detailVisible = true;
+  invoicesLabel(item: PaymentSchedule): string {
+    return scheduleInvoicesLabel(item, this.payableReferences, this.formatMoney);
   }
 
-  onEditBill(bill: PurchaseBillListView): void {
-    if (bill.status === 'POSTED' || bill.status === 'PAID' || bill.status === 'PARTIALLY_PAID') {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Acción No Permitida',
-        detail: 'No se puede editar una obligación sincronizada desde Facturación.',
-      });
-      return;
-    }
-
-    this.router.navigate(['/financial/treasury/purchase-bills', bill.id, 'edit']);
+  methodLabel(item: PaymentSchedule): string {
+    return scheduleMethodLabel(item, this.methods);
   }
 
-  onDeleteBill(bill: PurchaseBillListView): void {
-    if (bill.status === 'POSTED' || bill.status === 'PAID' || bill.status === 'PARTIALLY_PAID') {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Acción No Permitida',
-        detail: 'Las obligaciones sincronizadas no se eliminan desde Tesorería.',
-      });
-      return;
-    }
+  cancelSchedule(schedule: PaymentSchedule): void {
+    this.runScheduleAction(this.api.cancelSchedule(schedule.id), 'Programación cancelada.');
+  }
 
-    this.confirmationService.confirm({
-      message: `¿Está seguro de eliminar la factura ${bill.billId}?`,
-      header: 'Confirmar Eliminación',
-      icon: 'pi pi-exclamation-triangle',
-      accept: () => {
-        this.purchaseBillService.deletePurchaseBill(bill.id).subscribe({
-          next: () => {
-            this.messageService.add({
-              severity: 'success',
-              summary: 'Éxito',
-              detail: 'Factura eliminada correctamente.',
-            });
-            this.loadBills();
-          },
-          error: (error) => {
-            console.error('Error al eliminar factura:', error);
-            this.messageService.add({
-              severity: 'error',
-              summary: 'Error',
-              detail: error?.message || 'No se pudo eliminar la factura.',
-            });
-          },
+  retrySchedule(schedule: PaymentSchedule): void {
+    this.runScheduleAction(this.api.retrySchedule(schedule.id), 'Reintento de programación iniciado.');
+  }
+
+  private runScheduleAction(action: Observable<PaymentSchedule>, successDetail: string): void {
+    this.actionBusy = true;
+    action.subscribe({
+      next: () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Éxito',
+          detail: successDetail,
         });
+        this.loadSchedules();
+        this.actionBusy = false;
+      },
+      error: (error) => {
+        console.error('Error en programación:', error);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: error?.error?.message || 'No se pudo completar la acción.',
+        });
+        this.actionBusy = false;
       },
     });
   }
 
-  onPayBill(bill: PurchaseBillListView): void {
-    this.router.navigate(['/financial/treasury/expense-receipts/creation'], {
-      queryParams: {
-        billId: bill.id,
-        billCode: bill.billId,
-        supplierId: bill.supplierId,
-        supplierName: bill.supplierName,
-        totalAmount: bill.total,
-        paidAmount: bill.paidAmount ?? 0,
-        pendingBalance: bill.pendingBalance ?? bill.total,
-      },
-    });
-  }
-
-  getStatusSeverity(status: string): 'success' | 'info' | 'warning' | 'danger' {
-    const severityMap: { [key: string]: 'success' | 'info' | 'warning' | 'danger' } = {
-      DRAFT: 'info',
-      POSTED: 'warning',
-      PARTIALLY_PAID: 'info',
-      PAID: 'success',
-      CANCELLED: 'danger',
-    };
-    return severityMap[status] || 'info';
+  getStatusSeverity(status: string): 'success' | 'info' | 'warning' | 'danger' | 'secondary' | 'contrast' {
+    switch (status) {
+      case 'EXECUTED':
+      case 'SCHEDULED':
+        return 'success';
+      case 'PROCESSING':
+      case 'WAITING_ACCOUNTING':
+        return 'info';
+      case 'FAILED':
+        return 'danger';
+      case 'CANCELED':
+        return 'secondary';
+      default:
+        return 'warning';
+    }
   }
 
   formatCurrency(amount: number): string {
+    return this.formatMoney(amount);
+  }
+
+  formatMoney(amount: number): string {
     return new Intl.NumberFormat('es-CO', {
       style: 'currency',
       currency: 'COP',
@@ -404,12 +277,12 @@ export class BillListComponent implements OnInit {
     }).format(amount || 0);
   }
 
-  formatDate(date: Date): string {
+  formatDate(value: string | Date): string {
     return new Intl.DateTimeFormat('es-CO', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
-    }).format(new Date(date));
+    }).format(new Date(value));
   }
 
   exportToCsv(): void {
@@ -421,7 +294,7 @@ export class BillListComponent implements OnInit {
   }
 
   private runExport(format: 'csv' | 'pdf'): void {
-    if (!this.filteredBills.length) {
+    if (!this.filteredSchedules.length) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Sin datos',
@@ -430,19 +303,20 @@ export class BillListComponent implements OnInit {
       return;
     }
 
-    const headers = ['Factura', 'Fecha', 'Proveedor', 'Total', 'Pagado', 'Saldo', 'Estado'];
-    const rows = this.filteredBills.map((bill) => [
-      bill.billId,
-      this.formatDate(bill.dateOpened),
-      bill.supplierName,
-      bill.total,
-      bill.paidAmount ?? 0,
-      bill.pendingBalance ?? 0,
-      bill.statusDisplay,
+    const headers = ['Fecha ejecución', 'Proveedor', 'Factura(s)', 'Método', 'Estado', 'Total', 'Reintentos', 'Comprobante'];
+    const rows = this.filteredSchedules.map((item) => [
+      item.executionDate,
+      this.suppliersLabel(item),
+      this.invoicesLabel(item),
+      this.methodLabel(item),
+      this.scheduleLabel(item.status),
+      scheduleTotal(item),
+      item.retryCount,
+      item.voucherId || '—',
     ]);
     const options = {
-      title: 'Programación de pagos de factura',
-      subtitle: `${rows.length} obligación(es) exportada(s)`,
+      title: 'Programación de pagos',
+      subtitle: `${rows.length} programación(es) exportada(s)`,
       filename: this.exportService.datedFilename('programacion-pagos', format),
       headers,
       rows,
@@ -473,28 +347,19 @@ export class BillListComponent implements OnInit {
     }
   }
 
-  getPartialCount(): number {
-    return this.allBills.filter((bill) => bill.status === 'PARTIALLY_PAID').length;
+  getScheduledCount(): number {
+    return this.allSchedules.filter((item) => item.status === 'SCHEDULED').length;
   }
 
-  getPostedCount(): number {
-    return this.allBills.filter(
-      (bill) => bill.status === 'POSTED' || bill.status === 'PARTIALLY_PAID',
-    ).length;
+  getExecutedCount(): number {
+    return this.allSchedules.filter((item) => item.status === 'EXECUTED').length;
   }
 
-  getPaidCount(): number {
-    return this.allBills.filter((bill) => bill.status === 'PAID').length;
+  getFailedCount(): number {
+    return this.allSchedules.filter((item) => item.status === 'FAILED').length;
   }
 
-  getCutoffDateLabel(): string {
-    const rangeValue = this.filterForm.get('cutoffDateRange')?.value;
-    const option = this.cutoffDateOptions.find((opt) => opt.value === rangeValue);
-    return option ? option.label : 'Rango personalizado';
-  }
-
-  getTotalFilteredAmount(): string {
-    const total = this.filteredBills.reduce((sum, bill) => sum + bill.total, 0);
-    return this.formatCurrency(total);
+  getCanceledCount(): number {
+    return this.allSchedules.filter((item) => item.status === 'CANCELED').length;
   }
 }

--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
@@ -37,7 +37,7 @@
   </div>
 
   <p-card header="Filtros" class="mb-4">
-    <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+    <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="flex flex-col gap-2">
         <label for="supplierId" class="font-semibold text-[var(--color-primary)]">Proveedor</label>
         <p-dropdown
@@ -55,39 +55,6 @@
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="document" class="font-semibold text-[var(--color-primary)]">Documento / factura</label>
-        <p-dropdown
-          id="document"
-          formControlName="document"
-          [options]="documentOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todas las facturas pendientes"
-          [showClear]="true"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
-      </div>
-
-      <div class="flex flex-col gap-2">
-        <label for="accountCode" class="font-semibold text-[var(--color-primary)]">Cuenta CxP</label>
-        <p-dropdown
-          id="accountCode"
-          formControlName="accountCode"
-          [options]="accountTypeOptions"
-          optionLabel="label"
-          optionValue="value"
-          placeholder="Todas las CxP con saldo"
-          [showClear]="true"
-          [filter]="true"
-          filterBy="label"
-          styleClass="w-full">
-        </p-dropdown>
-        <small class="text-gray-500">Solo cuentas usadas en obligaciones pendientes</small>
-      </div>
-
-      <div class="flex flex-col gap-2">
         <label for="cutoffDate" class="font-semibold text-[var(--color-primary)]">
           Fecha de corte <span class="text-red-500">*</span>
         </label>
@@ -96,7 +63,7 @@
           formControlName="cutoffDate"
           dateFormat="dd/mm/yy"
           [showIcon]="true"
-          placeholder="dd/mm/yyyy"
+          placeholder="dd/mm/aaaa"
           styleClass="w-full">
         </p-calendar>
         <small class="text-gray-500">Fecha contra la que se calculan los días de mora</small>
@@ -112,7 +79,7 @@
         </div>
       </div>
 
-      <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-3">
+      <div class="flex flex-col gap-2 md:col-span-2">
         <div class="flex gap-2 justify-end">
           <p-button
             label="Generar reporte"

--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
@@ -4,7 +4,6 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
 import { CalendarModule } from 'primeng/calendar';
 import { DropdownModule } from 'primeng/dropdown';
 import { CardModule } from 'primeng/card';
@@ -16,9 +15,7 @@ import { AgingReportService } from '../../Services/aging-report.service';
 import {
   AgingReportFilter,
   AgingReportResponse,
-  AccountTypeOption,
   SupplierOption,
-  DocumentOption,
 } from '../../Models/AgingReport';
 import { LocalStorageMethods } from '../../../../../../Shared/Methods/local-storage.method';
 import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
@@ -38,7 +35,6 @@ import { TREASURY_HELP } from '../../../../Shared/treasury-help-content';
     ReactiveFormsModule,
     TableModule,
     ButtonModule,
-    InputTextModule,
     CalendarModule,
     DropdownModule,
     CardModule,
@@ -55,10 +51,7 @@ export class AgingReportComponent implements OnInit {
 
   filterForm!: FormGroup;
   reportData: AgingReportResponse | null = null;
-  accountTypeOptions: AccountTypeOption[] = [];
   supplierOptions: SupplierOption[] = [];
-  documentOptions: DocumentOption[] = [];
-  allDocuments: DocumentOption[] = [];
   loading = false;
   exportingPdf = false;
   exportingCsv = false;
@@ -75,14 +68,11 @@ export class AgingReportComponent implements OnInit {
   ngOnInit(): void {
     this.initializeFilterForm();
     this.loadFilterOptions();
-    this.filterForm.get('supplierId')?.valueChanges.subscribe(() => this.onSupplierFilterChange());
   }
 
   initializeFilterForm(): void {
     this.filterForm = this.fb.group({
       supplierId: [null],
-      document: [null],
-      accountCode: [null],
       cutoffDate: [new Date(), Validators.required],
       includeDocuments: [true],
     });
@@ -102,9 +92,6 @@ export class AgingReportComponent implements OnInit {
     this.agingReportService.getFilterOptions(enterpriseId).subscribe({
       next: (options) => {
         this.supplierOptions = options.suppliers;
-        this.allDocuments = options.documents;
-        this.documentOptions = options.documents;
-        this.accountTypeOptions = options.accounts;
         this.onGenerateReport();
       },
       error: () => {
@@ -115,18 +102,6 @@ export class AgingReportComponent implements OnInit {
         });
       },
     });
-  }
-
-  onSupplierFilterChange(): void {
-    const supplierId = this.filterForm.value.supplierId;
-    this.documentOptions = supplierId == null
-      ? this.allDocuments
-      : this.allDocuments.filter((d) => d.supplierId === Number(supplierId));
-
-    const selectedDoc = this.filterForm.value.document;
-    if (selectedDoc && !this.documentOptions.some((d) => d.value === selectedDoc)) {
-      this.filterForm.patchValue({ document: null }, { emitEvent: false });
-    }
   }
 
   onGenerateReport(): void {
@@ -157,8 +132,6 @@ export class AgingReportComponent implements OnInit {
     const filters: AgingReportFilter = {
       supplierId,
       supplierName: supplier?.name,
-      document: this.filterForm.value.document || undefined,
-      accountCode: this.filterForm.value.accountCode,
       cutoffDate: this.filterForm.value.cutoffDate,
       includeDocuments: this.filterForm.value.includeDocuments,
     };
@@ -190,12 +163,9 @@ export class AgingReportComponent implements OnInit {
   clearFilters(): void {
     this.filterForm.reset({
       supplierId: null,
-      document: null,
-      accountCode: null,
       cutoffDate: new Date(),
       includeDocuments: true,
     });
-    this.documentOptions = this.allDocuments;
     this.onGenerateReport();
   }
 

--- a/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
@@ -36,25 +36,9 @@ describe('AgingReportService filter options', () => {
 });
 
 describe('AgingReportService report lines', () => {
-  it('resolves account description using account code from aging API', (done) => {
+  function createService(agingItems: unknown[]) {
     const api = {
-      aging: jasmine.createSpy('aging').and.returnValue(
-        of([
-          {
-            invoiceId: 1,
-            supplierId: 7,
-            reference: 'FC-100',
-            accountCode: '220501',
-            dueDate: '2026-08-01',
-            daysOverdue: 5,
-            current: 100,
-            days1to30: 0,
-            days31to60: 0,
-            days61to90: 0,
-            days91Plus: 0,
-          },
-        ]),
-      ),
+      aging: jasmine.createSpy('aging').and.returnValue(of(agingItems)),
     };
     const accounts = {
       getListAuxiliaryAccounts: jasmine.createSpy('getListAuxiliaryAccounts').and.returnValue(
@@ -62,12 +46,103 @@ describe('AgingReportService report lines', () => {
       ),
     };
     const thirds = {
-      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(of({ content: [] })),
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(
+        of({ content: [{ thId: 7, socialReason: 'Acme Ltda.' }] }),
+      ),
     };
-    const service = new AgingReportService(api as any, accounts as any, thirds as any);
+    return {
+      service: new AgingReportService(api as any, accounts as any, thirds as any),
+      api,
+    };
+  }
 
-    service.getAgingReport('ent-1', { cutoffDate: new Date('2026-08-13'), includeDocuments: true }).subscribe((report) => {
+  it('resolves account description using account code from aging API', (done) => {
+    const { service } = createService([
+      {
+        invoiceId: 1,
+        supplierId: 7,
+        reference: 'FC-100',
+        accountCode: '220501',
+        dueDate: '2026-08-01',
+        daysOverdue: 5,
+        current: 100,
+        days1to30: 0,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+      },
+    ]);
+
+    service.getAgingReport('ent-1', { cutoffDate: new Date(2026, 7, 13), includeDocuments: true }).subscribe((report) => {
       expect(report.lines[0].accountDescription).toBe('220501 - Proveedores nacionales');
+      done();
+    });
+  });
+
+  it('requests all suppliers when supplier filter is empty', (done) => {
+    const { service, api } = createService([]);
+    service.getAgingReport('ent-1', { cutoffDate: new Date(2026, 7, 13) }).subscribe((report) => {
+      expect(api.aging).toHaveBeenCalledWith('ent-1', '2026-08-13', undefined, undefined, undefined);
+      expect(report.supplierName).toBe('Todos los proveedores');
+      done();
+    });
+  });
+
+  it('requests a specific supplier when supplier filter is set', (done) => {
+    const { service, api } = createService([]);
+    service.getAgingReport('ent-1', {
+      supplierId: 7,
+      supplierName: 'Acme Ltda.',
+      cutoffDate: new Date(2026, 7, 13),
+    }).subscribe((report) => {
+      expect(api.aging).toHaveBeenCalledWith('ent-1', '2026-08-13', 7, undefined, undefined);
+      expect(report.supplierName).toBe('Acme Ltda.');
+      done();
+    });
+  });
+
+  it('uses cutoff date for report date and preserves days overdue from API', (done) => {
+    const { service } = createService([
+      {
+        invoiceId: 2,
+        supplierId: 7,
+        reference: 'FC-200',
+        accountCode: '220501',
+        dueDate: '2026-08-01',
+        daysOverdue: 12,
+        current: 0,
+        days1to30: 250,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+      },
+    ]);
+    service.getAgingReport('ent-1', { cutoffDate: new Date(2026, 7, 13) }).subscribe((report) => {
+      expect(report.reportDate.toISOString().slice(0, 10)).toBe('2026-08-13');
+      expect(report.lines[0].daysOverdue).toBe(12);
+      expect(report.lines[0].days1to30).toBe(250);
+      done();
+    });
+  });
+
+  it('exports CSV from report data without document or account filters', (done) => {
+    const { service } = createService([
+      {
+        invoiceId: 3,
+        supplierId: 7,
+        reference: 'FC-300',
+        accountCode: '220501',
+        dueDate: '2026-08-05',
+        daysOverdue: 8,
+        current: 50,
+        days1to30: 0,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+      },
+    ]);
+    service.exportAgingReport('ent-1', { cutoffDate: new Date(2026, 7, 13) }).subscribe((blob) => {
+      expect(blob.type).toContain('text/csv');
       done();
     });
   });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.html
@@ -1,6 +1,5 @@
 <!-- Vendor Reports List -->
 <div class="container-fluid p-4">
-    <!-- Page Header -->
     <div class="flex justify-between items-center mb-6">
         <div>
             <h1 class="text-3xl font-bold text-[var(--color-primary)] mb-2 inline-block">Reportes de Proveedores</h1>
@@ -34,21 +33,26 @@
         </div>
     </div>
 
-    <!-- Filters Card -->
     <p-card header="Filtros de Búsqueda" class="mb-4">
-        <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-
-            <!-- Search Term Filter -->
+        <form [formGroup]="filterForm" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
             <div class="flex flex-col gap-2">
-                <label for="searchTerm" class="font-semibold text-[var(--color-primary)]">Buscar Proveedor</label>
-                <input
-                    pInputText
-                    id="searchTerm"
-                    formControlName="searchTerm"
-                    placeholder="Nombre del proveedor...">
+                <label for="supplierSearch" class="font-semibold text-[var(--color-primary)]">Buscar Proveedor</label>
+                <p-autoComplete
+                    id="supplierSearch"
+                    [(ngModel)]="supplierSelection"
+                    [ngModelOptions]="{ standalone: true }"
+                    [suggestions]="filteredSuppliers"
+                    (completeMethod)="searchSupplier($event)"
+                    field="displayName"
+                    placeholder="Todos los proveedores"
+                    [dropdown]="true"
+                    [showClear]="true"
+                    (onSelect)="onSupplierFilterChange()"
+                    (onClear)="onSupplierFilterChange()"
+                    styleClass="w-full">
+                </p-autoComplete>
             </div>
 
-            <!-- Date From Filter -->
             <div class="flex flex-col gap-2">
                 <label for="dateFrom" class="font-semibold text-[var(--color-primary)]">Desde</label>
                 <p-calendar
@@ -56,11 +60,11 @@
                     formControlName="dateFrom"
                     dateFormat="dd/mm/yy"
                     [showIcon]="true"
-                    placeholder="Fecha desde">
+                    placeholder="Fecha desde"
+                    styleClass="w-full">
                 </p-calendar>
             </div>
 
-            <!-- Date To Filter -->
             <div class="flex flex-col gap-2">
                 <label for="dateTo" class="font-semibold text-[var(--color-primary)]">Hasta</label>
                 <p-calendar
@@ -68,68 +72,36 @@
                     formControlName="dateTo"
                     dateFormat="dd/mm/yy"
                     [showIcon]="true"
-                    placeholder="Fecha hasta">
+                    placeholder="Fecha hasta"
+                    styleClass="w-full">
                 </p-calendar>
             </div>
 
-            <!-- Min Balance Filter -->
             <div class="flex flex-col gap-2">
-                <label for="balanceFrom" class="font-semibold text-[var(--color-primary)]">Saldo Mínimo</label>
-                <p-inputNumber
-                    id="balanceFrom"
-                    formControlName="balanceFrom"
-                    mode="currency"
-                    currency="COP"
-                    locale="es-CO"
-                    placeholder="0">
-                </p-inputNumber>
-            </div>
-
-            <!-- Max Balance Filter -->
-            <div class="flex flex-col gap-2">
-                <label for="balanceTo" class="font-semibold text-[var(--color-primary)]">Saldo Máximo</label>
-                <p-inputNumber
-                    id="balanceTo"
-                    formControlName="balanceTo"
-                    mode="currency"
-                    currency="COP"
-                    locale="es-CO"
-                    placeholder="999999999">
-                </p-inputNumber>
-            </div>
-
-            <!-- Filter Actions -->
-            <div class="flex flex-col gap-2 md:col-span-1 lg:col-span-1">
-                <label class="font-semibold text-[var(--color-primary)]">Acciones</label>
-                <div class="filter-actions filter-buttons-container">
-                    <!-- Clear Filters Button -->
-                    <p-button
-                        label="Limpiar Filtros"
-                        icon="pi pi-filter-slash"
-                        severity="secondary"
-                        [outlined]="true"
-                        size="small"
-                        styleClass="w-full"
-                        pTooltip="Eliminar todos los filtros aplicados"
-                        tooltipPosition="top"
-                        (onClick)="clearFilters()">
-                    </p-button>
-                </div>
+                <label class="font-semibold text-[var(--color-primary)] invisible md:visible">Limpiar</label>
+                <p-button
+                    label="Limpiar filtros"
+                    icon="pi pi-filter-slash"
+                    severity="secondary"
+                    [outlined]="true"
+                    styleClass="w-full"
+                    (onClick)="clearFilters()">
+                </p-button>
             </div>
         </form>
     </p-card>
 
-    <!-- Vendors Table -->
     <p-card header="Lista de Proveedores" class="mb-4">
         <p-table
             [value]="filteredVendors"
             [loading]="loading"
+            [first]="vendorTableFirst"
+            (onPage)="onVendorTablePage($event)"
             [paginator]="true"
             [rows]="10"
             [rowsPerPageOptions]="[5, 10, 20, 50]"
             [showCurrentPageReport]="true"
             currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} proveedores"
-            [globalFilterFields]="['name']"
             styleClass="p-datatable-striped">
 
             <ng-template pTemplate="caption">
@@ -137,17 +109,6 @@
                     <span class="text-lg font-semibold">
                         Total: {{ filteredVendors.length }} proveedores
                     </span>
-                    <div class="flex gap-2">
-                        <span class="p-input-icon-left">
-                            <i class="pi pi-search"></i>
-                            <input
-                                pInputText
-                                type="text"
-                                placeholder="Búsqueda global..."
-                                (input)="$event.target && $any($event.target).value && $any(dt).filterGlobal($any($event.target).value, 'contains')"
-                                #dt>
-                        </span>
-                    </div>
                 </div>
             </ng-template>
 
@@ -213,7 +174,6 @@
                     </td>
                     <td>
                         <div class="flex gap-1">
-                            <!-- View Button -->
                             <p-button
                                 icon="pi pi-eye"
                                 size="small"
@@ -254,7 +214,6 @@
         </p-table>
     </p-card>
 
-    <!-- Summary Statistics -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
         <p-card>
             <div class="text-center">
@@ -289,6 +248,5 @@
         </p-card>
     </div>
 
-    <!-- Toast Messages -->
     <p-toast></p-toast>
 </div>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.spec.ts
@@ -1,0 +1,134 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { VendorListComponent } from './vendor-list.component';
+import { VendorSupplierOption } from '../../Services/vendor-report.service';
+
+describe('VendorListComponent filters', () => {
+  function component() {
+    const vendorReportService = {
+      getProveedores: jasmine.createSpy('getProveedores').and.returnValue(of([
+        supplier(7, 'PEPSI'),
+        supplier(8, 'Proveedor PP8 Local'),
+      ])),
+      getVendorSummaries: jasmine.createSpy('getVendorSummaries').and.returnValue(of([
+        {
+          id: 7,
+          name: 'PEPSI',
+          totalDebits: 100,
+          totalCredits: 500,
+          currentBalance: 400,
+          lastTransactionDate: new Date(2026, 7, 14),
+          transactionCount: 2,
+        },
+      ])),
+    };
+    const messageService = { add: jasmine.createSpy('add') };
+    const exportService = {
+      datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
+      downloadCsv: jasmine.createSpy('downloadCsv'),
+      downloadPdf: jasmine.createSpy('downloadPdf'),
+    };
+    const value = new VendorListComponent(
+      new FormBuilder(),
+      vendorReportService as any,
+      messageService as any,
+      { navigate: jasmine.createSpy('navigate') } as any,
+      exportService as any,
+    );
+    value.ngOnInit();
+    return { value, vendorReportService, messageService, exportService };
+  }
+
+  function supplier(id: number, name: string): VendorSupplierOption {
+    return {
+      thId: id,
+      entId: 'enterprise-a',
+      typeId: {} as any,
+      thirdTypes: [],
+      personType: 'Juridica' as any,
+      idNumber: id,
+      state: true,
+      address: 'addr',
+      phoneNumber: '1',
+      email: 'a@b.com',
+      displayName: name,
+    };
+  }
+
+  it('loads proveedores by type for autocomplete', () => {
+    const { value, vendorReportService } = component();
+    expect(vendorReportService.getProveedores).toHaveBeenCalled();
+    expect(value.allSuppliers.length).toBe(2);
+  });
+
+  it('filters supplier suggestions case-insensitively by prefix', fakeAsync(() => {
+    const { value } = component();
+    value.searchSupplier({ query: 'pep' });
+    tick(300);
+    expect(value.filteredSuppliers.length).toBe(1);
+    expect(value.filteredSuppliers[0].displayName).toBe('PEPSI');
+  }));
+
+  it('reloads report when supplier is selected', () => {
+    const { value, vendorReportService } = component();
+    value.supplierSelection = supplier(7, 'PEPSI');
+    value.onSupplierFilterChange();
+    expect(vendorReportService.getVendorSummaries).toHaveBeenCalledWith(
+      jasmine.objectContaining({ supplierId: 7 }),
+    );
+    expect(value.vendorTableFirst).toBe(0);
+  });
+
+  it('reloads report when dates change', () => {
+    const { value, vendorReportService } = component();
+    value.filterForm.patchValue({
+      dateFrom: new Date(2026, 7, 1),
+      dateTo: new Date(2026, 7, 31),
+    });
+    value.onDateFilterChange();
+    expect(vendorReportService.getVendorSummaries).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        dateFrom: value.filterForm.value.dateFrom,
+        dateTo: value.filterForm.value.dateTo,
+      }),
+    );
+  });
+
+  it('blocks invalid date range', () => {
+    const { value, vendorReportService, messageService } = component();
+    value.filterForm.setValue({
+      dateFrom: new Date(2026, 7, 20),
+      dateTo: new Date(2026, 7, 1),
+    }, { emitEvent: false });
+    const callsBefore = vendorReportService.getVendorSummaries.calls.count();
+    value.onDateFilterChange();
+    expect(messageService.add).toHaveBeenCalled();
+    expect(vendorReportService.getVendorSummaries.calls.count()).toBe(callsBefore);
+  });
+
+  it('clears filters and reloads all vendors', () => {
+    const { value, vendorReportService } = component();
+    value.supplierSelection = supplier(7, 'PEPSI');
+    value.filterForm.patchValue({
+      dateFrom: new Date(2026, 7, 1),
+      dateTo: new Date(2026, 7, 31),
+    });
+    value.clearFilters();
+    expect(value.supplierSelection).toBeNull();
+    expect(value.filterForm.value.dateFrom).toBeNull();
+    const lastFilter = vendorReportService.getVendorSummaries.calls.mostRecent().args[0];
+    expect(lastFilter.supplierId).toBeUndefined();
+    expect(lastFilter.dateFrom).toBeNull();
+    expect(lastFilter.dateTo).toBeNull();
+  });
+
+  it('exports filtered vendors to PDF', () => {
+    const { value, exportService } = component();
+    value.exportToPdf();
+    expect(exportService.downloadPdf).toHaveBeenCalled();
+    const options = exportService.downloadPdf.calls.mostRecent().args[0];
+    expect(options.rows.length).toBe(1);
+    expect(options.rows[0][0]).toBe('PEPSI');
+  });
+});

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-list/vendor-list.component.ts
@@ -1,24 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
 
-// PrimeNG
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { DropdownModule } from 'primeng/dropdown';
 import { CalendarModule } from 'primeng/calendar';
-import { InputNumberModule } from 'primeng/inputnumber';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
-
-// Services and Models
-import { VendorReportService } from '../../Services/vendor-report.service';
-import { VendorReportSummary, VendorListFilter } from '../../Models/VendorReport';
+import { AutoCompleteModule } from 'primeng/autocomplete';
 import { MessageService } from 'primeng/api';
+
+import { VendorReportService, VendorSupplierOption } from '../../Services/vendor-report.service';
+import { VendorReportSummary, VendorListFilter } from '../../Models/VendorReport';
 import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
 import { exportErrorDetail, exportSuccessDetail, reportEmptyFiltersMessage } from '../../../../Shared/treasury-status-labels';
 import { ContextualHelpComponent } from '../../../../../../Shared/Components/contextual-help/contextual-help.component';
@@ -33,64 +30,138 @@ import { TREASURY_HELP } from '../../../../Shared/treasury-help-content';
     ReactiveFormsModule,
     TableModule,
     ButtonModule,
-    InputTextModule,
-    DropdownModule,
     CalendarModule,
-    InputNumberModule,
     CardModule,
     ToastModule,
     TagModule,
     TooltipModule,
+    AutoCompleteModule,
     ContextualHelpComponent,
   ],
   templateUrl: './vendor-list.component.html',
   styleUrls: ['./vendor-list.component.css'],
-  providers: [MessageService]
+  providers: [MessageService],
 })
-export class VendorListComponent implements OnInit {
+export class VendorListComponent implements OnInit, OnDestroy {
+  private static readonly SUPPLIER_SEARCH_DEBOUNCE_MS = 300;
+  private readonly destroy$ = new Subject<void>();
+  private supplierSearchTimer?: ReturnType<typeof setTimeout>;
 
   vendors: VendorReportSummary[] = [];
   filteredVendors: VendorReportSummary[] = [];
-  loading: boolean = false;
-
+  loading = false;
   filterForm!: FormGroup;
   exportingPdf = false;
   exportingCsv = false;
+  vendorTableFirst = 0;
 
-  statusOptions = [
-    { label: 'Todos los proveedores', value: 'all' },
-    { label: 'Con saldo pendiente', value: 'with_balance' },
-    { label: 'Sin saldo pendiente', value: 'no_balance' }
-  ];
+  allSuppliers: VendorSupplierOption[] = [];
+  filteredSuppliers: VendorSupplierOption[] = [];
+  supplierSelection: VendorSupplierOption | null = null;
+
   readonly help = TREASURY_HELP.vendorReports;
 
   constructor(
-    private fb: FormBuilder,
-    private vendorReportService: VendorReportService,
-    private messageService: MessageService,
-    private router: Router,
-    private exportService: TreasuryExportService,
+    private readonly fb: FormBuilder,
+    private readonly vendorReportService: VendorReportService,
+    private readonly messageService: MessageService,
+    private readonly router: Router,
+    private readonly exportService: TreasuryExportService,
   ) {}
 
   ngOnInit(): void {
     this.initializeFilterForm();
+    this.setupReactiveFilters();
+    this.loadSupplierOptions();
     this.loadVendors();
+  }
+
+  ngOnDestroy(): void {
+    if (this.supplierSearchTimer) {
+      clearTimeout(this.supplierSearchTimer);
+    }
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   initializeFilterForm(): void {
     this.filterForm = this.fb.group({
-      searchTerm: [''],
       dateFrom: [null],
       dateTo: [null],
-      balanceFrom: [null],
-      balanceTo: [null],
-      status: ['all']
     });
   }
 
+  setupReactiveFilters(): void {
+    this.filterForm.get('dateFrom')?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onDateFilterChange());
+    this.filterForm.get('dateTo')?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onDateFilterChange());
+  }
+
+  loadSupplierOptions(): void {
+    this.vendorReportService.getProveedores().subscribe({
+      next: (suppliers) => {
+        this.allSuppliers = suppliers;
+        this.filteredSuppliers = suppliers.slice(0, 50);
+      },
+      error: (error) => {
+        console.error('Error al cargar proveedores:', error);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'No se pudieron cargar los proveedores de la empresa',
+        });
+      },
+    });
+  }
+
+  searchSupplier(event: { query?: string }): void {
+    const query = String(event.query ?? '').trim().toLowerCase();
+    if (this.supplierSearchTimer) {
+      clearTimeout(this.supplierSearchTimer);
+    }
+    this.supplierSearchTimer = setTimeout(() => {
+      this.filteredSuppliers = !query
+        ? this.allSuppliers.slice(0, 50)
+        : this.allSuppliers.filter((supplier) =>
+            supplier.displayName.toLowerCase().startsWith(query),
+          );
+    }, VendorListComponent.SUPPLIER_SEARCH_DEBOUNCE_MS);
+  }
+
+  onSupplierFilterChange(): void {
+    this.resetVendorTablePage();
+    this.loadVendors();
+  }
+
+  onDateFilterChange(): void {
+    const { dateFrom, dateTo } = this.filterForm.value;
+    if (dateFrom && dateTo && this.stripTime(dateFrom) > this.stripTime(dateTo)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Rango inválido',
+        detail: 'La fecha Desde no puede ser posterior a la fecha Hasta.',
+      });
+      return;
+    }
+    this.resetVendorTablePage();
+    this.loadVendors();
+  }
+
   loadVendors(): void {
+    const { dateFrom, dateTo } = this.filterForm.value;
+    if (dateFrom && dateTo && this.stripTime(dateFrom) > this.stripTime(dateTo)) {
+      return;
+    }
+
     this.loading = true;
-    const filter: VendorListFilter = this.filterForm.value;
+    const filter: VendorListFilter = {
+      supplierId: this.supplierSelection ? Number(this.supplierSelection.thId) : undefined,
+      dateFrom,
+      dateTo,
+    };
 
     this.vendorReportService.getVendorSummaries(filter).subscribe({
       next: (data) => {
@@ -103,35 +174,43 @@ export class VendorListComponent implements OnInit {
         this.messageService.add({
           severity: 'error',
           summary: 'Error',
-          detail: 'No se pudieron cargar los proveedores'
+          detail: 'No se pudieron cargar los reportes de proveedores',
         });
         this.loading = false;
-      }
+      },
     });
-  }
-
-  applyFilters(): void {
-    this.loadVendors();
   }
 
   clearFilters(): void {
+    this.supplierSelection = null;
+    this.filteredSuppliers = this.allSuppliers.slice(0, 50);
     this.filterForm.reset({
-      searchTerm: '',
       dateFrom: null,
       dateTo: null,
-      balanceFrom: null,
-      balanceTo: null,
-      status: 'all'
     });
+    this.resetVendorTablePage();
     this.loadVendors();
   }
 
+  onVendorTablePage(event: { first?: number }): void {
+    this.vendorTableFirst = event.first ?? 0;
+  }
+
+  private resetVendorTablePage(): void {
+    this.vendorTableFirst = 0;
+  }
+
+  private stripTime(value: Date): Date {
+    const date = new Date(value);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
   viewVendorReport(vendor: VendorReportSummary): void {
-    // Navegar al reporte detallado del proveedor
     this.router.navigate(['/financial/treasury/reports/vendor-report', vendor.id], {
       queryParams: {
-        name: vendor.name
-      }
+        name: vendor.name,
+      },
     });
   }
 
@@ -148,11 +227,11 @@ export class VendorListComponent implements OnInit {
   }
 
   getTotalWithBalance(): number {
-    return this.filteredVendors.filter(v => v.currentBalance > 0).length;
+    return this.filteredVendors.filter((v) => v.currentBalance > 0).length;
   }
 
   getTotalWithoutBalance(): number {
-    return this.filteredVendors.filter(v => v.currentBalance === 0).length;
+    return this.filteredVendors.filter((v) => v.currentBalance === 0).length;
   }
 
   getTotalBalance(): number {
@@ -162,36 +241,32 @@ export class VendorListComponent implements OnInit {
   hasActiveFilters(): boolean {
     const filter = this.filterForm.value;
     return !!(
-      filter.searchTerm?.trim()
+      this.supplierSelection
       || filter.dateFrom
       || filter.dateTo
-      || filter.balanceFrom != null
-      || filter.balanceTo != null
-      || (filter.status && filter.status !== 'all')
     );
   }
 
   getEmptyTitle(): string {
     if (this.vendors.length === 0) {
-      return 'No hay proveedores con facturas pendientes';
+      return 'No hay proveedores registrados';
     }
     if (this.hasActiveFilters()) {
       return 'No se encontraron proveedores que coincidan con la búsqueda';
     }
-    return 'No hay proveedores con facturas pendientes';
+    return 'No hay proveedores registrados';
   }
 
   getEmptySubtitle(): string {
     return this.hasActiveFilters() ? 'Intente ajustar los filtros de búsqueda' : '';
   }
 
-  // Utility methods for consistent formatting
   formatCurrency(amount: number): string {
     return new Intl.NumberFormat('es-CO', {
       style: 'currency',
       currency: 'COP',
       minimumFractionDigits: 0,
-      maximumFractionDigits: 0
+      maximumFractionDigits: 0,
     }).format(amount);
   }
 
@@ -199,7 +274,7 @@ export class VendorListComponent implements OnInit {
     return new Intl.DateTimeFormat('es-CO', {
       year: 'numeric',
       month: '2-digit',
-      day: '2-digit'
+      day: '2-digit',
     }).format(new Date(date));
   }
 

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -12,8 +12,8 @@ export interface VendorReportTransaction {
   date: Date;
   dueDate?: Date;
   reference: string;
-  documentNumber?: string; // Número del documento original (factura, nota, etc.)
-  expenseReceiptNumber?: string; // Número del comprobante de egreso (CE-XXXX)
+  documentNumber?: string;
+  expenseReceiptNumber?: string;
   type: 'Bill' | 'Payment';
   description: string;
   debits: number;
@@ -49,10 +49,7 @@ export interface VendorReport {
 }
 
 export interface VendorListFilter {
-  searchTerm?: string;
+  supplierId?: number;
   dateFrom?: Date;
   dateTo?: Date;
-  balanceFrom?: number;
-  balanceTo?: number;
-  status?: 'all' | 'with_balance' | 'no_balance';
 }

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -1,0 +1,59 @@
+import { of } from 'rxjs';
+import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/ePersonType';
+import { VendorReportService } from './vendor-report.service';
+
+describe('VendorReportService summaries', () => {
+  function service() {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 7,
+        invoiced: 500,
+        paid: 100,
+        pending: 400,
+        invoices: [{ issueDate: '2026-08-14' }],
+        vouchers: [],
+      })),
+    };
+    const thirds = {
+      getThirdsByType: jasmine.createSpy('getThirdsByType').and.returnValue(of({
+        content: [{
+          thId: 7,
+          entId: 'enterprise-a',
+          typeId: {} as any,
+          thirdTypes: [],
+          personType: ePersonType.juridica,
+          socialReason: 'PEPSI',
+          idNumber: 7,
+          state: true,
+          address: 'addr',
+          phoneNumber: '1',
+          email: 'a@b.com',
+        }],
+      })),
+      getThirdParties: jasmine.createSpy('getThirdParties'),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    return { value, api, thirds };
+  }
+
+  it('loads summaries from proveedores by type', (done) => {
+    const { value, thirds } = service();
+    value.getVendorSummaries().subscribe((summaries) => {
+      expect(thirds.getThirdsByType).toHaveBeenCalledWith('enterprise-a', 'Proveedor');
+      expect(summaries.length).toBe(1);
+      expect(summaries[0].name).toBe('PEPSI');
+      done();
+    });
+  });
+
+  it('passes supplier and date filters to statement API', (done) => {
+    const { value, api } = service();
+    const dateFrom = new Date(2026, 7, 1);
+    const dateTo = new Date(2026, 7, 31);
+    value.getVendorSummaries({ supplierId: 7, dateFrom, dateTo }).subscribe(() => {
+      expect(api.statement).toHaveBeenCalledWith('enterprise-a', 7, '2026-08-01', '2026-08-31');
+      done();
+    });
+  });
+});

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -6,9 +6,14 @@ import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { LocalStorageMethods } from '../../../../../Shared/Methods/local-storage.method';
 import { ThirdService } from '../../../../../GeneralMasters/ThirdParties/Services/third.service';
+import { Third } from '../../../../../GeneralMasters/ThirdParties/models/Third';
+import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/ePersonType';
+import { eThirdType } from '../../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { TreasuryApiService } from '../../../Shared/treasury-api.service';
 import { educationalDescription } from '../../../Shared/treasury-status-labels';
 import { VendorListFilter, VendorReport, VendorReportSummary } from '../Models/VendorReport';
+
+export type VendorSupplierOption = Third & { displayName: string };
 
 @Injectable({ providedIn: 'root' })
 export class VendorReportService {
@@ -24,35 +29,47 @@ export class VendorReportService {
     return id;
   }
 
+  getProveedores(): Observable<VendorSupplierOption[]> {
+    return this.thirds.getThirdsByType(this.enterpriseId(), eThirdType.Proveedor).pipe(
+      map((page) => (page.content || []).map((third) => this.toSupplierOption(third))),
+      catchError(() => of([])),
+    );
+  }
+
   getVendorSummaries(filter?: VendorListFilter): Observable<VendorReportSummary[]> {
     const enterpriseId = this.enterpriseId();
-    return forkJoin({
-      payables: this.api.pending(enterpriseId),
-      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(
-        catchError(() => of({ content: [] } as any)),
-      ),
-    }).pipe(
-      switchMap(({ payables, thirds }) => {
-        const thirdNames = new Map<number, string>(
-          (thirds?.content || []).map((t: any) => {
-            const name =
-              (t.socialReason as string) ||
-              [t.names, t.lastNames].filter(Boolean).join(' ') ||
-              `Proveedor ${t.thId}`;
-            return [Number(t.thId), String(name)] as [number, string];
-          }),
+    const from = filter?.dateFrom ? this.toIsoDate(filter.dateFrom) : undefined;
+    const to = filter?.dateTo ? this.toIsoDate(filter.dateTo) : undefined;
+
+    return this.getProveedores().pipe(
+      switchMap((suppliers) => {
+        const selectedId = filter?.supplierId;
+        const targetSuppliers =
+          selectedId != null
+            ? suppliers.filter((supplier) => Number(supplier.thId) === selectedId)
+            : suppliers;
+
+        if (!targetSuppliers.length) {
+          return of([]);
+        }
+
+        const nameById = new Map(
+          targetSuppliers.map((supplier) => [Number(supplier.thId), supplier.displayName]),
         );
-        const supplierIds = [...new Set((payables || []).map((item) => item.supplierId))];
-        if (!supplierIds.length) return of([]);
 
         return forkJoin(
-          supplierIds.map((id) => this.api.statement(enterpriseId, id)),
+          targetSuppliers.map((supplier) =>
+            this.api.statement(enterpriseId, Number(supplier.thId), from, to).pipe(
+              catchError(() => of(null)),
+            ),
+          ),
         ).pipe(
           map((statements) =>
             (statements as any[])
+              .filter(Boolean)
               .map((statement) => ({
                 id: statement.supplierId,
-                name: thirdNames.get(statement.supplierId) || `Proveedor ${statement.supplierId}`,
+                name: nameById.get(statement.supplierId) || `Proveedor ${statement.supplierId}`,
                 totalDebits: statement.paid,
                 totalCredits: statement.invoiced,
                 currentBalance: statement.pending,
@@ -61,29 +78,15 @@ export class VendorReportService {
                     ...(statement.invoices || []).map((invoice: any) =>
                       new Date(invoice.issueDate).getTime(),
                     ),
+                    ...(statement.vouchers || []).map((voucher: any) =>
+                      new Date(voucher.issueDate).getTime(),
+                    ),
                     0,
                   ),
                 ),
                 transactionCount:
                   (statement.invoices?.length || 0) + (statement.vouchers?.length || 0),
-              }))
-              .filter(
-                (item) =>
-                  !filter?.searchTerm ||
-                  item.name.toLowerCase().includes(filter.searchTerm.toLowerCase()),
-              )
-              .filter(
-                (item) => filter?.balanceFrom == null || item.currentBalance >= filter.balanceFrom,
-              )
-              .filter(
-                (item) => filter?.balanceTo == null || item.currentBalance <= filter.balanceTo,
-              )
-              .filter(
-                (item) => filter?.status !== 'with_balance' || item.currentBalance > 0,
-              )
-              .filter(
-                (item) => filter?.status !== 'no_balance' || item.currentBalance === 0,
-              ),
+              })),
           ),
         );
       }),
@@ -390,5 +393,27 @@ export class VendorReportService {
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
     }).format(amount || 0);
+  }
+
+  private toIsoDate(value: Date): string {
+    const date = new Date(value);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private toSupplierOption(third: Third): VendorSupplierOption {
+    return {
+      ...third,
+      displayName: this.thirdDisplayName(third),
+    };
+  }
+
+  private thirdDisplayName(third: Third): string {
+    if (third.personType === ePersonType.natural) {
+      return `${third.names || ''} ${third.lastNames || ''}`.trim() || `Proveedor ${third.thId}`;
+    }
+    return third.socialReason || `Proveedor ${third.thId}`;
   }
 }

--- a/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
@@ -1,0 +1,136 @@
+export interface AccountingMovementViewRow {
+  accountId?: number;
+  accountCode: string;
+  accountName: string;
+  detail: string;
+  debit: number;
+  credit: number;
+  thirdPartyId?: number;
+}
+
+export interface AccountingEntryViewHeader {
+  documentTypeLabel?: string;
+  voucherNumber?: string;
+  supplierLabel?: string;
+  entryCode?: string;
+  entryDate?: string;
+  entryStatus?: string;
+  entryDescription?: string;
+}
+
+export interface AccountingEntryView {
+  header: AccountingEntryViewHeader;
+  movements: AccountingMovementViewRow[];
+}
+
+export interface AccountCatalogueRef {
+  id?: number;
+  code: string;
+  description: string;
+  status?: boolean;
+}
+
+export function buildAccountCatalogueLookup(accounts: AccountCatalogueRef[]): Map<number, { code: string; description: string }> {
+  const lookup = new Map<number, { code: string; description: string }>();
+  accounts.forEach((account) => {
+    if (account.id == null) {
+      return;
+    }
+    lookup.set(Number(account.id), {
+      code: String(account.code),
+      description: String(account.description),
+    });
+  });
+  return lookup;
+}
+
+export function resolveAccountFromLookup(
+  accountRef: unknown,
+  lookup: Map<number, { code: string; description: string }>,
+): { accountId?: number; accountCode: string; accountName: string } {
+  const numericId = Number(accountRef);
+  const isNumericId = accountRef != null && accountRef !== '' && !Number.isNaN(numericId);
+  if (isNumericId && lookup.has(numericId)) {
+    const account = lookup.get(numericId)!;
+    return {
+      accountId: numericId,
+      accountCode: account.code,
+      accountName: account.description,
+    };
+  }
+
+  const raw = String(accountRef ?? '').trim();
+  if (raw) {
+    const byCode = [...lookup.values()].find((account) => account.code === raw);
+    if (byCode) {
+      return {
+        accountCode: byCode.code,
+        accountName: byCode.description,
+      };
+    }
+    if (!isNumericId || raw.length > 4) {
+      return {
+        accountCode: raw,
+        accountName: '—',
+      };
+    }
+    return {
+      accountId: numericId,
+      accountCode: '—',
+      accountName: `Cuenta ${raw}`,
+    };
+  }
+
+  return {
+    accountCode: '—',
+    accountName: '—',
+  };
+}
+
+export function mapAccountingMovementsForView(
+  movements: unknown[],
+  accountLookup: Map<number, { code: string; description: string }>,
+): AccountingMovementViewRow[] {
+  return (movements as Record<string, unknown>[]).map((movement) => {
+    const accountRef = movement['accountCode'] ?? movement['account'] ?? movement['accountId'];
+    const resolved = resolveAccountFromLookup(accountRef, accountLookup);
+    const thirdPartyRaw = movement['thirdPartyId'];
+    const thirdPartyId = thirdPartyRaw != null ? Number(thirdPartyRaw) : undefined;
+    return {
+      accountId: resolved.accountId,
+      accountCode: resolved.accountCode,
+      accountName: resolved.accountName,
+      detail: String(movement['description'] ?? ''),
+      debit: Number(movement['debit'] ?? 0),
+      credit: Number(movement['credit'] ?? 0),
+      thirdPartyId: Number.isNaN(thirdPartyId) ? undefined : thirdPartyId,
+    };
+  });
+}
+
+export function accountingTotalsBalanced(debitTotal: number, creditTotal: number, tolerance = 0.01): boolean {
+  return Math.abs(debitTotal - creditTotal) <= tolerance;
+}
+
+export function buildAccountingEntryView(
+  entry: Record<string, unknown> | null | undefined,
+  movements: AccountingMovementViewRow[],
+  headerContext: Partial<AccountingEntryViewHeader> = {},
+): AccountingEntryView {
+  const entryCode = entry?.['code'];
+  const entryDate = entry?.['date'];
+  const entryStatus = entry?.['status'];
+  const entryDescription = entry?.['description'];
+  return {
+    header: {
+      documentTypeLabel: headerContext.documentTypeLabel,
+      voucherNumber: headerContext.voucherNumber,
+      supplierLabel: headerContext.supplierLabel,
+      entryCode: headerContext.entryCode ?? (entryCode != null ? String(entryCode) : undefined),
+      entryDate: headerContext.entryDate ?? (entryDate != null ? String(entryDate) : undefined),
+      entryStatus: headerContext.entryStatus ?? (entryStatus != null ? String(entryStatus) : undefined),
+      entryDescription: headerContext.entryDescription ?? (entryDescription != null ? String(entryDescription) : undefined),
+    },
+    movements,
+  };
+}

--- a/src/app/Financial/Treasury/Shared/treasury-api.models.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.models.ts
@@ -6,6 +6,10 @@ export interface VoucherRequest {
   enterpriseId: string; issueDate: string; paymentMethodId: number; bankAccountId?: number;
   observations?: string; details: VoucherDetailRequest[];
 }
+export interface ScheduleRequest {
+  enterpriseId: string; executionDate: string; paymentMethodId: number; bankAccountId?: number;
+  observations?: string; details: VoucherDetailRequest[];
+}
 export interface VoucherDetail {
   id: number; supplierId: number; invoiceId: number; invoiceReference: string;
   payableAccountId: number; payableAccountCode: string; previousBalance: number;
@@ -14,7 +18,7 @@ export interface VoucherDetail {
 export interface PaymentVoucher {
   id: number; voucherNumber: string; enterpriseId: string; issueDate: string;
   status: VoucherStatus; paymentMethodId: number; bankAccountId?: number; total: number;
-  observations?: string; accountingEntryId?: number; failureReason?: string; voidReason?: string;
+  observations?: string; accountingEntryId?: number; accountingEntryCode?: string; failureReason?: string; voidReason?: string;
   version: number; details: VoucherDetail[];
 }
 export interface Payable {
@@ -24,10 +28,16 @@ export interface Payable {
   payableAccountId: number; payableAccountCode: string; active: boolean; version: number;
 }
 export interface Page<T> { content: T[]; totalElements: number; totalPages: number; number: number; size: number; }
+export interface ScheduleDetail {
+  id?: number;
+  supplierId: number;
+  invoiceId: number;
+  amount: number;
+}
 export interface PaymentSchedule {
   id: number; enterpriseId: string; executionDate: string; status: ScheduleStatus;
-  paymentMethodId: number; bankAccountId?: number; total: number; observations?: string;
-  retryCount: number; voucherId?: number; failureReason?: string; details: unknown[];
+  paymentMethodId: number; bankAccountId?: number; total?: number; observations?: string;
+  retryCount: number; voucherId?: number; failureReason?: string; details: ScheduleDetail[];
 }
 export interface AgingLine {
   supplierId: number; invoiceId: number; reference: string; accountCode: string; dueDate: string;

--- a/src/app/Financial/Treasury/Shared/treasury-api.service.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { AgingLine, Page, Payable, PaymentSchedule, PaymentVoucher, SupplierStatement, VoucherRequest, VoucherStatus, WriteOffRequest } from './treasury-api.models';
+import { AgingLine, Page, Payable, PaymentSchedule, PaymentVoucher, ScheduleRequest, SupplierStatement, VoucherRequest, VoucherStatus, WriteOffRequest } from './treasury-api.models';
 
 @Injectable({ providedIn: 'root' })
 export class TreasuryApiService {
@@ -34,8 +34,8 @@ export class TreasuryApiService {
     return this.http.patch<Payable>(`${this.base}/payables/${id}/due-date`, { dueDate, reason }, { params: { enterpriseId } });
   }
   schedules(enterpriseId: string) { return this.http.get<PaymentSchedule[]>(`${this.base}/payment-schedules`, { params: { enterpriseId } }); }
-  createSchedule(request: VoucherRequest & { executionDate: string }) { return this.http.post<PaymentSchedule>(`${this.base}/payment-schedules`, request); }
-  updateSchedule(id: number, request: VoucherRequest & { executionDate: string }) { return this.http.put<PaymentSchedule>(`${this.base}/payment-schedules/${id}`, request); }
+  createSchedule(request: ScheduleRequest) { return this.http.post<PaymentSchedule>(`${this.base}/payment-schedules`, request); }
+  updateSchedule(id: number, request: ScheduleRequest) { return this.http.put<PaymentSchedule>(`${this.base}/payment-schedules/${id}`, request); }
   deleteSchedule(id: number) { return this.http.delete<void>(`${this.base}/payment-schedules/${id}`); }
   cancelSchedule(id: number) { return this.http.post<PaymentSchedule>(`${this.base}/payment-schedules/${id}/cancel`, null); }
   retrySchedule(id: number) { return this.http.post<PaymentSchedule>(`${this.base}/payment-schedules/${id}/retry`, null); }

--- a/src/app/Financial/Treasury/Shared/treasury-help-content.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-help-content.ts
@@ -3,15 +3,16 @@ export const TREASURY_HELP = {
   operations: {
     title: 'Operaciones de Tesorería',
     summary:
-      'Consolida obligaciones por pagar, comprobantes de egreso, programaciones y bajas de CxP. ' +
-      'Los métodos de pago activos se vinculan a cuentas contables del catálogo; si un método exige cuenta bancaria, debe seleccionarse antes de pagar.',
+      'Gestione las obligaciones pendientes con proveedores. Desde aquí puede efectuar pagos, programarlos o registrar bajas de cuentas por pagar.\n\n' +
+      'Pagar: registra el pago total o parcial de una obligación pendiente.\n' +
+      'Programar: agenda el pago de una obligación para una fecha determinada.\n' +
+      'Baja CxP: reduce total o parcialmente una obligación sin realizar un pago, utilizando una cuenta contrapartida.',
     slug: 'tesoreria',
   },
   expenseReceipts: {
-    title: 'Comprobantes de egreso',
+    title: 'Comprobantes de Egreso',
     summary:
-      'Registro de pagos a proveedores. Solo aparecen proveedores con facturas pendientes (CxP). ' +
-      'Un abono parcial reduce el saldo; la anulación revierte el comprobante contabilizado.',
+      'Consulte y gestione los comprobantes generados por pagos a proveedores. Puede revisar su estado, consultar el asiento contable, anular cuando corresponda y exportar la información.',
     slug: 'tesoreria',
   },
   makePayment: {
@@ -22,10 +23,10 @@ export const TREASURY_HELP = {
     slug: 'tesoreria',
   },
   paymentSchedule: {
-    title: 'Programación de pagos',
+    title: 'Programación de Pagos',
     summary:
-      'Consulta obligaciones sincronizadas desde Facturación con saldo pendiente. ' +
-      'Permite filtrar por proveedor, estado y vencimiento para planificar pagos.',
+      'Consulte y gestione los pagos de facturas que fueron programados previamente desde Operaciones de Tesorería. ' +
+      'Puede cancelar programaciones pendientes o reintentar las fallidas.',
     slug: 'tesoreria',
   },
   agingReport: {

--- a/src/app/Financial/Treasury/Shared/treasury-payment-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-payment-messages.ts
@@ -1,0 +1,5 @@
+export const NO_ACTIVE_PAYMENT_METHODS_MESSAGE =
+  'No se puede realizar el pago porque la empresa no tiene métodos de pago activos configurados.';
+
+export const NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE =
+  'El método de pago seleccionado requiere una cuenta bancaria activa.';

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
@@ -1,0 +1,49 @@
+import { PaymentSchedule } from './treasury-api.models';
+import { translatePaymentMethodName } from './treasury-status-labels';
+import { resolveSupplierName } from './treasury-third-party.integration';
+
+export function scheduleTotal(item: PaymentSchedule): number {
+  if (item.total != null && !Number.isNaN(Number(item.total))) {
+    return Number(item.total);
+  }
+  return (item.details ?? []).reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
+}
+
+export function scheduleSuppliersLabel(
+  item: PaymentSchedule,
+  supplierNames: Map<number, string>,
+): string {
+  const supplierIds = [...new Set((item.details ?? []).map((detail) => detail.supplierId))];
+  if (!supplierIds.length) {
+    return '—';
+  }
+  if (supplierIds.length === 1) {
+    return resolveSupplierName(supplierNames, supplierIds[0]);
+  }
+  return supplierIds.map((id) => resolveSupplierName(supplierNames, id)).join(', ');
+}
+
+export function scheduleInvoicesLabel(
+  item: PaymentSchedule,
+  payableReferenceById: Map<number, string>,
+  formatMoney: (amount: number) => string,
+): string {
+  const details = item.details ?? [];
+  if (!details.length) {
+    return '—';
+  }
+  return details
+    .map((detail) => {
+      const reference = payableReferenceById.get(detail.invoiceId) ?? `ID ${detail.invoiceId}`;
+      return `${reference} (${formatMoney(Number(detail.amount ?? 0))})`;
+    })
+    .join(', ');
+}
+
+export function scheduleMethodLabel(
+  item: PaymentSchedule,
+  methods: Array<{ id: number; name?: string }>,
+): string {
+  const method = methods.find((entry) => entry.id === Number(item.paymentMethodId));
+  return method ? translatePaymentMethodName(method.name) : `#${item.paymentMethodId}`;
+}

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
@@ -36,6 +36,11 @@ const ACCOUNTING_ENTRY_LABELS: Record<string, string> = {
   VOIDED: 'Anulado',
 };
 
+const ACCOUNTING_SOURCE_TYPE_LABELS: Record<string, string> = {
+  PAYMENT_VOUCHER: 'Comprobante de egreso',
+  PAYABLE_WRITEOFF: 'Baja de cuenta por pagar',
+};
+
 const PAYMENT_METHOD_NAME_LABELS: Record<string, string> = {
   CASH: 'Efectivo',
   TRANSFER: 'Transferencia bancaria',
@@ -71,6 +76,16 @@ export function transactionTypeLabel(type?: string | null): string {
 export function accountingEntryStatusLabel(status?: string | null): string {
   if (!status) return '-';
   return ACCOUNTING_ENTRY_LABELS[status] ?? 'Desconocido';
+}
+
+export function accountingSourceDocumentTypeLabel(type?: string | null): string {
+  if (!type) return '-';
+  return ACCOUNTING_SOURCE_TYPE_LABELS[type] ?? type;
+}
+
+export function scheduleStatusFilterOptions(includeAll = true) {
+  const options = Object.entries(SCHEDULE_LABELS).map(([value, label]) => ({ label, value }));
+  return includeAll ? [{ label: 'Todos los estados', value: '' }, ...options] : options;
 }
 
 export function voucherStatusFilterOptions(includeAll = true) {

--- a/src/app/Financial/Treasury/Shared/treasury-writeoff-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-writeoff-messages.ts
@@ -1,0 +1,17 @@
+export const WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE =
+  'La obligación no tiene saldo disponible para dar de baja.';
+
+export const WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE =
+  'El monto de la baja no puede superar el saldo disponible.';
+
+export const WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE =
+  'Seleccione una cuenta contrapartida.';
+
+export const WRITE_OFF_REASON_REQUIRED_MESSAGE =
+  'Ingrese el motivo de la baja.';
+
+export const WRITE_OFF_AMOUNT_INVALID_MESSAGE =
+  'El monto de la baja debe ser mayor que cero.';
+
+export const WRITE_OFF_CREATE_SUCCESS_MESSAGE =
+  'Baja de CxP creada correctamente. Debe contabilizarla para aplicar la baja.';


### PR DESCRIPTION
## Summary
- Reorganize Treasury Operations: pay/schedule/write-off on obligations; vouchers consultation-only
- Reactive filters on comprobantes (autocomplete proveedor, dates, estado) and vendor reports
- Vendor reports: load proveedores via getThirdsByType; remove saldo min/max filters
- Payment schedules list in Programación; expense receipts list as consultation/export
- Show accounting entry code (AE-PV-*) on vouchers; purchase invoice detail totals
- E2E write-off locator fix for PrimeNG dropdown

## Deploy
Merge to **develop** triggers Docker build to PP8 dev (on-push-to-develop.yml).

## Test plan
- [ ] Reportes de Proveedores: autocomplete proveedor + fechas reactivas
- [x] Operations: filters, write-off dialog, voucher list
- [ ] PDF/CSV export with active filters
- [ ] Angular unit tests pass
- [ ] Optional: payable-writeoff-e2e.spec.ts
