### PR TITLE
fix(purchase): show backend message when save fails

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
@@ -167,4 +167,12 @@ describe('PurchaseInvoiceCreationComponent save state', () => {
       summary: 'Respuesta demorada',
     }));
   }));
+
+  it('shows API message when purchase save fails', () => {
+    const component = Object.create(PurchaseInvoiceCreationComponent.prototype) as any;
+    expect(component.purchaseSaveErrorDetail({
+      error: { message: 'La empresa aún no tiene un catálogo de cuentas válido.' },
+    })).toBe('La empresa aún no tiene un catálogo de cuentas válido.');
+    expect(component.purchaseSaveErrorDetail({})).toBe('No se pudo crear la factura de compra');
+  });
 });

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -347,7 +347,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
           summary: timedOut ? 'Respuesta demorada' : 'Error',
           detail: timedOut
             ? 'El servidor tardó demasiado en responder. Verifique el listado antes de intentar guardar nuevamente.'
-            : 'No se pudo crear la factura de compra',
+            : this.purchaseSaveErrorDetail(error),
         });
       },
     });
@@ -355,6 +355,14 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
 
   cancel(): void {
     this.router.navigate(['/enterprise/list']);
+  }
+
+  private purchaseSaveErrorDetail(error: unknown): string {
+    const apiMessage = (error as { error?: { message?: string } })?.error?.message;
+    if (apiMessage?.trim()) {
+      return apiMessage.trim();
+    }
+    return 'No se pudo crear la factura de compra';
   }
 
   onPaymentTermChange(): void {


### PR DESCRIPTION
## Summary
- Toast on save failure shows API message (e.g. missing catalogue guidance)
- Depends on facture-management PR for new backend messages

## Test plan
- [ ] Save purchase invoice without catalogue shows informative toast
- [ ] purchaseSaveErrorDetail unit test
