### PR TITLE
feat(treasury): payable write-off discard and void UX

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -121,7 +121,7 @@
                   severity="danger"
                   [outlined]="true"
                   [disabled]="!canWriteOffPayable(payable)"
-                  [pTooltip]="!canWriteOffPayable(payable) ? 'La obligación no tiene saldo disponible para dar de baja.' : undefined"
+                  [pTooltip]="writeOffPayableTooltip(payable)"
                   tooltipPosition="top"
                   (onClick)="openWriteOffDialog(payable)">
                 </p-button>
@@ -441,7 +441,7 @@
     </p-table>
   </p-card>
 
-  <p-card header="Bajas de CxP">
+  <p-card header="Bajas de CxP" #writeOffsSection>
     <p-table
       [value]="writeOffs"
       [loading]="busy"
@@ -478,12 +478,25 @@
                 (onClick)="confirmWriteOff(item)">
               </p-button>
               <p-button
+                *ngIf="item.status === 'DRAFT'"
+                label="Descartar borrador"
+                icon="pi pi-trash"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                [pTooltip]="writeOffDiscardTooltip"
+                tooltipPosition="top"
+                (onClick)="discardDraftWriteOff(item)">
+              </p-button>
+              <p-button
                 *ngIf="item.status === 'POSTED' || item.status === 'VOID_FAILED'"
                 [label]="item.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular'"
                 icon="pi pi-times"
                 size="small"
                 severity="danger"
                 [outlined]="true"
+                [pTooltip]="writeOffVoidTooltip"
+                tooltipPosition="top"
                 (onClick)="voidWriteOff(item)">
               </p-button>
             </div>
@@ -953,6 +966,48 @@
         [loading]="busy"
         [disabled]="busy"
         (onClick)="confirmWriteOffFromDialog()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Descartar borrador"
