### PR TITLE
fix(treasury): guide users when payment methods are missing

### DIFF
--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.html
@@ -163,7 +163,7 @@
                         <small class="p-error error-message">El método de pago es requerido.</small>
                     }
                     @if (paymentMethodOptions.length === 0) {
-                        <small class="text-orange-600">{{ noActivePaymentMethodsMessage }}</small>
+                        <small class="text-orange-600">{{ paymentMethodsHelpMessage }}</small>
                     }
                     <small class="text-gray-500">Métodos configurados en maestros de la empresa</small>
                 </div>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-creation/expense-receipt-creation.component.ts
@@ -34,8 +34,8 @@ import { translatePaymentMethodName } from '../../../Shared/treasury-status-labe
 import { ContextualHelpComponent } from '../../../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../../../Shared/treasury-help-content';
 import {
-  NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
   NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE,
+  paymentMethodsAvailabilityMessage,
 } from '../../../Shared/treasury-payment-messages';
 
 // Modelos adicionales para el frontend
@@ -82,18 +82,22 @@ export class ExpenseReceiptCreationComponent {
   receiptTypes: DropdownOption[] = [];
   paymentMethods: PaymentMethod[] = [];
   paymentMethodOptions: { id: number; label: string; requiresBankAccount: boolean }[] = [];
+  allPaymentMethodsCount = 0;
   bankAccounts: BankAccount[] = [];
   bankAccountOptions: { id: number; label: string }[] = [];
   receiptTypeOptions: DropdownOption[] = [];
   auxiliaryAccounts: DropdownOption[] = [];
   requiresBankAccount = false;
   readonly help = TREASURY_HELP.makePayment;
-  readonly noActivePaymentMethodsMessage = NO_ACTIVE_PAYMENT_METHODS_MESSAGE;
   readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
   readonly supplierEmptyMessage = 'No hay proveedores con facturas pendientes';
   readonly supplierFilterEmptyMessage = 'No se encontraron proveedores que coincidan con la búsqueda';
   supplierSearchQuery = '';
   allSuppliersCount = 0;
+
+  get paymentMethodsHelpMessage(): string {
+    return paymentMethodsAvailabilityMessage(this.allPaymentMethodsCount, this.paymentMethodOptions.length);
+  }
 
   // Para Autocomplete de Proveedor
   suppliers: Supplier[] = [];
@@ -207,8 +211,10 @@ export class ExpenseReceiptCreationComponent {
     }).subscribe({
       next: ({ methods, accounts }) => {
         const activeAccountIds = buildActiveAccountIdSet(accounts);
+        const configured = (methods.content || []).filter((method) => method.status !== false);
+        this.allPaymentMethodsCount = configured.length;
         this.paymentMethods = filterSelectablePaymentMethods(
-          (methods.content || []).filter((method) => method.status !== false),
+          configured,
           activeAccountIds,
         );
         this.paymentMethodOptions = this.paymentMethods.map((method) => ({
@@ -220,7 +226,7 @@ export class ExpenseReceiptCreationComponent {
           this.messageService.add({
             severity: 'warn',
             summary: 'Métodos de pago',
-            detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+            detail: this.paymentMethodsHelpMessage,
             life: 8000,
           });
         }
@@ -462,7 +468,8 @@ export class ExpenseReceiptCreationComponent {
       this.messageService.add({
         severity: 'warn',
         summary: 'Métodos de pago',
-        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
+        detail: this.paymentMethodsHelpMessage,
+        life: 8000,
       });
       return;
     }

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -42,6 +42,12 @@
   </div>
 
   <p-message *ngIf="error" severity="error" [text]="error" styleClass="mb-4 w-full"></p-message>
+  <p-message
+    *ngIf="noActivePaymentMethods && paymentMethodsHelpMessage"
+    severity="warn"
+    [text]="paymentMethodsHelpMessage"
+    styleClass="mb-4 w-full">
+  </p-message>
 
   <div class="treasury-sections">
   <fieldset [disabled]="busy" class="treasury-fieldset">
@@ -582,7 +588,7 @@
           (onChange)="dialogPaymentMethodChanged()">
         </p-dropdown>
         <p *ngIf="noActivePaymentMethods" class="text-orange-600 text-sm m-0">
-          {{ noActivePaymentMethodsMessage }}
+          {{ paymentMethodsHelpMessage }}
         </p>
       </div>
       <div class="flex flex-col gap-2" *ngIf="dialogRequiresBankAccount">
@@ -729,7 +735,7 @@
           (onChange)="schedulePaymentMethodChanged()">
         </p-dropdown>
         <p *ngIf="noActivePaymentMethods" class="text-orange-600 text-sm m-0">
-          {{ noActivePaymentMethodsMessage }}
+          {{ paymentMethodsHelpMessage }}
         </p>
       </div>
       <div class="flex flex-col gap-2" *ngIf="scheduleRequiresBankAccount">

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -98,12 +98,25 @@ describe('TreasuryOperationsComponent PP8', () => {
 
   it('blocks payment dialog when no active payment methods are available', () => {
     const { value } = component();
+    value.allPaymentMethodsCount = 0;
     value.methodOptions = [];
     const messageService = (value as any).messageService;
     value.openPaymentDialog(value.payables[0]);
     expect(value.paymentDialogVisible).toBeFalse();
     expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
       summary: 'Métodos de pago',
+      detail: jasmine.stringMatching(/Métodos de Pago/),
+    }));
+  });
+
+  it('explains inactive accounting accounts when payment methods are filtered out', () => {
+    const { value } = component();
+    value.allPaymentMethodsCount = 2;
+    value.methodOptions = [];
+    const messageService = (value as any).messageService;
+    value.openPaymentDialog(value.payables[0]);
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: jasmine.stringMatching(/cuenta contable activa/),
     }));
   });
 
@@ -115,7 +128,7 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.confirmPayFromDialog();
     const messageService = (value as any).messageService;
     expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
-      detail: 'El método de pago seleccionado requiere una cuenta bancaria activa.',
+      detail: 'No hay cuentas bancarias activas para este método. Configure cuentas bancarias en Maestros Generales → Banco y Cuentas Bancarias.',
     }));
   });
 

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -59,8 +59,8 @@ import {
 import { ContextualHelpComponent } from '../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../Shared/treasury-help-content';
 import {
-  NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
   NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE,
+  paymentMethodsAvailabilityMessage,
 } from '../Shared/treasury-payment-messages';
 import {
   WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
@@ -115,6 +115,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   writeOffs: any[] = [];
   methods: any[] = [];
   methodOptions: { id: number; label: string }[] = [];
+  allPaymentMethodsCount = 0;
   banks: any[] = [];
   accounts: any[] = [];
   bankOptions: { id: number; label: string }[] = [];
@@ -173,7 +174,6 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   dueDateReason = '';
   minDueDate!: Date;
   readonly help = TREASURY_HELP.operations;
-  readonly noActivePaymentMethodsMessage = NO_ACTIVE_PAYMENT_METHODS_MESSAGE;
   readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
   readonly voucherStatusOptions = voucherStatusFilterOptions();
   private supplierNames = new Map<number, string>();
@@ -351,6 +351,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           label: `${account.code} - ${account.description}`
         }));
         const activeAccountIds = buildActiveAccountIdSet(data.accounts);
