### PR TITLE
fix(treasury): post payments outside secure contexts

### DIFF
--- a/src/app/Financial/Treasury/Shared/treasury-api.service.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { TreasuryApiService } from './treasury-api.service';
+import { createTreasuryIdempotencyKey, TreasuryApiService } from './treasury-api.service';
 
 describe('TreasuryApiService PP8', () => {
   let service: TreasuryApiService;
@@ -40,6 +40,20 @@ describe('TreasuryApiService PP8', () => {
     service.postVoucher(10, 'enterprise-a', 'stable-key').subscribe();
     const request = http.expectOne(req => req.url.endsWith('/payment-vouchers/10/post'));
     expect(request.request.headers.get('Idempotency-Key')).toBe('stable-key');
+    request.flush({});
+  });
+
+  it('generates an idempotency key when randomUUID is unavailable', () => {
+    const key = createTreasuryIdempotencyKey(null);
+
+    expect(key).toMatch(/^treasury-\d+-[a-z0-9]+$/);
+  });
+
+  it('posts a voucher with an automatically generated idempotency key', () => {
+    service.postVoucher(11, 'enterprise-a').subscribe();
+    const request = http.expectOne(req => req.url.endsWith('/payment-vouchers/11/post'));
+
+    expect(request.request.headers.get('Idempotency-Key')).toBeTruthy();
     request.flush({});
   });
 });

--- a/src/app/Financial/Treasury/Shared/treasury-api.service.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.service.ts
@@ -4,6 +4,15 @@ import { Observable, catchError, throwError } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import { AgingLine, Page, Payable, PayableWriteOff, PaymentSchedule, PaymentVoucher, ScheduleRequest, SupplierStatement, VoucherRequest, VoucherStatus, WriteOffRequest } from './treasury-api.models';
 
+export function createTreasuryIdempotencyKey(
+  randomUuid: (() => string) | null =
+    typeof globalThis.crypto?.randomUUID === 'function'
+      ? globalThis.crypto.randomUUID.bind(globalThis.crypto)
+      : null,
+): string {
+  return randomUuid?.() ?? `treasury-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 @Injectable({ providedIn: 'root' })
 export class TreasuryApiService {
   private readonly base = `${environment.API_URL}treasury`;
@@ -18,9 +27,10 @@ export class TreasuryApiService {
   createVoucher(request: VoucherRequest) { return this.http.post<PaymentVoucher>(`${this.base}/payment-vouchers`, request); }
   updateVoucher(id: number, request: VoucherRequest) { return this.http.put<PaymentVoucher>(`${this.base}/payment-vouchers/${id}`, request); }
   deleteVoucher(id: number, enterpriseId: string) { return this.http.delete<void>(`${this.base}/payment-vouchers/${id}`, { params: { enterpriseId } }); }
-  postVoucher(id: number, enterpriseId: string, key: string = crypto.randomUUID()) {
+  postVoucher(id: number, enterpriseId: string, key?: string) {
+    const idempotencyKey = key || createTreasuryIdempotencyKey();
     return this.http.post<PaymentVoucher>(`${this.base}/payment-vouchers/${id}/post`, null,
-      { params: { enterpriseId }, headers: new HttpHeaders().set('Idempotency-Key', key) });
+      { params: { enterpriseId }, headers: new HttpHeaders().set('Idempotency-Key', idempotencyKey) });
   }
   voidVoucher(id: number, enterpriseId: string, reason: string) {
     return this.http.post<PaymentVoucher>(`${this.base}/payment-vouchers/${id}/void`, { reason }, { params: { enterpriseId } });


### PR DESCRIPTION
## Summary
- Generate voucher posting idempotency keys when `crypto.randomUUID()` is unavailable.
- Prevent deployed non-secure HTTP environments from stopping after voucher creation and leaving payments in DRAFT.
- Add coverage for fallback and automatic idempotency headers.

## Test plan
- [x] `ng test --include=**/treasury-api.service.spec.ts --browsers=ChromeHeadless --watch=false`
- [x] `ng test --include=**/treasury-operations.component.spec.ts --browsers=ChromeHeadless --watch=false`
- [ ] Deploy and pay a total or partial obligation; verify the voucher reaches POSTING/POSTED.