+  [(visible)]="writeOffDiscardDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(440px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelDiscardWriteOffDialog()">
+  <div class="flex flex-col gap-3" *ngIf="writeOffDiscardTarget">
+    <p class="text-sm text-gray-700 m-0">
+      ¿Desea descartar esta baja de CxP? La obligación no será modificada.
+    </p>
+    <div class="rounded border border-gray-200 bg-gray-50 p-3 text-sm">
+      <div class="flex justify-between gap-2">
+        <span class="text-gray-500">Monto</span>
+        <span class="font-semibold">{{ writeOffDiscardTarget.total | currency:'COP' }}</span>
+      </div>
+      <div class="flex justify-between gap-2 mt-2" *ngIf="writeOffDiscardTarget.reason">
+        <span class="text-gray-500">Motivo</span>
+        <span class="text-right">{{ writeOffDiscardTarget.reason }}</span>
+      </div>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cancelar"
+        severity="secondary"
+        [outlined]="true"
+        (onClick)="cancelDiscardWriteOffDialog()">
+      </p-button>
+      <p-button
+        label="Descartar borrador"
+        icon="pi pi-trash"
+        severity="danger"
+        [disabled]="busy"
+        (onClick)="confirmDiscardWriteOff()">
       </p-button>
     </div>
   </ng-template>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -7,7 +7,14 @@ import {
   WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
   WRITE_OFF_CREATE_SUCCESS_MESSAGE,
   WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+  WRITE_OFF_PENDING_BLOCK_MESSAGE,
+  WRITE_OFF_POST_FAILED_MESSAGE,
+  WRITE_OFF_POSTED_PARTIAL_MESSAGE,
+  WRITE_OFF_POSTED_TOTAL_MESSAGE,
   WRITE_OFF_REASON_REQUIRED_MESSAGE,
+  WRITE_OFF_DISCARD_SUCCESS_MESSAGE,
+  WRITE_OFF_VOIDED_MESSAGE,
+  WRITE_OFF_VOID_FAILED_MESSAGE,
 } from '../Shared/treasury-writeoff-messages';
 
 describe('TreasuryOperationsComponent PP8', () => {
@@ -17,12 +24,14 @@ describe('TreasuryOperationsComponent PP8', () => {
       createSchedule: jasmine.createSpy('createSchedule').and.returnValue(NEVER),
       createWriteOff: jasmine.createSpy('createWriteOff').and.returnValue(NEVER),
       confirmWriteOff: jasmine.createSpy('confirmWriteOff').and.returnValue(NEVER),
+      discardWriteOff: jasmine.createSpy('discardWriteOff').and.returnValue(NEVER),
       voidWriteOff: jasmine.createSpy('voidWriteOff').and.returnValue(NEVER),
       changeDueDate: jasmine.createSpy('changeDueDate').and.returnValue(of({})),
       pending: jasmine.createSpy('pending').and.returnValue(of([])),
       vouchers: jasmine.createSpy('vouchers').and.returnValue(of({ content: [] })),
       schedules: jasmine.createSpy('schedules').and.returnValue(of([])),
       writeOffs: jasmine.createSpy('writeOffs').and.returnValue(of([])),
+      writeOff: jasmine.createSpy('writeOff').and.returnValue(of({ id: 1, status: 'POSTED', total: 100 })),
     };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const exportService = {
@@ -282,6 +291,96 @@ describe('TreasuryOperationsComponent PP8', () => {
     expect(value.canWriteOffPayable(zeroBalance)).toBeFalse();
   });
 
+  it('disables write-off when obligation has active DRAFT write-off', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 279, pendingAmount: 279 });
+    value.writeOffs = [{
+      id: 4,
+      status: 'DRAFT',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeFalse();
+    expect(value.writeOffPayableTooltip(target)).toBe(WRITE_OFF_PENDING_BLOCK_MESSAGE);
+  });
+
+  it('disables write-off when obligation has POSTING write-off', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 279, pendingAmount: 279 });
+    value.writeOffs = [{
+      id: 5,
+      status: 'POSTING',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeFalse();
+  });
+
+  it('re-enables write-off after VOIDED draft on same obligation', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 279, pendingAmount: 279 });
+    value.writeOffs = [{
+      id: 6,
+      status: 'VOIDED',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeTrue();
+  });
+
+  it('re-enables write-off after POSTED partial write-off when balance remains', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 179, pendingAmount: 179 });
+    value.writeOffs = [{
+      id: 7,
+      status: 'POSTED',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeTrue();
+  });
+
+  it('re-enables write-off after FAILED write-off when balance available', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 279, pendingAmount: 279 });
+    value.writeOffs = [{
+      id: 8,
+      status: 'FAILED',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeTrue();
+  });
+
+  it('blocks opening dialog when active write-off exists', () => {
+    const { value } = component();
+    const messageService = (value as any).messageService;
+    const target = payable({ id: 11, availableAmount: 279 });
+    value.writeOffs = [{
+      id: 9,
+      status: 'DRAFT',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    value.openWriteOffDialog(target);
+    expect(value.writeOffDialogVisible).toBeFalse();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_PENDING_BLOCK_MESSAGE,
+    }));
+  });
+
+  it('keeps write-off disabled after reload when DRAFT exists', () => {
+    const { value } = component();
+    const target = payable({ id: 11, availableAmount: 279 });
+    value.writeOffs = [{
+      id: 10,
+      status: 'DRAFT',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeFalse();
+  });
+
   it('opens write-off dialog with obligation context and readonly labels', () => {
     const { value } = component();
     const target = payable({ availableAmount: 500, pendingAmount: 500, originalAmount: 500 });
@@ -412,10 +511,10 @@ describe('TreasuryOperationsComponent PP8', () => {
     expect(payload.details[0].payableAccountCode).toBeUndefined();
   });
 
-  it('shows success message and reloads write-offs after creation', () => {
+  it('shows success message and reloads write-offs after creation', fakeAsync(() => {
     const { value, api } = component();
     const messageService = (value as any).messageService;
-    api.createWriteOff.and.returnValue(of({ id: 12, status: 'DRAFT', total: 100 }));
+    api.createWriteOff.and.returnValue(of({ id: 12, status: 'DRAFT', total: 100, reason: 'Motivo' }));
     api.writeOffs.and.returnValue(of([{ id: 12, status: 'DRAFT', total: 100, reason: 'Motivo' }]));
     const target = payable();
     value.openWriteOffDialog(target);
@@ -423,10 +522,162 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.writeOffCounterpartAccountId = 4295;
     value.writeOffReason = 'Motivo';
     value.confirmWriteOffFromDialog();
+    tick();
     expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
       detail: WRITE_OFF_CREATE_SUCCESS_MESSAGE,
     }));
     expect(api.writeOffs).toHaveBeenCalledWith('enterprise-a');
+    expect(value.writeOffs.some((item) => item.id === 12)).toBeTrue();
+  }));
+
+  it('keeps payable visible after creating DRAFT write-off reload', fakeAsync(() => {
+    const { value, api } = component();
+    const target = payable({ availableAmount: 279, pendingAmount: 279 });
+    value.payables = [target];
+    api.createWriteOff.and.returnValue(of({ id: 13, status: 'DRAFT', total: 100 }));
+    api.writeOffs.and.returnValue(of([{ id: 13, status: 'DRAFT', total: 100 }]));
+    api.pending.and.returnValue(of([target]));
+    value.openWriteOffDialog(target);
+    value.writeOffAmount = 100;
+    value.writeOffCounterpartAccountId = 4295;
+    value.writeOffReason = 'Parcial';
+    value.confirmWriteOffFromDialog();
+    tick();
+    expect(value.payables.some((item) => item.id === target.id)).toBeTrue();
+    expect(value.payables[0].availableAmount).toBe(279);
+  }));
+
+  it('shows partial success message when obligation remains after posting write-off', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable({ id: 11, availableAmount: 179, pendingAmount: 179 });
+    api.confirmWriteOff.and.returnValue(of({ id: 20, status: 'POSTING', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] }));
+    api.writeOff.and.returnValue(of({ id: 20, status: 'POSTED', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] }));
+    api.pending.and.returnValue(of([target]));
+    api.writeOffs.and.returnValue(of([{ id: 20, status: 'POSTED', total: 100 }]));
+    value.confirmWriteOff({ id: 20, status: 'DRAFT', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] });
+    tick();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_POSTED_PARTIAL_MESSAGE,
+    }));
+    expect(value.payables.some((item) => item.id === 11)).toBeTrue();
+  }));
+
+  it('shows total success message and removes payable when balance reaches zero', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable({ id: 11, availableAmount: 179, pendingAmount: 179 });
+    value.payables = [target];
+    api.confirmWriteOff.and.returnValue(of({ id: 21, status: 'POSTING', total: 179, details: [{ invoiceId: 11, supplierId: 7, amount: 179 }] }));
+    api.writeOff.and.returnValue(of({ id: 21, status: 'POSTED', total: 179, details: [{ invoiceId: 11, supplierId: 7, amount: 179 }] }));
+    api.pending.and.returnValue(of([]));
+    api.writeOffs.and.returnValue(of([{ id: 21, status: 'POSTED', total: 179 }]));
+    value.confirmWriteOff({ id: 21, status: 'DRAFT', total: 179, details: [{ invoiceId: 11, supplierId: 7, amount: 179 }] });
+    tick();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_POSTED_TOTAL_MESSAGE,
+    }));
+    expect(value.payables.length).toBe(0);
+  }));
+
+  it('shows failure message when write-off posting is rejected', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.payables = [target];
+    api.confirmWriteOff.and.returnValue(of({ id: 22, status: 'POSTING', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] }));
+    api.writeOff.and.returnValue(of({ id: 22, status: 'FAILED', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] }));
+    api.pending.and.returnValue(of([target]));
+    api.writeOffs.and.returnValue(of([{ id: 22, status: 'FAILED', total: 100 }]));
+    value.confirmWriteOff({ id: 22, status: 'DRAFT', total: 100, details: [{ invoiceId: 11, supplierId: 7, amount: 100 }] });
+    tick();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_POST_FAILED_MESSAGE,
+    }));
+    expect(value.payables[0].availableAmount).toBe(500);
+  }));
+
+  it('discard draft shows modal and discards without changing payables', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    const target = payable();
+    value.payables = [target];
+    const draft = { id: 23, status: 'DRAFT', total: 100 };
+    api.discardWriteOff.and.returnValue(of({ id: 23, status: 'VOIDED', total: 100 }));
+    api.writeOffs.and.returnValue(of([{ id: 23, status: 'VOIDED', total: 100 }]));
+    api.pending.and.returnValue(of([target]));
+    value.discardDraftWriteOff(draft);
+    expect(value.writeOffDiscardDialogVisible).toBeTrue();
+    value.confirmDiscardWriteOff();
+    tick();
+    expect(api.discardWriteOff).toHaveBeenCalledWith(23);
+    expect(api.voidWriteOff).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_DISCARD_SUCCESS_MESSAGE,
+    }));
+    expect(value.payables[0].availableAmount).toBe(500);
+  }));
+
+  it('cancel discard modal does not call API', () => {
+    const { value, api } = component();
+    value.discardDraftWriteOff({ id: 23, status: 'DRAFT', total: 100 });
+    expect(value.writeOffDiscardDialogVisible).toBeTrue();
+    value.cancelDiscardWriteOffDialog();
+    expect(value.writeOffDiscardDialogVisible).toBeFalse();
+    expect(api.discardWriteOff).not.toHaveBeenCalled();
+    expect(api.voidWriteOff).not.toHaveBeenCalled();
+  });
+
+  it('voidWriteOff polls until VOIDED and refreshes list without page reload', fakeAsync(() => {
+    const { value, api } = component();
+    const messageService = (value as any).messageService;
+    api.voidWriteOff.and.returnValue(of({ id: 30, status: 'VOIDING', total: 100 }));
+    api.writeOff.and.returnValues(
+      of({ id: 30, status: 'VOIDING', total: 100 }),
+      of({ id: 30, status: 'VOIDED', total: 100 }),
+    );
+    api.writeOffs.and.returnValue(of([{ id: 30, status: 'VOIDED', total: 100 }]));
+    api.pending.and.returnValue(of([]));
+    value.voidWriteOff({ id: 30, status: 'POSTED', total: 100 });
+    tick(2000);
+    tick(2000);
+    expect(api.voidWriteOff).toHaveBeenCalledWith(30);
+    expect(api.discardWriteOff).not.toHaveBeenCalled();
+    expect(value.writeOffs[0].status).toBe('VOIDED');
+    expect(messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: WRITE_OFF_VOIDED_MESSAGE,
+    }));
+  }));
+
+  it('re-enables write-off button after discarding draft write-off', fakeAsync(() => {
+    const { value, api } = component();
+    const target = payable({ id: 11, availableAmount: 279, pendingAmount: 279 });
+    value.payables = [target];
+    value.writeOffs = [{
+      id: 31,
+      status: 'DRAFT',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    }];
+    expect(value.canWriteOffPayable(target)).toBeFalse();
+    const draft = {
+      id: 31,
+      status: 'DRAFT',
+      total: 100,
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    };
+    api.discardWriteOff.and.returnValue(of({ id: 31, status: 'VOIDED', total: 100 }));
+    api.writeOffs.and.returnValue(of([{ id: 31, status: 'VOIDED', total: 100 }]));
+    api.pending.and.returnValue(of([target]));
+    value.discardDraftWriteOff(draft);
+    value.confirmDiscardWriteOff();
+    tick();
+    expect(value.canWriteOffPayable(target)).toBeTrue();
+  }));
+
+  it('disables write-off action when available balance is zero', () => {
+    const { value } = component();
+    expect(value.canWriteOffPayable(payable({ availableAmount: 0, pendingAmount: 0 }))).toBeFalse();
   });
 
   it('shows accounting entry code from API in voucher table label', () => {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { forkJoin, Observable, of, Subject, timer, TimeoutError } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, finalize, switchMap, take, takeUntil, takeWhile, timeout } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, finalize, map, switchMap, take, takeUntil, takeWhile, timeout } from 'rxjs/operators';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -25,7 +25,7 @@ import { ChartAccountService } from '../../../GeneralMasters/AccountCatalogue/se
 import { BankAccountsService } from '../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
 import { ThirdService } from '../../../GeneralMasters/ThirdParties/Services/third.service';
 import { TreasuryApiService } from '../Shared/treasury-api.service';