+        this.allPaymentMethodsCount = data.methods.content?.length ?? 0;
         this.methods = filterSelectablePaymentMethods(
           data.methods.content,
           activeAccountIds,
@@ -565,6 +566,10 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     return this.methodOptions.length === 0;
   }
 
+  get paymentMethodsHelpMessage(): string {
+    return paymentMethodsAvailabilityMessage(this.allPaymentMethodsCount, this.methodOptions.length);
+  }
+
   get dialogBankAccountsUnavailable(): boolean {
     return this.dialogRequiresBankAccount && this.bankOptions.length === 0;
   }
@@ -603,8 +608,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       this.messageService.add({
         severity: 'warn',
         summary: 'Métodos de pago',
-        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
-        life: 6000,
+        detail: this.paymentMethodsHelpMessage,
+        life: 8000,
       });
       return;
     }
@@ -646,8 +651,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       this.messageService.add({
         severity: 'warn',
         summary: 'Métodos de pago',
-        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
-        life: 6000,
+        detail: this.paymentMethodsHelpMessage,
+        life: 8000,
       });
       return;
     }
@@ -964,8 +969,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       this.messageService.add({
         severity: 'warn',
         summary: 'Métodos de pago',
-        detail: NO_ACTIVE_PAYMENT_METHODS_MESSAGE,
-        life: 6000,
+        detail: this.paymentMethodsHelpMessage,
+        life: 8000,
       });
       return false;
     }