-import { Payable, PaymentSchedule, PaymentVoucher } from '../Shared/treasury-api.models';
+import { Payable, PayableWriteOff, PaymentSchedule, PaymentVoucher } from '../Shared/treasury-api.models';
 import {
   accountingEntryStatusLabel,
   accountingSourceDocumentTypeLabel,
@@ -68,8 +68,18 @@ import {
   WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
   WRITE_OFF_CREATE_SUCCESS_MESSAGE,
   WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE,
+  WRITE_OFF_PENDING_BLOCK_MESSAGE,
+  WRITE_OFF_POST_FAILED_MESSAGE,
+  WRITE_OFF_POSTED_PARTIAL_MESSAGE,
+  WRITE_OFF_POSTED_TOTAL_MESSAGE,
   WRITE_OFF_REASON_REQUIRED_MESSAGE,
+  WRITE_OFF_DISCARD_SUCCESS_MESSAGE,
+  WRITE_OFF_DISCARD_TOOLTIP,
+  WRITE_OFF_VOID_TOOLTIP,
+  WRITE_OFF_VOIDED_MESSAGE,
+  WRITE_OFF_VOID_FAILED_MESSAGE,
 } from '../Shared/treasury-writeoff-messages';
+import { hasActiveWriteOffForInvoice } from '../Shared/treasury-writeoff-availability';
 import { ExpenseReceiptService } from '../ExpenseReceipts/Service/expense-receipt.service';
 import { Supplier } from '../ExpenseReceipts/Model/Models';
 
@@ -108,11 +118,13 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private readonly voucherNumberFilter$ = new Subject<string>();
 
+  @ViewChild('writeOffsSection') writeOffsSection?: ElementRef<HTMLElement>;
+
   payables: Payable[] = [];
   vouchers: PaymentVoucher[] = [];
   allVouchers: PaymentVoucher[] = [];
   schedules: PaymentSchedule[] = [];
-  writeOffs: any[] = [];
+  writeOffs: PayableWriteOff[] = [];
   methods: any[] = [];
   methodOptions: { id: number; label: string }[] = [];
   allPaymentMethodsCount = 0;
@@ -126,6 +138,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   ];
   minExecutionDate!: Date;
   writeOffDialogVisible = false;