--- a/src/app/Financial/Treasury/Shared/treasury-payment-messages.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-payment-messages.spec.ts
@@ -1,0 +1,19 @@
+import {
+  NO_PAYMENT_METHODS_CONFIGURED_MESSAGE,
+  NO_SELECTABLE_PAYMENT_METHODS_MESSAGE,
+  paymentMethodsAvailabilityMessage,
+} from './treasury-payment-messages';
+
+describe('treasury-payment-messages', () => {
+  it('returns empty when selectable payment methods exist', () => {
+    expect(paymentMethodsAvailabilityMessage(3, 2)).toBe('');
+  });
+
+  it('guides to configure payment methods when none exist', () => {
+    expect(paymentMethodsAvailabilityMessage(0, 0)).toBe(NO_PAYMENT_METHODS_CONFIGURED_MESSAGE);
+  });
+
+  it('guides to fix accounting accounts when methods exist but are not selectable', () => {
+    expect(paymentMethodsAvailabilityMessage(2, 0)).toBe(NO_SELECTABLE_PAYMENT_METHODS_MESSAGE);
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-payment-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-payment-messages.ts
@@ -1,5 +1,27 @@
-export const NO_ACTIVE_PAYMENT_METHODS_MESSAGE =
-  'No se puede realizar el pago porque la empresa no tiene métodos de pago activos configurados.';
+export const NO_PAYMENT_METHODS_CONFIGURED_MESSAGE =
+  'La empresa no tiene métodos de pago configurados. Registre y active métodos de pago en '
+  + 'Maestros Generales → Métodos de Pago antes de pagar obligaciones en Tesorería.';
+
+export const NO_SELECTABLE_PAYMENT_METHODS_MESSAGE =
+  'No hay métodos de pago listos para usar. Verifique que cada método tenga una cuenta contable '
+  + 'activa en el catálogo de cuentas.';
+
+/** @deprecated use paymentMethodsAvailabilityMessage */
+export const NO_ACTIVE_PAYMENT_METHODS_MESSAGE = NO_PAYMENT_METHODS_CONFIGURED_MESSAGE;
 
 export const NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE =
-  'El método de pago seleccionado requiere una cuenta bancaria activa.';
+  'No hay cuentas bancarias activas para este método. Configure cuentas bancarias en '
+  + 'Maestros Generales → Banco y Cuentas Bancarias.';
+
+export function paymentMethodsAvailabilityMessage(
+  configuredCount: number,
+  selectableCount: number,
+): string {
+  if (selectableCount > 0) {
+    return '';
+  }
+  if (configuredCount === 0) {
+    return NO_PAYMENT_METHODS_CONFIGURED_MESSAGE;
+  }
+  return NO_SELECTABLE_PAYMENT_METHODS_MESSAGE;
+}


### PR DESCRIPTION
## Summary
- Informative messages when empresa has no payment methods or none are selectable (inactive accounting accounts)
- Warning banner on Operaciones de Tesorería before attempting Pagar/Programar
- Same guidance in expense receipt creation and payment/schedule dialogs
- Improved bank account message pointing to Maestros Generales

## Test plan
- [ ] treasury-payment-messages.spec.ts (3 tests)
- [ ] treasury-operations.component.spec.ts (36 tests PASS)
- [ ] Open Operations with empty payment methods: see banner and toast on Pagar