+  writeOffDiscardDialogVisible = false;
+  writeOffDiscardTarget?: PayableWriteOff;
   writeOffTarget?: Payable;
   writeOffAmount?: number;
   writeOffCounterpartAccountId?: number;
@@ -166,6 +180,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   accountingCreditTotal = 0;
   busy = false;
   error = '';
+  readonly writeOffDiscardTooltip = WRITE_OFF_DISCARD_TOOLTIP;
+  readonly writeOffVoidTooltip = WRITE_OFF_VOID_TOOLTIP;
   exportingPdf = false;
   exportingCsv = false;
   dueDateDialogVisible = false;
@@ -322,13 +338,13 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     this.busy = true;
     this.error = '';
     forkJoin({
-      payables: this.api.pending(this.enterpriseId),
-      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }),
-      schedules: this.api.schedules(this.enterpriseId),
-      writeOffs: this.api.writeOffs(this.enterpriseId),
-      methods: this.paymentMethods.findAllActive(this.enterpriseId),
-      banks: this.bankAccounts.findAllActive(this.enterpriseId),
-      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId),
+      payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
+      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }).pipe(catchError(() => of({ content: this.allVouchers } as any))),
+      schedules: this.api.schedules(this.enterpriseId).pipe(catchError(() => of(this.schedules))),
+      writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
+      methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
+      banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
+      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
       thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(
         catchError(() => of({ content: [] } as any)),
       ),
@@ -339,7 +355,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         this.allVouchers = data.vouchers.content;
         this.applyVoucherFilters();
         this.schedules = data.schedules;
-        this.writeOffs = data.writeOffs;
+        this.writeOffs = this.normalizeWriteOffList(data.writeOffs);
         this.banks = data.banks.content;
         this.bankOptions = this.banks.map((bank: any) => ({
           id: bank.id,
@@ -406,8 +422,24 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     }
   }
 
+  hasActiveWriteOffForPayable(payable: Payable): boolean {
+    return hasActiveWriteOffForInvoice(this.writeOffs, payable.id);
+  }
+
   canWriteOffPayable(payable: Payable): boolean {
-    return payable.active && Number(payable.availableAmount) > 0;
+    return payable.active
+      && Number(payable.availableAmount) > 0
+      && !this.hasActiveWriteOffForPayable(payable);
+  }
+
+  writeOffPayableTooltip(payable: Payable): string | undefined {
+    if (!payable.active || Number(payable.availableAmount) <= 0) {
+      return WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE;
+    }
+    if (this.hasActiveWriteOffForPayable(payable)) {
+      return WRITE_OFF_PENDING_BLOCK_MESSAGE;
+    }
+    return undefined;
   }
 
   payableAccountLabel(payable: Payable): string {
@@ -421,7 +453,16 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   openWriteOffDialog(payable: Payable) {
-    if (!this.canWriteOffPayable(payable)) {
+    if (this.hasActiveWriteOffForPayable(payable)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Baja pendiente',
+        detail: WRITE_OFF_PENDING_BLOCK_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
+    if (!payable.active || Number(payable.availableAmount) <= 0) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Sin saldo',
@@ -488,6 +529,16 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       });
       return;
     }
+    const accountCode = this.resolveAccountCode(account);
+    if (!accountCode) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Cuenta contrapartida',
+        detail: 'La cuenta seleccionada no tiene código contable válido.',
+        life: 5000,
+      });
+      return;
+    }
     const reason = (this.writeOffReason ?? '').trim();
     if (!reason) {
       this.messageService.add({
@@ -504,15 +555,17 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         enterpriseId: this.enterpriseId,
         reason,
         counterpartAccountId: account.id,
-        counterpartAccountCode: account.code,
+        counterpartAccountCode: accountCode,
         details: [{
           supplierId: payable.supplierId,
           invoiceId: payable.id,
           amount,
         }],
       }),
-      () => {
+      (created) => {
+        this.upsertWriteOff(created);
         this.cancelWriteOffDialog();
+        this.scrollToWriteOffsSection();
         return {
           summary: 'Baja de CxP',
           detail: WRITE_OFF_CREATE_SUCCESS_MESSAGE,
@@ -1134,14 +1187,194 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
 
   cancel(schedule: PaymentSchedule) { this.run(this.api.cancelSchedule(schedule.id)); }
   retry(schedule: PaymentSchedule) { this.run(this.api.retrySchedule(schedule.id)); }
-  confirmWriteOff(item: any) {
-    this.run(this.api.confirmWriteOff(item.id), () => ({
-      summary: 'Baja contabilizada',
-      detail: 'La baja de CxP fue enviada a contabilización.',
-      life: 6000,
+
+  confirmWriteOff(item: PayableWriteOff) {
+    const invoiceId = this.writeOffInvoiceId(item);
+    this.busy = true;
+    this.error = '';
+    this.api.confirmWriteOff(item.id).pipe(
+      timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
+      switchMap((confirmed) => this.waitForWriteOffPosting(confirmed.id ?? item.id)),
+      switchMap((updated) => forkJoin({
+        payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
+        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
+      }).pipe(map((data) => ({ updated, ...data })))),
+      finalize(() => {
+        this.busy = false;
+      }),
+    ).subscribe({
+      next: ({ updated, payables, writeOffs }) => {
+        this.payables = payables;
+        this.writeOffs = this.normalizeWriteOffList(writeOffs);
+        if (updated.status === 'POSTED') {
+          const stillPending = invoiceId != null
+            ? payables.some((payable) => payable.id === invoiceId)
+            : true;
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Baja contabilizada',
+            detail: stillPending ? WRITE_OFF_POSTED_PARTIAL_MESSAGE : WRITE_OFF_POSTED_TOTAL_MESSAGE,
+            life: 8000,
+          });
+        } else if (updated.status === 'FAILED') {
+          this.error = WRITE_OFF_POST_FAILED_MESSAGE;
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Contabilización fallida',
+            detail: WRITE_OFF_POST_FAILED_MESSAGE,
+            life: 8000,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Contabilización en proceso',
+            detail: `La baja sigue en estado ${this.writeOffLabel(updated.status)}. Actualice en unos segundos.`,
+            life: 8000,
+          });
+        }
+      },
+      error: (err: unknown) => this.handleOperationError(err, 'contabilizar la baja de CxP'),
+    });
+  }
+
+  discardDraftWriteOff(item: PayableWriteOff) {
+    this.writeOffDiscardTarget = item;
+    this.writeOffDiscardDialogVisible = true;
+  }
+
+  cancelDiscardWriteOffDialog() {
+    this.writeOffDiscardDialogVisible = false;
+    this.writeOffDiscardTarget = undefined;
+  }
+
+  confirmDiscardWriteOff() {
+    const item = this.writeOffDiscardTarget;
+    if (!item?.id) {
+      return;
+    }
+    this.writeOffDiscardDialogVisible = false;
+    this.writeOffDiscardTarget = undefined;
+    this.run(this.api.discardWriteOff(item.id), () => ({
+      summary: 'Borrador descartado',
+      detail: WRITE_OFF_DISCARD_SUCCESS_MESSAGE,
+      life: 8000,
     }));
   }
-  voidWriteOff(item: any) { this.run(this.api.voidWriteOff(item.id)); }
+
+  voidWriteOff(item: PayableWriteOff) {
+    this.busy = true;
+    this.error = '';
+    this.api.voidWriteOff(item.id).pipe(
+      timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
+      switchMap((voided) => {
+        const writeOffId = voided.id ?? item.id;
+        if (voided.status === 'VOIDING') {
+          return this.waitForWriteOffVoiding(writeOffId);
+        }
+        return of(voided);
+      }),
+      switchMap((updated) => forkJoin({
+        payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
+        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
+      }).pipe(map((data) => ({ updated, ...data })))),
+      finalize(() => {
+        this.busy = false;
+      }),
+    ).subscribe({
+      next: ({ updated, payables, writeOffs }) => {
+        this.payables = payables;
+        this.writeOffs = this.normalizeWriteOffList(writeOffs);
+        if (updated.status === 'VOIDED') {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Baja anulada',
+            detail: WRITE_OFF_VOIDED_MESSAGE,
+            life: 8000,
+          });
+        } else if (updated.status === 'VOID_FAILED') {
+          this.error = WRITE_OFF_VOID_FAILED_MESSAGE;
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Anulación fallida',
+            detail: WRITE_OFF_VOID_FAILED_MESSAGE,
+            life: 8000,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Anulación en proceso',
+            detail: `La baja sigue en estado ${this.writeOffLabel(updated.status)}. Actualice en unos segundos.`,
+            life: 8000,
+          });
+        }
+      },
+      error: (err: unknown) => this.handleOperationError(err, 'anular la baja de CxP'),
+    });
+  }
+
+  private writeOffInvoiceId(item: PayableWriteOff): number | undefined {
+    const detail = item.details?.[0];
+    return detail?.invoiceId != null ? Number(detail.invoiceId) : undefined;
+  }
+
+  private waitForWriteOffPosting(writeOffId: number) {
+    return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
+      take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
+      switchMap(() => this.api.writeOff(writeOffId)),
+      takeWhile((writeOff) => writeOff.status === 'POSTING', true),
+    );
+  }
+
+  private waitForWriteOffVoiding(writeOffId: number) {
+    return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
+      take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
+      switchMap(() => this.api.writeOff(writeOffId)),
+      takeWhile((writeOff) => writeOff.status === 'VOIDING', true),
+    );
+  }
+
+  private resolveAccountCode(account: { code?: string; codeAccount?: string }): string {
+    return String(account.code ?? account.codeAccount ?? '').trim();
+  }
+
+  private normalizeWriteOff(raw: PayableWriteOff | Record<string, unknown>): PayableWriteOff {
+    const record = raw as Record<string, unknown>;
+    const rawStatus = record['status'];
+    const status = typeof rawStatus === 'string' ? rawStatus : 'DRAFT';
+    return {
+      ...(raw as PayableWriteOff),
+      id: Number(record['id']),
+      total: Number(record['total'] ?? 0),
+      status,
+    };
+  }
+
+  private normalizeWriteOffList(items: PayableWriteOff[]): PayableWriteOff[] {
+    return (items ?? []).map((item) => this.normalizeWriteOff(item));
+  }
+
+  private upsertWriteOff(raw: PayableWriteOff): void {
+    if (!raw?.id) {
+      return;
+    }
+    const item = this.normalizeWriteOff(raw);
+    const index = this.writeOffs.findIndex((entry) => entry.id === item.id);
+    if (index >= 0) {
+      this.writeOffs = [
+        ...this.writeOffs.slice(0, index),
+        item,
+        ...this.writeOffs.slice(index + 1),
+      ];
+      return;
+    }
+    this.writeOffs = [item, ...this.writeOffs];
+  }
+
+  private scrollToWriteOffsSection(): void {
+    setTimeout(() => {
+      this.writeOffsSection?.nativeElement?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+    }, 150);
+  }
 
   openDueDateDialog(payable: Payable) {
     this.dueDateTarget = payable;
@@ -1235,11 +1468,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     this.error = '';
     request.pipe(
       timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
-      finalize(() => {
-        this.busy = false;
-      }),
-    ).subscribe({
-      next: (result: any) => {
+      switchMap((result: any) => {
         if (onSuccess) {
           const message = onSuccess(result);
           this.messageService.add({
@@ -1249,10 +1478,63 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
             life: message.life ?? 6000,
           });
         }
-        this.reload();
-      },
+        return this.api.writeOffs(this.enterpriseId).pipe(
+          catchError(() => of(this.writeOffs)),
+          switchMap((writeOffs) => {
+            this.writeOffs = this.normalizeWriteOffList(writeOffs);
+            return this.reloadCoreData();
+          }),
+        );
+      }),
+      finalize(() => {
+        this.busy = false;
+      }),
+    ).subscribe({
+      next: () => undefined,
       error: (err: unknown) => this.handleOperationError(err, 'completar la operación'),
     });
+  }
+
+  private reloadCoreData(): Observable<void> {
+    return forkJoin({
+      payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
+      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }).pipe(catchError(() => of({ content: this.allVouchers } as any))),
+      schedules: this.api.schedules(this.enterpriseId).pipe(catchError(() => of(this.schedules))),
+      methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
+      banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
+      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
+      thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
+    }).pipe(
+      switchMap((data) => {
+        this.payables = data.payables;
+        this.supplierNames = buildThirdPartyNameMap(data.thirds?.content || []);
+        this.allVouchers = data.vouchers.content;
+        this.applyVoucherFilters();
+        this.schedules = data.schedules;
+        this.banks = data.banks.content;
+        this.bankOptions = this.banks.map((bank: any) => ({
+          id: bank.id,
+          label: `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`,
+        }));
+        this.accounts = data.accounts.filter((a: any) => a.status !== false);
+        this.accountOptions = this.accounts.map((account: any) => ({
+          id: account.id,
+          label: `${account.code} - ${account.description}`,
+        }));
+        const activeAccountIds = buildActiveAccountIdSet(data.accounts);
+        this.allPaymentMethodsCount = data.methods.content?.length ?? 0;
+        this.methods = filterSelectablePaymentMethods(
+          data.methods.content,
+          activeAccountIds,
+          null,
+        );
+        this.methodOptions = this.methods.map((method) => ({
+          id: method.id,
+          label: translatePaymentMethodName(method.name),
+        }));
+        return of(undefined);
+      }),
+    );
   }
 
   private handleOperationError(err: unknown, action: string): void {

--- a/src/app/Financial/Treasury/Shared/treasury-api.models.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.models.ts
@@ -1,5 +1,6 @@
 export type VoucherStatus = 'DRAFT' | 'POSTING' | 'POSTED' | 'FAILED' | 'VOIDING' | 'VOIDED' | 'VOID_FAILED';
 export type ScheduleStatus = 'SCHEDULED' | 'PROCESSING' | 'WAITING_ACCOUNTING' | 'EXECUTED' | 'FAILED' | 'CANCELED';
+export type WriteOffStatus = 'DRAFT' | 'POSTING' | 'POSTED' | 'FAILED' | 'VOIDING' | 'VOIDED' | 'VOID_FAILED';
 
 export interface VoucherDetailRequest { supplierId: number; invoiceId: number; amount: number; }
 export interface VoucherRequest {
@@ -51,4 +52,16 @@ export interface SupplierStatement {
 export interface WriteOffRequest {
   enterpriseId: string; reason: string; counterpartAccountId: number;
   counterpartAccountCode: string; details: VoucherDetailRequest[];
+}
+export interface PayableWriteOff {
+  id: number;
+  enterpriseId?: string;
+  reason?: string;
+  counterpartAccountId?: number;
+  counterpartAccountCode?: string;
+  total: number;
+  status: WriteOffStatus | string;
+  accountingEntryId?: number;
+  version?: number;
+  details?: { id?: number; supplierId: number; invoiceId: number; amount: number }[];
 }

--- a/src/app/Financial/Treasury/Shared/treasury-api.service.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.service.ts
@@ -1,8 +1,8 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, catchError, throwError } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { AgingLine, Page, Payable, PaymentSchedule, PaymentVoucher, ScheduleRequest, SupplierStatement, VoucherRequest, VoucherStatus, WriteOffRequest } from './treasury-api.models';
+import { AgingLine, Page, Payable, PayableWriteOff, PaymentSchedule, PaymentVoucher, ScheduleRequest, SupplierStatement, VoucherRequest, VoucherStatus, WriteOffRequest } from './treasury-api.models';
 
 @Injectable({ providedIn: 'root' })
 export class TreasuryApiService {
@@ -47,11 +47,32 @@ export class TreasuryApiService {
     if (document) params = params.set('document', document);
     return this.http.get<AgingLine[]>(`${this.base}/reports/aging`, { params });
   }
-  writeOffs(enterpriseId: string) { return this.http.get<unknown[]>(`${this.base}/payable-write-offs`, { params: { enterpriseId } }); }
+  writeOffs(enterpriseId: string) {
+    return this.http.get<PayableWriteOff[]>(`${this.base}/payable-write-offs`, { params: { enterpriseId } });
+  }
+  writeOff(id: number) {
+    return this.http.get<PayableWriteOff>(`${this.base}/payable-write-offs/${id}`);
+  }
   accountingEntry(sourceDocumentId: number) {
     return this.http.get<any>(`${environment.API_URL}accountCatalogue/accounting/entries/by-source/${sourceDocumentId}/PAYMENT_VOUCHER`);
   }
-  createWriteOff(request: WriteOffRequest) { return this.http.post<unknown>(`${this.base}/payable-write-offs`, request); }
-  confirmWriteOff(id: number) { return this.http.post<unknown>(`${this.base}/payable-write-offs/${id}/confirm`, null); }
-  voidWriteOff(id: number) { return this.http.post<unknown>(`${this.base}/payable-write-offs/${id}/void`, null); }
+  createWriteOff(request: WriteOffRequest) {
+    return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs`, request);
+  }
+  confirmWriteOff(id: number) {
+    return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs/${id}/confirm`, null);
+  }
+  discardWriteOff(id: number) {
+    return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs/${id}/discard`, null).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 404) {
+          return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs/${id}/void`, null);
+        }
+        return throwError(() => err);
+      }),
+    );
+  }
+  voidWriteOff(id: number) {
+    return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs/${id}/void`, null);
+  }
 }

--- a/src/app/Financial/Treasury/Shared/treasury-writeoff-availability.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-writeoff-availability.spec.ts
@@ -1,0 +1,33 @@
+import { hasActiveWriteOffForInvoice, isBlockingWriteOffStatus } from './treasury-writeoff-availability';
+import { PayableWriteOff } from './treasury-api.models';
+
+describe('treasury-writeoff-availability', () => {
+  const invoiceId = 11;
+
+  it('treats DRAFT and POSTING as blocking', () => {
+    expect(isBlockingWriteOffStatus('DRAFT')).toBeTrue();
+    expect(isBlockingWriteOffStatus('POSTING')).toBeTrue();
+    expect(isBlockingWriteOffStatus('VOIDING')).toBeTrue();
+    expect(isBlockingWriteOffStatus('POSTED')).toBeFalse();
+    expect(isBlockingWriteOffStatus('FAILED')).toBeFalse();
+    expect(isBlockingWriteOffStatus('VOIDED')).toBeFalse();
+    expect(isBlockingWriteOffStatus('VOID_FAILED')).toBeFalse();
+  });
+
+  it('detects active write-off for invoice from list', () => {
+    const writeOffs: PayableWriteOff[] = [
+      { id: 1, status: 'DRAFT', total: 100, details: [{ supplierId: 7, invoiceId, amount: 100 }] },
+    ];
+    expect(hasActiveWriteOffForInvoice(writeOffs, invoiceId)).toBeTrue();
+    expect(hasActiveWriteOffForInvoice(writeOffs, 99)).toBeFalse();
+  });
+
+  it('does not block when only finalized write-offs exist', () => {
+    const writeOffs: PayableWriteOff[] = [
+      { id: 2, status: 'POSTED', total: 100, details: [{ supplierId: 7, invoiceId, amount: 100 }] },
+      { id: 3, status: 'FAILED', total: 50, details: [{ supplierId: 7, invoiceId, amount: 50 }] },
+      { id: 4, status: 'VOIDED', total: 25, details: [{ supplierId: 7, invoiceId, amount: 25 }] },
+    ];
+    expect(hasActiveWriteOffForInvoice(writeOffs, invoiceId)).toBeFalse();
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-writeoff-availability.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-writeoff-availability.ts
@@ -1,0 +1,23 @@
+import { PayableWriteOff, WriteOffStatus } from './treasury-api.models';
+
+/** Estados no finalizados que impiden crear otra baja sobre la misma obligación. */
+export const BLOCKING_WRITE_OFF_STATUSES: ReadonlySet<WriteOffStatus> = new Set([
+  'DRAFT',
+  'POSTING',
+  'VOIDING',
+]);
+
+export function isBlockingWriteOffStatus(status?: string | null): boolean {
+  return status != null && BLOCKING_WRITE_OFF_STATUSES.has(status as WriteOffStatus);
+}
+
+export function writeOffBlocksInvoice(writeOff: PayableWriteOff, invoiceId: number): boolean {
+  if (!isBlockingWriteOffStatus(writeOff.status)) {
+    return false;
+  }
+  return (writeOff.details ?? []).some((detail) => Number(detail.invoiceId) === invoiceId);
+}
+
+export function hasActiveWriteOffForInvoice(writeOffs: PayableWriteOff[], invoiceId: number): boolean {
+  return writeOffs.some((writeOff) => writeOffBlocksInvoice(writeOff, invoiceId));
+}

--- a/src/app/Financial/Treasury/Shared/treasury-writeoff-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-writeoff-messages.ts
@@ -15,3 +15,36 @@ export const WRITE_OFF_AMOUNT_INVALID_MESSAGE =
 
 export const WRITE_OFF_CREATE_SUCCESS_MESSAGE =
   'Baja de CxP creada correctamente. Debe contabilizarla para aplicar la baja.';
+
+export const WRITE_OFF_POSTED_TOTAL_MESSAGE =
+  'Baja de CxP contabilizada correctamente. La obligación quedó sin saldo pendiente.';
+
+export const WRITE_OFF_POSTED_PARTIAL_MESSAGE =
+  'Baja de CxP contabilizada correctamente. Se actualizó el saldo pendiente de la obligación.';
+
+export const WRITE_OFF_DISCARD_CONFIRM_MESSAGE =
+  '¿Desea descartar esta baja de CxP? La obligación no será modificada.';
+
+export const WRITE_OFF_DISCARD_SUCCESS_MESSAGE =
+  'Borrador de baja de CxP descartado correctamente. La obligación no fue modificada.';
+
+export const WRITE_OFF_DISCARD_ONLY_DRAFT_MESSAGE =
+  'Solo se pueden descartar bajas de CxP en estado borrador.';
+
+export const WRITE_OFF_DISCARD_TOOLTIP =
+  'Descartar esta baja sin afectar la obligación';
+
+export const WRITE_OFF_VOID_TOOLTIP =
+  'Anular una baja ya contabilizada';
+
+export const WRITE_OFF_VOIDED_MESSAGE =
+  'Baja de CxP anulada correctamente. Se restauró el saldo pendiente de la obligación.';
+
+export const WRITE_OFF_VOID_FAILED_MESSAGE =
+  'No fue posible anular la baja de CxP. El saldo de la obligación no fue modificado.';
+
+export const WRITE_OFF_POST_FAILED_MESSAGE =
+  'No fue posible contabilizar la baja de CxP. El saldo de la obligación no fue modificado.';
+
+export const WRITE_OFF_PENDING_BLOCK_MESSAGE =
+  'Esta obligación ya tiene una baja de CxP pendiente de contabilización.';


### PR DESCRIPTION
## Summary
- DRAFT write-offs show Contabilizar + Descartar borrador; POSTED show Anular with confirmation modal.
- Poll write-off status after void until Anulado (same pattern as posting).
- discardWriteOff API with fallback to void; availability helper blocks duplicate active write-offs.

## Test plan
- [ ] 
g test --include=**/treasury-operations.component.spec.ts
- [ ] 
g test --include=**/treasury-writeoff-availability.spec.ts
- [ ] Create DRAFT baja CxP, discard via modal, list refreshes without accounting void.
- [x] Post write-off, anular, confirm status updates to Anulado without manual reload.