### PR TITLE
feat(treasury): integrate payables operations, reports and write-offs in UI

### DIFF
--- a/src/app/Commercial/InvoiceTemplate/services/steleton.service.ts
+++ b/src/app/Commercial/InvoiceTemplate/services/steleton.service.ts
@@ -45,6 +45,10 @@ export class SteletonService {
     return this.http.get<any>(`${API_URL}factures/skeleton/by-code/${factCode}`);
   }
 
+  getFactureById(id: number): Observable<any> {
+    return this.http.get<any>(`${API_URL}factures/skeleton/${id}`);
+  }
+
   getTotalReturnedQuantity(factCode: number, productId: number): Observable<number> {
     return this.http.get<number>(`${API_URL}factures/skeleton/${factCode}/products/${productId}/returned-quantity`);
   }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.css
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.css
@@ -1,0 +1,23 @@
+.detail-field dt {
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin-bottom: 0.15rem;
+}
+
+.detail-field dd {
+  margin: 0;
+  font-weight: 600;
+  color: #111827;
+}
+
+.amount-summary {
+  background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+}
+
+.amount-summary .net-value {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  color: var(--color-primary, #1e3a5f);
+}

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.html
@@ -1,98 +1,318 @@
-<div class="w-full px-4 sm:px-6 lg:px-8 pt-20 font-sans">
+<div class="w-full px-4 sm:px-6 lg:px-8 pt-20 font-sans max-w-6xl mx-auto">
     <p-toast></p-toast>
     <p-confirmDialog></p-confirmDialog>
 
     @if (errorMessage) {
-        <p-message severity="error" [text]="errorMessage"></p-message>
+        <p-message severity="error" [text]="errorMessage" styleClass="w-full mb-4"></p-message>
+    }
+
+    @if (loading) {
+        <p-card>
+            <p class="text-gray-600 m-0">Cargando comprobante...</p>
+        </p-card>
     }
 
     @if (receipt) {
-        <!-- CABECERA -->
-        <div class="mb-8">
-            <h1 class="font-['Titillium_Web'] font-bold text-3xl text-[var(--color-primary)] border-b-4 border-[var(--color-secondary)] inline-block pb-1">
-                Detalles del Comprobante de Egreso
-            </h1>
-            <p class="mt-2 text-base text-gray-600">
-                Información detallada del comprobante {{ receipt.receiptCode }}
-            </p>
+        <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+                <h1 class="font-['Titillium_Web'] font-bold text-3xl text-[var(--color-primary)] border-b-4 border-[var(--color-secondary)] inline-block pb-1">
+                    Detalles del Comprobante de Egreso
+                </h1>
+                <p class="mt-2 text-base text-gray-600">
+                    Información detallada del comprobante
+                    <span class="font-mono font-semibold text-[var(--color-primary)]">{{ receipt.receiptCode }}</span>
+                </p>
+            </div>
+            <p-tag [value]="receipt.status" [severity]="statusSeverity()"></p-tag>
         </div>
 
-        <!-- INFORMACIÓN PRINCIPAL -->
-        <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-            <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Información General</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <span class="font-medium">Código del Comprobante:</span>
-                    <span class="ml-2">{{ receipt.receiptCode }}</span>
+        <div class="amount-summary p-5 mb-6 grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
+            <div>
+                <p class="text-sm text-gray-500 m-0">Monto neto pagado</p>
+                <p class="net-value font-bold m-0 mt-1">{{ formatMoney(receipt.netAmount) }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500 m-0">Monto bruto / total facturas</p>
+                <p class="text-xl font-semibold m-0 mt-1">{{ formatMoney(receipt.grossAmount) }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500 m-0">Retenciones</p>
+                <p class="text-xl font-semibold m-0 mt-1">{{ formatMoney(receipt.retentionsAmount) }}</p>
+            </div>
+        </div>
+
+        <p-card styleClass="mb-6 shadow-sm">
+            <ng-template pTemplate="title">
+                <span class="text-lg font-semibold text-[var(--color-primary)]">Información general</span>
+            </ng-template>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+                <dl class="detail-field">
+                    <dt>Código del comprobante</dt>
+                    <dd class="font-mono text-blue-600">{{ receipt.receiptCode }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Estado</dt>
+                    <dd>{{ receipt.status }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Fecha de elaboración</dt>
+                    <dd>{{ receipt.issueDate | date:'dd/MM/yyyy' }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Fecha/hora de ejecución</dt>
+                    <dd>
+                        {{ receipt.executionDateTime ? (receipt.executionDateTime | date:'dd/MM/yyyy HH:mm') : '—' }}
+                    </dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Proveedor</dt>
+                    <dd>{{ displayText(receipt.supplierName) }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Identificación / NIT</dt>
+                    <dd>{{ displayText(receipt.supplierIdentification) }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Método de pago</dt>
+                    <dd>{{ displayText(receipt.paymentMethodName) }}</dd>
+                </dl>
+                @if (receipt.scheduleId) {
+                    <dl class="detail-field">
+                        <dt>Programación de origen</dt>
+                        <dd>
+                            <button
+                                type="button"
+                                class="text-blue-600 hover:underline font-mono bg-transparent border-0 p-0 cursor-pointer"
+                                (click)="openScheduleDetail()">
+                                #{{ receipt.scheduleId }}
+                                @if (receipt.scheduleExecutionDate) {
+                                    ({{ receipt.scheduleExecutionDate | date:'dd/MM/yyyy' }})
+                                }
+                            </button>
+                        </dd>
+                    </dl>
+                }
+            </div>
+            @if (receipt.observations) {
+                <p-divider></p-divider>
+                <dl class="detail-field">
+                    <dt>Observaciones</dt>
+                    <dd class="font-normal text-gray-700">{{ receipt.observations }}</dd>
+                </dl>
+            }
+        </p-card>
+
+        @if (receipt.details && receipt.details.length > 0) {
+            <p-card styleClass="mb-6 shadow-sm">
+                <ng-template pTemplate="title">
+                    <span class="text-lg font-semibold text-[var(--color-primary)]">Facturas pagadas</span>
+                </ng-template>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-gray-200 text-left text-gray-600">
+                                <th class="py-2 pr-3">N.º / referencia</th>
+                                <th class="py-2 pr-3">Cuenta CxP</th>
+                                <th class="py-2 pr-3 text-right">Valor factura</th>
+                                <th class="py-2 pr-3 text-right">Valor pagado</th>
+                                <th class="py-2 pr-3 text-right">Retenciones</th>
+                                <th class="py-2 pr-3 text-right">Saldo restante</th>
+                                <th class="py-2 text-right" style="min-width: 11rem">Productos/servicios</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (detail of receipt.details; track detail.invoiceId) {
+                                <tr class="border-b border-gray-100 align-top">
+                                    <td class="py-3 pr-3 font-mono">{{ detail.invoiceCode || detail.invoiceId }}</td>
+                                    <td class="py-3 pr-3 font-mono text-gray-700">{{ detail.payableAccountCode }}</td>
+                                    <td class="py-3 pr-3 text-right">{{ formatMoney(detail.invoiceValue) }}</td>
+                                    <td class="py-3 pr-3 text-right font-semibold">{{ formatMoney(detail.amountPaid) }}</td>
+                                    <td class="py-3 pr-3 text-right">{{ formatMoney(detail.retentionsApplied) }}</td>
+                                    <td class="py-3 pr-3 text-right">{{ formatMoney(detail.remainingBalance) }}</td>
+                                    <td class="py-3 text-right">
+                                        <p-button
+                                            [label]="isProductsExpanded(detail) ? 'Ocultar' : 'Ver productos/servicios'"
+                                            icon="pi pi-box"
+                                            size="small"
+                                            [outlined]="true"
+                                            [loading]="isProductsLoading(detail)"
+                                            (onClick)="toggleProducts(detail)">
+                                        </p-button>
+                                    </td>
+                                </tr>
+                                @if (isProductsExpanded(detail)) {
+                                    <tr>
+                                        <td colspan="7" class="pb-4 pt-0">
+                                            <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                                                @if (isProductsLoading(detail)) {
+                                                    <p class="text-gray-600 m-0">Consultando productos en Facturación...</p>
+                                                } @else if (productsError(detail)) {
+                                                    <p class="text-gray-600 m-0">{{ productsError(detail) }}</p>
+                                                } @else if (detail.productLines?.length) {
+                                                    <p-table [value]="detail.productLines!" styleClass="p-datatable-sm p-datatable-striped">
+                                                        <ng-template pTemplate="header">
+                                                            <tr>
+                                                                <th>Producto/servicio</th>
+                                                                <th>Descripción</th>
+                                                                <th class="text-right">Cantidad</th>
+                                                                <th class="text-right">Valor unitario</th>
+                                                                <th class="text-right">Subtotal</th>
+                                                                <th class="text-right">Impuestos</th>
+                                                                <th class="text-right">Descuento</th>
+                                                                <th class="text-right">Total línea</th>
+                                                            </tr>
+                                                        </ng-template>
+                                                        <ng-template pTemplate="body" let-line>
+                                                            <tr>
+                                                                <td>{{ line.productLabel }}</td>
+                                                                <td>{{ line.description || '—' }}</td>
+                                                                <td class="text-right">{{ line.quantity }}</td>
+                                                                <td class="text-right">{{ formatMoney(line.unitPrice) }}</td>
+                                                                <td class="text-right">{{ formatMoney(line.subtotal) }}</td>
+                                                                <td class="text-right">
+                                                                    @if (line.taxLabel !== '—') {
+                                                                        <span>{{ line.taxLabel }}</span>
+                                                                        <span class="block text-xs text-gray-500">{{ formatMoney(line.taxAmount) }}</span>
+                                                                    } @else {
+                                                                        —
+                                                                    }
+                                                                </td>
+                                                                <td class="text-right">
+                                                                    @if (line.discountPercent > 0) {
+                                                                        <span>{{ line.discountPercent }}%</span>
+                                                                        <span class="block text-xs text-gray-500">{{ formatMoney(line.discountAmount) }}</span>
+                                                                    } @else {
+                                                                        —
+                                                                    }
+                                                                </td>
+                                                                <td class="text-right font-semibold">{{ formatMoney(line.lineTotal) }}</td>
+                                                            </tr>
+                                                        </ng-template>
+                                                    </p-table>
+                                                }
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            }
+                        </tbody>
+                    </table>
                 </div>
-                <div>
-                    <span class="font-medium">Fecha de Elaboración:</span>
-                    <span class="ml-2">{{ receipt.issueDate | date:'dd/MM/yyyy' }}</span>
+            </p-card>
+        }
+
+        <p-card styleClass="mb-6 shadow-sm">
+            <ng-template pTemplate="title">
+                <span class="text-lg font-semibold text-[var(--color-primary)]">Información del pago</span>
+            </ng-template>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+                <dl class="detail-field">
+                    <dt>Método</dt>
+                    <dd>{{ displayText(receipt.paymentMethodName) }}</dd>
+                </dl>
+                @if (receipt.paymentMethodRequiresBankAccount) {
+                    <dl class="detail-field">
+                        <dt>Cuenta origen</dt>
+                        <dd>{{ displayText(receipt.bankAccountLabel) }}</dd>
+                    </dl>
+                }
+                <dl class="detail-field">
+                    <dt>Referencia / comprobante</dt>
+                    <dd class="font-mono">{{ receipt.receiptCode }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Fecha de ejecución</dt>
+                    <dd>
+                        {{ receipt.executionDateTime ? (receipt.executionDateTime | date:'dd/MM/yyyy HH:mm') : '—' }}
+                    </dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Monto neto pagado</dt>
+                    <dd class="text-green-700">{{ formatMoney(receipt.netAmount) }}</dd>
+                </dl>
+            </div>
+        </p-card>
+
+        <p-card styleClass="mb-6 shadow-sm">
+            <ng-template pTemplate="title">
+                <div class="flex flex-wrap items-center justify-between gap-3 w-full">
+                    <span class="text-lg font-semibold text-[var(--color-primary)]">Información contable</span>
+                    @if (receipt.accountingEntryId) {
+                        <p-button
+                            label="Actualizar asiento"
+                            icon="pi pi-refresh"
+                            size="small"
+                            [outlined]="true"
+                            [loading]="loadingAccounting"
+                            (onClick)="showAccounting()">
+                        </p-button>
+                    }
                 </div>
-                <div>
-                    <span class="font-medium">Proveedor:</span>
-                    <span class="ml-2">{{ receipt.supplierName }}</span>
-                </div>
-                <div>
-                    <span class="font-medium">Método de Pago:</span>
-                    <span class="ml-2">{{ receipt.paymentMethodName }}</span>
-                </div>
-                <div>
-                    <span class="font-medium">Estado:</span>
-                    <span class="ml-2" [ngClass]="{'text-red-600': receipt.statusKey === 'VOIDED', 'text-green-600': receipt.statusKey === 'POSTED', 'text-orange-600': receipt.statusKey === 'DRAFT'}">
-                        {{ receipt.status }}
-                    </span>
-                </div>
-                <div>
-                    <span class="font-medium">Monto Total:</span>
-                    <span class="ml-2 font-semibold text-green-600">
-                        {{ receipt.totalAmount | currency:'COP':'symbol':'1.0-0':'es-CO' }}
-                    </span>
-                </div>
+            </ng-template>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+                <dl class="detail-field">
+                    <dt>Estado contable</dt>
+                    <dd>{{ displayText(receipt.accountingStatusLabel) }}</dd>
+                </dl>
+                <dl class="detail-field">
+                    <dt>Asiento</dt>
+                    <dd class="font-mono">{{ displayText(receipt.accountingEntryCode) }}</dd>
+                </dl>
+                @if (receipt.accountingEntryId) {
+                    <dl class="detail-field">
+                        <dt>ID asiento contable</dt>
+                        <dd class="font-mono">{{ receipt.accountingEntryId }}</dd>
+                    </dl>
+                }
             </div>
 
-            @if (receipt.observations) {
-                <div class="mt-4">
-                    <span class="font-medium">Observaciones:</span>
-                    <p class="mt-1 text-gray-700">{{ receipt.observations }}</p>
-                </div>
+            @if (loadingAccounting && !accountingMovements.length) {
+                <p class="text-gray-600 mt-4 m-0">Consultando movimientos del asiento...</p>
             }
-        </div>
 
-        <!-- DETALLES DE FACTURAS (si aplica) -->
-        @if (receipt.details && receipt.details.length > 0) {
-            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Facturas Pagadas</h2>
-                <p-table [value]="receipt.details" [tableStyle]="{'min-width': '50rem'}" styleClass="p-datatable-striped">
+            @if (accountingMovements.length) {
+                <p-message
+                    *ngIf="!accountingIsBalanced"
+                    severity="warn"
+                    text="El asiento no está balanceado: el total débito difiere del total crédito."
+                    styleClass="mt-4 w-full">
+                </p-message>
+                <p-table
+                    [value]="accountingMovements"
+                    styleClass="p-datatable-sm p-datatable-striped mt-4">
                     <ng-template pTemplate="header">
                         <tr>
-                            <th>Código de Factura</th>
-                            <th>Cuenta Contable</th>
-                            <th class="text-right">Monto Pagado</th>
+                            <th>Código cuenta</th>
+                            <th>Cuenta</th>
+                            <th>Detalle</th>
+                            <th class="text-right">Débito</th>
+                            <th class="text-right">Crédito</th>
                         </tr>
                     </ng-template>
-                    <ng-template pTemplate="body" let-detail>
+                    <ng-template pTemplate="body" let-row>
                         <tr>
-                            <td>{{ detail.invoiceCode }}</td>
-                            <td>{{ detail.accountingAccount }}</td>
-                            <td class="text-right">{{ detail.amountPaid | currency:'COP':'symbol':'1.0-0':'es-CO' }}</td>
+                            <td class="font-mono">{{ row.accountCode }}</td>
+                            <td>{{ row.accountName }}</td>
+                            <td>{{ row.detail }}</td>
+                            <td class="text-right">{{ formatMoney(row.debit) }}</td>
+                            <td class="text-right">{{ formatMoney(row.credit) }}</td>
                         </tr>
                     </ng-template>
                 </p-table>
-            </div>
-        }
+            }
+        </p-card>
 
-        <!-- BOTONES DE ACCIÓN -->
-        <div class="flex justify-center gap-4 mb-8">
+        <div class="flex justify-center gap-3 mb-8 flex-wrap">
             <p-button
-                label="Ver Contabilización"
+                label="Ver página de contabilización"
                 icon="pi pi-calculator"
-                (onClick)="viewAccounting()">
+                [outlined]="true"
+                (onClick)="viewAccountingPage()">
             </p-button>
 
             @if (receipt.statusKey === 'POSTED') {
                 <p-button
-                    label="Anular Comprobante"
+                    label="Anular comprobante"
                     icon="pi pi-times"
                     styleClass="p-button-danger"
                     (onClick)="openAnnulDialog()">
@@ -100,7 +320,7 @@
             }
 
             <p-button
-                label="Volver al Listado"
+                label="Volver al listado"
                 icon="pi pi-arrow-left"
                 styleClass="p-button-secondary"
                 (onClick)="goBackToList()">
@@ -108,14 +328,12 @@
         </div>
     }
 
-    <!-- DIÁLOGO DE ANULACIÓN -->
     <p-dialog
         header="Anular Comprobante de Egreso"
         [(visible)]="displayAnnulDialog"
         [modal]="true"
         [style]="{width: '500px'}"
         [closable]="true">
-
         <div class="mb-4">
             <label for="annulReason" class="block font-medium text-gray-700 mb-2">
                 Motivo de la anulación <span class="text-red-500">*</span>
@@ -128,7 +346,6 @@
                 class="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent">
             </textarea>
         </div>
-
         <div class="flex justify-end gap-2">
             <p-button
                 label="Cancelar"
@@ -138,7 +355,7 @@
                 [disabled]="isSubmittingAnnulment">
             </p-button>
             <p-button
-                label="Confirmar Anulación"
+                label="Confirmar anulación"
                 icon="pi pi-check"
                 styleClass="p-button-danger"
                 (onClick)="confirmAnnulment()"

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.html
@@ -152,14 +152,14 @@
                                                     <p-table [value]="detail.productLines!" styleClass="p-datatable-sm p-datatable-striped">
                                                         <ng-template pTemplate="header">
                                                             <tr>
-                                                                <th>Producto/servicio</th>
-                                                                <th>Descripción</th>
-                                                                <th class="text-right">Cantidad</th>
-                                                                <th class="text-right">Valor unitario</th>
-                                                                <th class="text-right">Subtotal</th>
-                                                                <th class="text-right">Impuestos</th>
-                                                                <th class="text-right">Descuento</th>
-                                                                <th class="text-right">Total línea</th>
+                                                                <th scope="col">Producto/servicio</th>
+                                                                <th scope="col">Descripción</th>
+                                                                <th scope="col" class="text-right">Cantidad</th>
+                                                                <th scope="col" class="text-right">Valor unitario</th>
+                                                                <th scope="col" class="text-right">Subtotal</th>
+                                                                <th scope="col" class="text-right">Impuestos</th>
+                                                                <th scope="col" class="text-right">Descuento</th>
+                                                                <th scope="col" class="text-right">Total línea</th>
                                                             </tr>
                                                         </ng-template>
                                                         <ng-template pTemplate="body" let-line>
@@ -282,11 +282,11 @@
                     styleClass="p-datatable-sm p-datatable-striped mt-4">
                     <ng-template pTemplate="header">
                         <tr>
-                            <th>Código cuenta</th>
-                            <th>Cuenta</th>
-                            <th>Detalle</th>
-                            <th class="text-right">Débito</th>
-                            <th class="text-right">Crédito</th>
+                            <th scope="col">Código cuenta</th>
+                            <th scope="col">Cuenta</th>
+                            <th scope="col">Detalle</th>
+                            <th scope="col" class="text-right">Débito</th>
+                            <th scope="col" class="text-right">Crédito</th>
                         </tr>
                     </ng-template>
                     <ng-template pTemplate="body" let-row>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { ExpenseReceiptDetailsView } from '../../Model/ExpenseReceiptView';
+import { Component, OnInit } from '@angular/core';
+import { ExpenseReceiptDetailsView, ExpenseReceiptDetailView } from '../../Model/ExpenseReceiptView';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
 import { CommonModule } from '@angular/common';
@@ -11,37 +11,68 @@ import { FormsModule } from '@angular/forms';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ToastModule } from 'primeng/toast';
 import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { CardModule } from 'primeng/card';
+import { DividerModule } from 'primeng/divider';
+import {
+  AccountingEntryViewHeader,
+  AccountingMovementViewRow,
+  accountingTotalsBalanced,
+} from '../../../Shared/treasury-accounting-display';
+import { accountingEntryStatusLabel } from '../../../Shared/treasury-status-labels';
 
 @Component({
   selector: 'app-expense-receipt-details',
   standalone: true,
-  imports: [CommonModule, RouterModule, ButtonModule, MessageModule, DialogModule, FormsModule, ConfirmDialogModule, ToastModule, TableModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    ButtonModule,
+    MessageModule,
+    DialogModule,
+    FormsModule,
+    ConfirmDialogModule,
+    ToastModule,
+    TableModule,
+    TagModule,
+    CardModule,
+    DividerModule,
+  ],
   templateUrl: './expense-receipt-details.component.html',
   styleUrl: './expense-receipt-details.component.css',
-  providers: [ConfirmationService, MessageService]
+  providers: [ConfirmationService, MessageService],
 })
-export class ExpenseReceiptDetailsComponent {
+export class ExpenseReceiptDetailsComponent implements OnInit {
   receipt: ExpenseReceiptDetailsView | null = null;
   errorMessage: string | null = null;
+  loading = false;
 
-  // Propiedades para el diálogo de anulación
-  displayAnnulDialog: boolean = false;
-  annulReason: string = '';
-  isSubmittingAnnulment: boolean = false;
+  displayAnnulDialog = false;
+  annulReason = '';
+  isSubmittingAnnulment = false;
+
+  accountingEntryHeader: AccountingEntryViewHeader = {};
+  accountingMovements: AccountingMovementViewRow[] = [];
+  accountingDebitTotal = 0;
+  accountingCreditTotal = 0;
+  loadingAccounting = false;
+  accountingStatusLabel = accountingEntryStatusLabel;
+  expandedInvoiceIds = new Set<number>();
+  loadingProductLines = new Set<number>();
+  productLineErrors = new Map<number, string>();
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private expenseReceiptService: ExpenseReceiptService,
     private confirmationService: ConfirmationService,
-    private messageService: MessageService
+    private messageService: MessageService,
   ) {}
 
   ngOnInit(): void {
     const idParam = this.route.snapshot.paramMap.get('id');
     if (idParam) {
-      const receiptId = +idParam; // El '+' convierte el string a número
-      this.loadReceiptDetails(receiptId);
+      this.loadReceiptDetails(+idParam);
     } else {
       this.errorMessage = 'No se proporcionó el identificador del comprobante.';
     }
@@ -49,14 +80,93 @@ export class ExpenseReceiptDetailsComponent {
 
   loadReceiptDetails(id: number): void {
     this.errorMessage = null;
+    this.loading = true;
     this.expenseReceiptService.getExpenseReceiptById(id).subscribe({
       next: (receipt) => {
         this.receipt = receipt || null;
+        this.loading = false;
+        if (this.receipt?.accountingEntryId) {
+          this.showAccounting();
+        }
       },
-      error: (error) => {
-        console.error('Error al cargar los detalles del comprobante:', error);
+      error: () => {
+        this.loading = false;
         this.errorMessage = 'No se pudo cargar la información del comprobante.';
-      }
+      },
+    });
+  }
+
+  get accountingIsBalanced(): boolean {
+    return accountingTotalsBalanced(this.accountingDebitTotal, this.accountingCreditTotal);
+  }
+
+  formatMoney(amount: number | null | undefined): string {
+    const value = Number(amount ?? 0);
+    if (!Number.isFinite(value)) {
+      return '—';
+    }
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  displayText(value: string | null | undefined): string {
+    const text = (value ?? '').trim();
+    return text || '—';
+  }
+
+  statusSeverity(): 'success' | 'warn' | 'danger' | 'info' | 'secondary' {
+    const key = this.receipt?.statusKey;
+    if (key === 'POSTED') return 'success';
+    if (key === 'VOIDED') return 'danger';
+    if (key === 'FAILED' || key === 'VOID_FAILED') return 'danger';
+    if (key === 'DRAFT') return 'secondary';
+    if (key === 'POSTING' || key === 'VOIDING') return 'warn';
+    return 'info';
+  }
+
+  showAccounting(): void {
+    if (!this.receipt) {
+      return;
+    }
+    this.loadingAccounting = true;
+    this.accountingEntryHeader = {};
+    this.accountingMovements = [];
+    this.accountingDebitTotal = 0;
+    this.accountingCreditTotal = 0;
+    this.expenseReceiptService.getAccountingEntryView(this.receipt.id, {
+      voucherNumber: this.receipt.receiptCode,
+      supplierLabel: this.receipt.supplierName,
+    }).subscribe({
+      next: (view) => {
+        this.accountingEntryHeader = view.header;
+        this.accountingMovements = view.movements;
+        this.accountingDebitTotal = this.accountingMovements.reduce((sum, row) => sum + row.debit, 0);
+        this.accountingCreditTotal = this.accountingMovements.reduce((sum, row) => sum + row.credit, 0);
+        if (this.receipt && !this.receipt.accountingEntryCode && view.header.entryCode) {
+          this.receipt.accountingEntryCode = view.header.entryCode;
+        }
+        this.loadingAccounting = false;
+      },
+      error: () => {
+        this.loadingAccounting = false;
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Asiento no disponible',
+          detail: 'No fue posible consultar el asiento del comprobante.',
+        });
+      },
+    });
+  }
+
+  openScheduleDetail(): void {
+    if (!this.receipt?.scheduleId) {
+      return;
+    }
+    this.router.navigate(['/financial/treasury/purchase-bills'], {
+      queryParams: { scheduleId: this.receipt.scheduleId },
     });
   }
 
@@ -70,34 +180,50 @@ export class ExpenseReceiptDetailsComponent {
       this.messageService.add({
         severity: 'warn',
         summary: 'Validación',
-        detail: 'Debe proporcionar una razón para la anulación.'
+        detail: 'Debe proporcionar una razón para la anulación.',
       });
       return;
     }
 
     this.isSubmittingAnnulment = true;
-
-    this.expenseReceiptService.voidExpenseReceipt(this.receipt.id, this.annulReason).subscribe({
+    const receiptCode = this.receipt.receiptCode;
+    const receiptId = this.receipt.id;
+    this.expenseReceiptService.voidExpenseReceipt(receiptId, this.annulReason).subscribe({
       next: (response) => {
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Éxito',
-          detail: `Comprobante ${response.receiptCode} anulado correctamente.`
-        });
+        const code = response.receiptCode?.trim() || receiptCode;
+        if (response.status === 'VOID_FAILED') {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Anulación fallida',
+            detail: `No se pudo anular el comprobante ${code}. Revise el estado en el listado.`,
+          });
+          return;
+        }
+        const stillVoiding = response.status === 'VOIDING';
         this.displayAnnulDialog = false;
-        this.loadReceiptDetails(this.receipt!.id); // Recargar los detalles
+        this.annulReason = '';
+        this.router.navigate(['/financial/treasury/expense-receipts'], {
+          state: {
+            voidReceiptFeedback: {
+              severity: stillVoiding ? 'warn' : 'success',
+              summary: stillVoiding ? 'Anulación en proceso' : 'Éxito',
+              detail: stillVoiding
+                ? `El comprobante ${code} está anulándose. Verifique el estado en el listado en unos segundos.`
+                : `Comprobante ${code} anulado correctamente.`,
+            },
+          },
+        });
       },
-      error: (error) => {
-        console.error('Error al anular el comprobante:', error);
+      error: () => {
         this.messageService.add({
           severity: 'error',
           summary: 'Error',
-          detail: 'No se pudo anular el comprobante. Intente nuevamente.'
+          detail: 'No se pudo anular el comprobante. Intente nuevamente.',
         });
       },
       complete: () => {
         this.isSubmittingAnnulment = false;
-      }
+      },
     });
   }
 
@@ -106,7 +232,7 @@ export class ExpenseReceiptDetailsComponent {
     this.annulReason = '';
   }
 
-  viewAccounting(): void {
+  viewAccountingPage(): void {
     if (this.receipt) {
       this.router.navigate(['/financial/treasury/expense-receipts', this.receipt.id, 'accounting']);
     }
@@ -114,5 +240,56 @@ export class ExpenseReceiptDetailsComponent {
 
   goBackToList(): void {
     this.router.navigate(['/financial/treasury/expense-receipts']);
+  }
+
+  isProductsExpanded(detail: ExpenseReceiptDetailView): boolean {
+    return this.expandedInvoiceIds.has(detail.invoiceId);
+  }
+
+  isProductsLoading(detail: ExpenseReceiptDetailView): boolean {
+    return this.loadingProductLines.has(detail.invoiceId);
+  }
+
+  productsError(detail: ExpenseReceiptDetailView): string | undefined {
+    return this.productLineErrors.get(detail.invoiceId);
+  }
+
+  toggleProducts(detail: ExpenseReceiptDetailView): void {
+    if (this.expandedInvoiceIds.has(detail.invoiceId)) {
+      this.expandedInvoiceIds.delete(detail.invoiceId);
+      return;
+    }
+    this.expandedInvoiceIds.add(detail.invoiceId);
+    this.productLineErrors.delete(detail.invoiceId);
+    if (!detail.sourceInvoiceId) {
+      this.productLineErrors.set(
+        detail.invoiceId,
+        'No se encontró la factura de origen en Facturación.',
+      );
+      return;
+    }
+    if (detail.productLines) {
+      return;
+    }
+    this.loadingProductLines.add(detail.invoiceId);
+    this.expenseReceiptService.getPaidInvoiceProductLines(detail.sourceInvoiceId).subscribe({
+      next: (lines) => {
+        detail.productLines = lines;
+        this.loadingProductLines.delete(detail.invoiceId);
+        if (!lines.length) {
+          this.productLineErrors.set(
+            detail.invoiceId,
+            'La factura no tiene productos o servicios registrados.',
+          );
+        }
+      },
+      error: () => {
+        this.loadingProductLines.delete(detail.invoiceId);
+        this.productLineErrors.set(
+          detail.invoiceId,
+          'No fue posible consultar los productos de la factura.',
+        );
+      },
+    });
   }
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipts-list/expense-receipts-list.component.ts
@@ -82,7 +82,41 @@ export class ExpenseReceiptsListComponent implements OnInit {
   ngOnInit(): void {
     this.initializeForm();
     this.setupFilterSubscriptions();
+    this.showVoidNavigationFeedback();
     this.loadReceipts();
+  }
+
+  private showVoidNavigationFeedback(): void {
+    const navigationState = this.router.lastSuccessfulNavigation?.extras?.state as {
+      voidReceiptFeedback?: {
+        severity: 'success' | 'warn' | 'error';
+        summary: string;
+        detail: string;
+      };
+    } | undefined;
+    const historyState = history.state as {
+      voidReceiptFeedback?: {
+        severity: 'success' | 'warn' | 'error';
+        summary: string;
+        detail: string;
+      };
+    };
+    const feedback = navigationState?.voidReceiptFeedback ?? historyState?.voidReceiptFeedback;
+    if (!feedback) {
+      return;
+    }
+    if (historyState?.voidReceiptFeedback) {
+      const { voidReceiptFeedback: _, ...rest } = history.state as Record<string, unknown>;
+      history.replaceState(rest, '');
+    }
+    setTimeout(() => {
+      this.messageService.add({
+        severity: feedback.severity,
+        summary: feedback.summary,
+        detail: feedback.detail,
+        life: 8000,
+      });
+    });
   }
 
   initializeForm(): void {

--- a/src/app/Financial/Treasury/ExpenseReceipts/Model/ExpenseReceiptView.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Model/ExpenseReceiptView.ts
@@ -1,26 +1,43 @@
 import { AccountingEntryLine } from "./AccountingEntryLine";
-import { ExpenseReceipt } from "./ExpenseReceipt";
+import { PaidInvoiceLineView } from "../../Shared/treasury-purchase-invoice-lines";
 
-export interface ExpenseReceiptDetailView { // <-- Esta es la interfaz del detalle de la vista
+export interface ExpenseReceiptDetailView {
     invoiceId: number;
+    sourceInvoiceId?: number;
     amountPaid: number;
-    invoiceCode: string;        // <-- ¡Ajustado!
-    accountingAccount: number;  // <-- ¡Ajustado!
-    // Podrías añadir: accountingAccountName?: string; si quieres mostrar el nombre
+    invoiceCode: string;
+    invoiceValue: number;
+    retentionsApplied: number;
+    payableAccountCode: string;
+    remainingBalance: number;
+    productLines?: PaidInvoiceLineView[];
 }
 
 export interface ExpenseReceiptDetailsView {
     id: number;
     receiptCode: string;
     issueDate: Date;
-    thirdPartyId: number; // Aunque no se muestra, es útil tenerlo
+    executionDateTime?: Date;
+    thirdPartyId: number;
     supplierName: string;
+    supplierIdentification?: string;
     paymentMethodName: string;
+    paymentMethodRequiresBankAccount?: boolean;
+    bankAccountId?: number;
+    bankAccountLabel?: string;
     status: string;
     statusKey?: string;
+    grossAmount: number;
+    retentionsAmount: number;
+    netAmount: number;
     totalAmount: number;
     observations: string;
     isDirectExpense: boolean;
-    details: ExpenseReceiptDetailView[]; // Usa la interfaz de detalle actualizada
+    accountingEntryId?: number;
+    accountingEntryCode?: string;
+    accountingStatusLabel?: string;
+    scheduleId?: number;
+    scheduleExecutionDate?: string;
+    details: ExpenseReceiptDetailView[];
     accountingEntry?: AccountingEntryLine[];
 }

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
@@ -12,12 +12,15 @@ describe('ExpenseReceiptService payable accounts', () => {
       ])),
     };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const skeleton = { getFactureById: jasmine.createSpy() };
     const service = new ExpenseReceiptService(
       api as any,
       null as any,
       null as any,
       null as any,
+      null as any,
       storage as any,
+      skeleton as any,
     );
 
     const result = await firstValueFrom(service.getPayableAccounts());
@@ -27,5 +30,219 @@ describe('ExpenseReceiptService payable accounts', () => {
       { id: 20, code: '2205', name: 'Cuenta por pagar', fullName: '2205 - Cuenta por pagar' },
       { id: 30, code: '2335', name: 'Cuenta por pagar', fullName: '2335 - Cuenta por pagar' },
     ]);
+  });
+
+  it('maps voucher detail amounts and schedule origin for receipt details', async () => {
+    const api = {
+      voucher: jasmine.createSpy().and.returnValue(of({
+        id: 21,
+        voucherNumber: 'CE-A753A051',
+        issueDate: '2026-08-14',
+        status: 'POSTED',
+        paymentMethodId: 1,
+        bankAccountId: 33,
+        total: 90000,
+        accountingEntryId: 40,
+        accountingEntryCode: 'AE-PV-21',
+        createdAt: '2026-08-14T15:30:00Z',
+        updatedAt: '2026-08-14T15:31:00Z',
+        details: [{
+          supplierId: 7,
+          invoiceId: 11,
+          invoiceReference: '678151694',
+          payableAccountCode: '220501',
+          previousBalance: 100000,
+          amountPaid: 90000,
+          remainingBalance: 0,
+        }],
+      })),
+      schedules: jasmine.createSpy().and.returnValue(of([
+        { id: 5, voucherId: 21, executionDate: '2026-08-14', status: 'EXECUTED', details: [] },
+      ])),
+      payable: jasmine.createSpy().and.returnValue(of({
+        id: 11,
+        sourceInvoiceId: 501,
+        originalAmount: 100000,
+        reference: '678151694',
+        payableAccountCode: '220501',
+      })),
+      accountingEntry: jasmine.createSpy().and.returnValue(of({ code: 'AE-PV-21', movements: [] })),
+    };
+    const paymentMethods = {
+      findAll: jasmine.createSpy().and.returnValue(of({
+        content: [{ id: 1, name: 'Transferencia', requiresBankAccount: true }],
+      })),
+    };
+    const bankAccounts = {
+      findAllActive: jasmine.createSpy().and.returnValue(of({
+        content: [{ id: 33, accountNumber: '123456', bank: { name: 'Banco Demo' } }],
+      })),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy().and.returnValue(of({
+        content: [{ thId: 7, socialReason: 'Proveedor Demo', idNumber: 900123456, verificationNumber: 1 }],
+      })),
+      getThirdPartie: jasmine.createSpy().and.returnValue(of({
+        thId: 7,
+        socialReason: 'Proveedor Demo',
+        idNumber: 900123456,
+        verificationNumber: 1,
+      })),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const skeleton = { getFactureById: jasmine.createSpy() };
+    const service = new ExpenseReceiptService(
+      api as any,
+      paymentMethods as any,
+      null as any,
+      bankAccounts as any,
+      thirds as any,
+      storage as any,
+      skeleton as any,
+    );
+
+    const receipt = await firstValueFrom(service.getExpenseReceiptById(21));
+
+    expect(api.payable).toHaveBeenCalledWith(11, 'enterprise-a');
+    expect(receipt.grossAmount).toBe(100000);
+    expect(receipt.retentionsAmount).toBe(10000);
+    expect(receipt.netAmount).toBe(90000);
+    expect(receipt.supplierIdentification).toBe('900123456-1');
+    expect(receipt.accountingStatusLabel).toBe('Activo');
+    expect(receipt.scheduleId).toBe(5);
+    expect(receipt.bankAccountLabel).toContain('Banco Demo');
+    expect(receipt.details[0].payableAccountCode).toBe('220501');
+    expect(receipt.details[0].retentionsApplied).toBe(10000);
+    expect(receipt.details[0].sourceInvoiceId).toBe(501);
+  });
+
+  it('falls back to voucher total and payable when detail balances are missing', async () => {
+    const api = {
+      voucher: jasmine.createSpy().and.returnValue(of({
+        id: 30,
+        voucherNumber: 'CE-C6DEB140',
+        issueDate: '2026-08-13',
+        status: 'POSTED',
+        paymentMethodId: 2,
+        total: 1455,
+        accountingEntryId: 55,
+        accountingEntryCode: 'AE-PV-30',
+        updatedAt: '2026-08-13T23:53:00Z',
+        details: [{
+          supplierId: 78,
+          invoiceId: 20,
+          invoiceReference: '680688965',
+          payableAccountCode: '220501',
+          amount: 1455,
+        }],
+      })),
+      schedules: jasmine.createSpy().and.returnValue(of([])),
+      payable: jasmine.createSpy().and.returnValue(of({
+        id: 20,
+        sourceInvoiceId: 880,
+        reference: '680688965',
+        originalAmount: 2323,
+        payableAccountCode: '220501',
+      })),
+      accountingEntry: jasmine.createSpy().and.returnValue(of({ code: 'AE-PV-30', movements: [] })),
+    };
+    const paymentMethods = {
+      findAll: jasmine.createSpy().and.returnValue(of({
+        content: [{ id: 2, name: 'CHECK', requiresBankAccount: false }],
+      })),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy().and.returnValue(of({ content: [] })),
+      getThirdPartie: jasmine.createSpy().and.returnValue(of({
+        thId: 78,
+        socialReason: 'Proveedor Real',
+        idNumber: 800123456,
+        verificationNumber: 4,
+      })),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const skeleton = { getFactureById: jasmine.createSpy() };
+    const service = new ExpenseReceiptService(
+      api as any,
+      paymentMethods as any,
+      null as any,
+      { findAllActive: jasmine.createSpy().and.returnValue(of({ content: [] })) } as any,
+      thirds as any,
+      storage as any,
+      skeleton as any,
+    );
+
+    const receipt = await firstValueFrom(service.getExpenseReceiptById(30));
+
+    expect(thirds.getThirdPartie).toHaveBeenCalledWith(78, 'enterprise-a');
+    expect(receipt.supplierName).toBe('Proveedor Real');
+    expect(receipt.supplierIdentification).toBe('800123456-4');
+    expect(receipt.grossAmount).toBe(2323);
+    expect(receipt.netAmount).toBe(1455);
+    expect(receipt.retentionsAmount).toBe(868);
+    expect(receipt.details[0].invoiceValue).toBe(2323);
+    expect(receipt.details[0].amountPaid).toBe(1455);
+  });
+
+  it('maps void voucher response and polls until void completes', async () => {
+    const voidResponses = [
+      { id: 53, voucherNumber: 'CE-C6DEB140', status: 'VOIDING', paymentMethodId: 1, issueDate: '2026-08-13', total: 1455, details: [] },
+      { id: 53, voucherNumber: 'CE-C6DEB140', status: 'VOIDED', paymentMethodId: 1, issueDate: '2026-08-13', total: 1455, details: [] },
+    ];
+    let voucherCalls = 0;
+    const api = {
+      voidVoucher: jasmine.createSpy().and.returnValue(of(voidResponses[0])),
+      voucher: jasmine.createSpy().and.callFake(() => of(voidResponses[Math.min(voucherCalls++, 1)])),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const skeleton = { getFactureById: jasmine.createSpy() };
+    const service = new ExpenseReceiptService(
+      api as any,
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      storage as any,
+      skeleton as any,
+    );
+
+    const response = await firstValueFrom(service.voidExpenseReceipt(53, 'Motivo de prueba'));
+
+    expect(api.voidVoucher).toHaveBeenCalledWith(53, 'enterprise-a', 'Motivo de prueba');
+    expect(response.receiptCode).toBe('CE-C6DEB140');
+    expect(response.status).toBe('VOIDED');
+  });
+
+  it('loads paid invoice product lines from billing skeleton detail', async () => {
+    const skeleton = {
+      getFactureById: jasmine.createSpy().and.returnValue(of({
+        products: [{
+          productId: 9,
+          amount: 1,
+          unitPrice: 80000,
+          subtotal: 80000,
+          discount: 0,
+          description: 'Mantenimiento',
+          taxPercentage: [19],
+        }],
+      })),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const service = new ExpenseReceiptService(
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      storage as any,
+      skeleton as any,
+    );
+
+    const lines = await firstValueFrom(service.getPaidInvoiceProductLines(501));
+
+    expect(skeleton.getFactureById).toHaveBeenCalledWith(501);
+    expect(lines.length).toBe(1);
+    expect(lines[0].productLabel).toBe('Mantenimiento');
+    expect(lines[0].lineTotal).toBe(95200);
   });
 });

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, map, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Observable, forkJoin, map, of, timer } from 'rxjs';
+import { catchError, last, switchMap, take, takeWhile } from 'rxjs/operators';
 import { PaymentMethodsServiceService } from '../../../../GeneralMasters/PaymentMethods/services/payment-methods-service.service';
 import { ChartAccountService } from '../../../../GeneralMasters/AccountCatalogue/services/chart-account.service';
+import { BankAccountsService } from '../../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
 import { LocalStorageMethods } from '../../../../Shared/Methods/local-storage.method';
 import { TreasuryApiService } from '../../Shared/treasury-api.service';
 import { DropdownOption, ExpenseReceiptView, PurchaseInvoice, Supplier } from '../Model/Models';
@@ -11,14 +12,32 @@ import { ExpenseReceiptResponse } from '../Model/ExpenseReceiptResponse';
 import { ExpenseReceiptCreateRequest } from '../Model/ExpenseReceiptCreateRequest';
 import { AccountingEntryLine } from '../Model/AccountingEntryLine';
 import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
-import { educationalDescription, translatePaymentMethodName, voucherStatusLabel, accountingSourceDocumentTypeLabel } from '../../Shared/treasury-status-labels';
-import { buildThirdPartyNameMap, resolveSupplierName } from '../../Shared/treasury-third-party.integration';
+import { SteletonService } from '../../../../Commercial/InvoiceTemplate/services/steleton.service';
+import { PurchaseInvoiceProductLine } from '../../../../Commercial/PurchaseInvoice/models/purchase-invoice-payload';
+import {
+  accountingEntryStatusLabel,
+  educationalDescription,
+  translatePaymentMethodName,
+  voucherStatusLabel,
+  accountingSourceDocumentTypeLabel,
+} from '../../Shared/treasury-status-labels';
+import {
+  buildThirdPartyIdentificationMap,
+  buildThirdPartyNameMap,
+  resolveSupplierIdentification,
+  resolveSupplierName,
+} from '../../Shared/treasury-third-party.integration';
 import {
   AccountingEntryView,
   buildAccountCatalogueLookup,
   buildAccountingEntryView,
   mapAccountingMovementsForView,
 } from '../../Shared/treasury-accounting-display';
+import { PaymentVoucher, Payable, VoucherDetail } from '../../Shared/treasury-api.models';
+import {
+  PaidInvoiceLineView,
+  mapSkeletonProductsToLineViews,
+} from '../../Shared/treasury-purchase-invoice-lines';
 
 @Injectable({ providedIn: 'root' })
 export class ExpenseReceiptService {
@@ -26,8 +45,10 @@ export class ExpenseReceiptService {
     private readonly api: TreasuryApiService,
     private readonly paymentMethods: PaymentMethodsServiceService,
     private readonly accounts: ChartAccountService,
+    private readonly bankAccounts: BankAccountsService,
     private readonly thirds: ThirdService,
     private readonly storage: LocalStorageMethods,
+    private readonly skeleton: SteletonService,
   ) {}
 
   private enterpriseId(): string {
@@ -151,46 +172,233 @@ export class ExpenseReceiptService {
             supplierName,
             status: voucherStatusLabel(voucher.status),
             statusKey: voucher.status,
-            totalAmount: voucher.total,
+            totalAmount: Number(voucher.total ?? 0),
             accountingEntryId: voucher.accountingEntryId,
           };
         });
       }),
     );
   }
+
   getExpenseReceiptById(id: number): Observable<ExpenseReceiptDetailsView> {
     const enterpriseId = this.enterpriseId();
-    return forkJoin({
-      voucher: this.api.voucher(id, enterpriseId),
-      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
-      methods: this.paymentMethods.findAll(this.enterpriseId(), 0, 100).pipe(catchError(() => of({ content: [] } as any))),
-    }).pipe(
-      map(({ voucher, thirds, methods }) => {
-        const thirdNames = buildThirdPartyNameMap(thirds?.content || []);
-        const supplierId = voucher.details[0]?.supplierId ?? 0;
+    return this.api.voucher(id, enterpriseId).pipe(
+      switchMap((voucher) => {
+        const supplierIds = [...new Set((voucher.details ?? []).map((detail) => detail.supplierId))];
+        return forkJoin({
+          voucher: of(voucher),
+          thirds: this.loadThirdPartyMaps(enterpriseId, supplierIds),
+          methods: this.paymentMethods.findAll(this.enterpriseId(), 0, 100).pipe(catchError(() => of({ content: [] } as any))),
+          banks: this.bankAccounts.findAllActive(enterpriseId).pipe(catchError(() => of({ content: [] } as any))),
+          schedules: this.api.schedules(enterpriseId).pipe(catchError(() => of([]))),
+          payables: forkJoin(
+            (voucher.details ?? []).map((detail) =>
+              this.api.payable(detail.invoiceId, enterpriseId).pipe(catchError(() => of(null))),
+            ),
+          ),
+          accounting: voucher.accountingEntryId
+            ? this.api.accountingEntry(id).pipe(catchError(() => of(null)))
+            : of(null),
+        });
+      }),
+      map(({ voucher, thirds, methods, banks, schedules, payables, accounting }) => {
+        const thirdNames = thirds.names;
+        const thirdIdentifications = thirds.identifications;
+        const supplierIds = [...new Set((voucher.details ?? []).map((detail) => detail.supplierId))];
+        const supplierId = supplierIds[0] ?? 0;
+        const supplierLabel = supplierIds.length > 1
+          ? supplierIds.map((sid) => resolveSupplierName(thirdNames, sid)).join(', ')
+          : resolveSupplierName(thirdNames, supplierId);
         const method = (methods.content || []).find((item: any) => item.id === voucher.paymentMethodId);
+        const bank = (banks.content || []).find((item: any) => item.id === voucher.bankAccountId);
+        const schedule = schedules.find((item) => item.voucherId === voucher.id);
+        const payableList = payables as Array<Payable | null>;
+        const amounts = this.computeVoucherAmounts(voucher, payableList);
+        const executionRaw = voucher.updatedAt ?? voucher.createdAt;
+        const entryData = (accounting as { data?: Record<string, unknown> } | null)?.data
+          ?? (accounting as Record<string, unknown> | null);
+        const accountingEntryCode = voucher.accountingEntryCode?.trim()
+          || (typeof entryData?.['code'] === 'string' ? entryData['code'] : undefined)
+          || (typeof entryData?.['entryCode'] === 'string' ? entryData['entryCode'] : undefined);
         return {
           id: voucher.id,
           receiptCode: voucher.voucherNumber,
           issueDate: new Date(voucher.issueDate),
+          executionDateTime: executionRaw ? new Date(executionRaw) : undefined,
           thirdPartyId: supplierId,
-          supplierName: resolveSupplierName(thirdNames, supplierId),
+          supplierName: supplierLabel,
+          supplierIdentification: supplierIds.length === 1
+            ? resolveSupplierIdentification(thirdIdentifications, supplierId)
+            : supplierIds.map((sid) => resolveSupplierIdentification(thirdIdentifications, sid)).join(', '),
           paymentMethodName: translatePaymentMethodName(method?.name) || `Método ${voucher.paymentMethodId}`,
+          paymentMethodRequiresBankAccount: Boolean(method?.requiresBankAccount),
+          bankAccountId: voucher.bankAccountId,
+          bankAccountLabel: bank
+            ? `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`
+            : undefined,
           status: voucherStatusLabel(voucher.status),
           statusKey: voucher.status,
-          totalAmount: voucher.total,
-          observations: educationalDescription(voucher.observations, ''),
+          grossAmount: amounts.grossAmount,
+          retentionsAmount: amounts.retentionsAmount,
+          netAmount: amounts.netAmount,
+          totalAmount: amounts.netAmount,
+          observations: educationalDescription(voucher.observations, 'Pago a proveedor'),
           isDirectExpense: false,
-          details: voucher.details.map((detail) => ({
-            invoiceId: detail.invoiceId,
-            amountPaid: detail.amountPaid,
-            invoiceCode: detail.invoiceReference,
-            accountingAccount: detail.payableAccountId,
-          })),
+          accountingEntryId: voucher.accountingEntryId,
+          accountingEntryCode,
+          accountingStatusLabel: this.accountingStatusForVoucher(voucher),
+          scheduleId: schedule?.id,
+          scheduleExecutionDate: schedule?.executionDate,
+          details: (voucher.details ?? []).map((detail, index) =>
+            this.mapVoucherDetail(detail, payableList[index]?.sourceInvoiceId, payableList[index]),
+          ),
           accountingEntry: undefined,
         };
       }),
     );
+  }
+
+  private loadThirdPartyMaps(
+    enterpriseId: string,
+    supplierIds: number[],
+  ): Observable<{ names: Map<number, string>; identifications: Map<number, string> }> {
+    return this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(
+      catchError(() => of({ content: [] } as any)),
+      switchMap((thirdsPage) => {
+        const names = buildThirdPartyNameMap(thirdsPage?.content || []);
+        const identifications = buildThirdPartyIdentificationMap(thirdsPage?.content || []);
+        const missing = supplierIds.filter((id) => id != null && !names.has(Number(id)));
+        if (!missing.length) {
+          return of({ names, identifications });
+        }
+        return forkJoin(
+          missing.map((id) =>
+            this.thirds.getThirdPartie(id, enterpriseId).pipe(catchError(() => of(null))),
+          ),
+        ).pipe(
+          map((extraThirds) => {
+            extraThirds.filter(Boolean).forEach((third) => {
+              const id = Number(third!.thId);
+              const label =
+                (third!.socialReason as string) ||
+                [third!.names, third!.lastNames].filter(Boolean).join(' ') ||
+                `Proveedor ${id}`;
+              names.set(id, String(label));
+              const base = third!.idNumber != null ? String(third!.idNumber) : '';
+              identifications.set(
+                id,
+                base
+                  ? `${base}${third!.verificationNumber != null ? `-${third!.verificationNumber}` : ''}`
+                  : '—',
+              );
+            });
+            return { names, identifications };
+          }),
+        );
+      }),
+    );
+  }
+
+  private accountingStatusForVoucher(voucher: PaymentVoucher): string {
+    if (!voucher.accountingEntryId) {
+      return voucherStatusLabel(voucher.status);
+    }
+    if (voucher.status === 'VOIDED') {
+      return accountingEntryStatusLabel('VOIDED');
+    }
+    return accountingEntryStatusLabel('ACTIVE') === 'Desconocido'
+      ? 'Contabilizado'
+      : accountingEntryStatusLabel('ACTIVE');
+  }
+
+  getPaidInvoiceProductLines(sourceInvoiceId: number): Observable<PaidInvoiceLineView[]> {
+    return this.skeleton.getFactureById(sourceInvoiceId).pipe(
+      map((facture) => mapSkeletonProductsToLineViews(this.normalizeSkeletonProducts(facture as {
+        products?: PurchaseInvoiceProductLine[] | Iterable<PurchaseInvoiceProductLine>;
+      }))),
+    );
+  }
+
+  private computeVoucherAmounts(
+    voucher: PaymentVoucher,
+    payables: Array<Payable | null> = [],
+  ): {
+    grossAmount: number;
+    retentionsAmount: number;
+    netAmount: number;
+  } {
+    const details = voucher.details ?? [];
+    let grossAmount = 0;
+    let retentionsAmount = 0;
+    let netAmount = 0;
+    details.forEach((detail, index) => {
+      const amountPaid = this.detailAmountPaid(detail);
+      let previousBalance = Number(detail.previousBalance ?? 0);
+      const remainingBalance = Number(detail.remainingBalance ?? 0);
+      const payable = payables[index];
+      if (previousBalance <= 0 && payable) {
+        previousBalance = Number(
+          payable.originalAmount ?? payable.pendingAmount ?? payable.availableAmount ?? amountPaid,
+        );
+      }
+      const invoiceValue = previousBalance > 0 ? previousBalance : amountPaid;
+      const retention = Math.max(0, invoiceValue - amountPaid - remainingBalance);
+      grossAmount += invoiceValue;
+      retentionsAmount += retention;
+      netAmount += amountPaid;
+    });
+    if (!details.length) {
+      netAmount = Number(voucher.total ?? 0);
+      grossAmount = netAmount;
+    } else if (netAmount <= 0 && voucher.total) {
+      netAmount = Number(voucher.total);
+      if (grossAmount <= 0) {
+        grossAmount = netAmount;
+      }
+    }
+    return { grossAmount, retentionsAmount, netAmount };
+  }
+
+  private detailAmountPaid(detail: VoucherDetail): number {
+    return Number(detail.amountPaid ?? detail.amount ?? 0);
+  }
+
+  private mapVoucherDetail(
+    detail: VoucherDetail,
+    sourceInvoiceId?: number,
+    payable?: Payable | null,
+  ) {
+    const amountPaid = this.detailAmountPaid(detail);
+    let previousBalance = Number(detail.previousBalance ?? 0);
+    const remainingBalance = Number(detail.remainingBalance ?? 0);
+    if (previousBalance <= 0 && payable) {
+      previousBalance = Number(
+        payable.originalAmount ?? payable.pendingAmount ?? payable.availableAmount ?? amountPaid,
+      );
+    }
+    const invoiceValue = previousBalance > 0 ? previousBalance : amountPaid;
+    const retentionsApplied = Math.max(0, invoiceValue - amountPaid - remainingBalance);
+    return {
+      invoiceId: detail.invoiceId,
+      sourceInvoiceId: sourceInvoiceId != null ? Number(sourceInvoiceId) : undefined,
+      amountPaid,
+      invoiceCode: detail.invoiceReference?.trim() || payable?.reference || String(detail.invoiceId),
+      invoiceValue,
+      retentionsApplied,
+      payableAccountCode: detail.payableAccountCode?.trim() || payable?.payableAccountCode || '—',
+      remainingBalance,
+    };
+  }
+
+  private normalizeSkeletonProducts(facture: { products?: PurchaseInvoiceProductLine[] | Iterable<PurchaseInvoiceProductLine> }): PurchaseInvoiceProductLine[] {
+    const products = facture?.products;
+    if (!products) {
+      return [];
+    }
+    if (Array.isArray(products)) {
+      return products;
+    }
+    return Array.from(products);
   }
 
   createExpenseReceipt(request: ExpenseReceiptCreateRequest): Observable<ExpenseReceiptResponse> {
@@ -213,7 +421,47 @@ export class ExpenseReceiptService {
   }
 
   voidExpenseReceipt(receiptId: number, reason: string): Observable<ExpenseReceiptResponse> {
-    return this.api.voidVoucher(receiptId, this.enterpriseId(), reason) as unknown as Observable<ExpenseReceiptResponse>;
+    const enterpriseId = this.enterpriseId();
+    return this.api.voidVoucher(receiptId, enterpriseId, reason).pipe(
+      switchMap((voucher) => this.waitForVoucherVoidCompletion(receiptId, enterpriseId, voucher)),
+      map((voucher) => this.mapVoidedVoucherResponse(voucher)),
+    );
+  }
+
+  private waitForVoucherVoidCompletion(
+    receiptId: number,
+    enterpriseId: string,
+    voucher: PaymentVoucher,
+  ): Observable<PaymentVoucher> {
+    if (voucher.status !== 'VOIDING') {
+      return of(voucher);
+    }
+    return timer(0, 2000).pipe(
+      take(15),
+      switchMap(() => this.api.voucher(receiptId, enterpriseId)),
+      takeWhile((item) => item.status === 'VOIDING', true),
+      last(null),
+      map((item) => item ?? voucher),
+    );
+  }
+
+  private mapVoidedVoucherResponse(voucher: PaymentVoucher): ExpenseReceiptResponse {
+    return {
+      id: voucher.id,
+      receiptCode: voucher.voucherNumber,
+      thirdPartyId: voucher.details?.[0]?.supplierId ?? 0,
+      paymentMethodId: voucher.paymentMethodId,
+      status: voucher.status,
+      issueDate: voucher.issueDate,
+      totalAmount: Number(voucher.total ?? 0),
+      observations: voucher.observations ?? '',
+      details: (voucher.details ?? []).map((detail) => ({
+        invoiceId: detail.invoiceId,
+        amountPaid: Number(detail.amountPaid ?? 0),
+        invoiceCode: detail.invoiceReference,
+        accountingAccount: detail.payableAccountId,
+      })),
+    };
   }
 
   getAccountingEntry(receiptId: number): Observable<AccountingEntryLine[]> {
@@ -262,6 +510,7 @@ export class ExpenseReceiptService {
             documentTypeLabel: accountingSourceDocumentTypeLabel('PAYMENT_VOUCHER'),
             voucherNumber: headerContext.voucherNumber ?? voucher.voucherNumber,
             supplierLabel,
+            entryCode: voucher.accountingEntryCode,
           },
         );
       }),

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -477,14 +477,14 @@
       currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} bajas">
       <ng-template pTemplate="header">
         <tr>
-          <th>N.º</th>
-          <th>Fecha</th>
-          <th>Proveedor</th>
-          <th>Factura / referencia</th>
-          <th class="text-right">Total</th>
-          <th>Cuenta contrapartida</th>
-          <th>Estado</th>
-          <th style="min-width: 12rem">Acciones</th>
+          <th scope="col">N.º</th>
+          <th scope="col">Fecha</th>
+          <th scope="col">Proveedor</th>
+          <th scope="col">Factura / referencia</th>
+          <th scope="col" class="text-right">Total</th>
+          <th scope="col">Cuenta contrapartida</th>
+          <th scope="col">Estado</th>
+          <th scope="col" style="min-width: 12rem">Acciones</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-item>
@@ -1148,72 +1148,10 @@
   [draggable]="false"
   [resizable]="false"
   (onHide)="cancelScheduleDetailDialog()">
-  <div class="flex flex-col gap-3 text-sm" *ngIf="scheduleDetailTarget as item">
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-      <div>
-        <span class="text-gray-500">Programación</span>
-        <p class="font-mono font-semibold m-0">#{{ item.id }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Fecha de creación</span>
-        <p class="font-semibold m-0">{{ formatTreasuryInstant(item.createdAt) }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Fecha de ejecución</span>
-        <p class="font-semibold m-0">{{ item.executionDate }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Tipo</span>
-        <p class="font-semibold m-0">{{ scheduleTypeLabel(item) }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Proveedor</span>
-        <p class="font-semibold m-0">{{ scheduleSuppliersLabel(item) }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Método</span>
-        <p class="font-semibold m-0">{{ scheduleMethodLabel(item) }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Cuenta origen</span>
-        <p class="font-semibold m-0">{{ scheduleBankLabel(item) }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Total</span>
-        <p class="font-semibold m-0">{{ scheduleTotal(item) | currency:'COP' }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Estado</span>
-        <p class="m-0">
-          <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
-        </p>
-      </div>
-      <div>
-        <span class="text-gray-500">Reintentos</span>
-        <p class="font-semibold m-0">{{ item.retryCount }}</p>
-      </div>
-      <div>
-        <span class="text-gray-500">Último intento</span>
-        <p class="font-semibold m-0">{{ formatTreasuryInstant(item.updatedAt) }}</p>
-      </div>
-      <div *ngIf="canViewScheduleVoucher(item)">
-        <span class="text-gray-500">Comprobante</span>
-        <p class="font-mono font-semibold text-blue-600 m-0">{{ scheduleVoucherLabel(item) }}</p>
-      </div>
-    </div>
-    <div>
-      <span class="text-gray-500">Factura(s)</span>
-      <p class="font-mono text-sm m-0 mt-1">{{ scheduleInvoicesLabel(item) }}</p>
-    </div>
-    <div *ngIf="item.observations">
-      <span class="text-gray-500">Observaciones</span>
-      <p class="m-0 mt-1">{{ item.observations }}</p>
-    </div>
-    <div *ngIf="item.failureReason">
-      <span class="text-gray-500">Motivo del error</span>
-      <p class="m-0 mt-1 text-red-700">{{ item.failureReason }}</p>
-    </div>
-  </div>
+  <app-treasury-schedule-detail-panel
+    [item]="scheduleDetailTarget ?? null"
+    [view]="scheduleDetailView(scheduleDetailTarget)">
+  </app-treasury-schedule-detail-panel>
   <ng-template pTemplate="footer">
     <div class="flex gap-2 justify-end flex-wrap">
       <p-button

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -405,17 +405,41 @@
           </td>
           <td class="text-right font-semibold">{{ scheduleTotal(item) | currency:'COP':'symbol':'1.0-2' }}</td>
           <td>{{ item.retryCount }}</td>
-          <td>{{ item.voucherId || '-' }}</td>
+          <td>
+            <button
+              *ngIf="canViewScheduleVoucher(item)"
+              type="button"
+              class="font-mono font-semibold text-blue-600 hover:underline bg-transparent border-0 p-0"
+              (click)="openScheduleVoucher(item)">
+              {{ scheduleVoucherLabel(item) }}
+            </button>
+            <span *ngIf="!canViewScheduleVoucher(item)">—</span>
+          </td>
           <td>
             <div class="action-buttons flex flex-wrap gap-1">
               <p-button
-                *ngIf="item.status === 'SCHEDULED'"
+                label="Ver detalle"
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                (onClick)="showScheduleDetail(item)">
+              </p-button>
+              <p-button
+                *ngIf="canCancelSchedule(item)"
                 label="Cancelar"
                 icon="pi pi-ban"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
                 (onClick)="cancel(item)">
+              </p-button>
+              <p-button
+                *ngIf="canViewScheduleVoucher(item)"
+                label="Ver comprobante"
+                icon="pi pi-file"
+                size="small"
+                (onClick)="openScheduleVoucher(item)">
               </p-button>
               <p-button
                 *ngIf="item.status === 'FAILED'"
@@ -454,31 +478,45 @@
       <ng-template pTemplate="header">
         <tr>
           <th>N.º</th>
-          <th>Estado</th>
+          <th>Fecha</th>
+          <th>Proveedor</th>
+          <th>Factura / referencia</th>
           <th class="text-right">Total</th>
-          <th>Motivo</th>
-          <th style="min-width: 10rem">Acciones</th>
+          <th>Cuenta contrapartida</th>
+          <th>Estado</th>
+          <th style="min-width: 12rem">Acciones</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-item>
         <tr>
-          <td class="font-mono">{{ item.id }}</td>
+          <td class="font-mono">{{ writeOffNumberLabel(item) }}</td>
+          <td>{{ writeOffDateLabel(item) }}</td>
+          <td>{{ writeOffSupplierLabel(item) }}</td>
+          <td class="font-mono text-blue-600">{{ writeOffInvoiceReference(item) }}</td>
+          <td class="text-right font-semibold">{{ item.total | currency:'COP' }}</td>
+          <td>{{ writeOffCounterpartLabel(item) }}</td>
           <td>
             <p-tag [value]="writeOffLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
           </td>
-          <td class="text-right font-semibold">{{ item.total | currency:'COP' }}</td>
-          <td>{{ item.reason }}</td>
           <td>
             <div class="action-buttons flex flex-wrap gap-1">
               <p-button
-                *ngIf="item.status === 'DRAFT' || item.status === 'FAILED'"
+                label="Ver detalle"
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                (onClick)="showWriteOffDetail(item)">
+              </p-button>
+              <p-button
+                *ngIf="canPostWriteOff(item)"
                 [label]="item.status === 'FAILED' ? 'Reintentar' : 'Contabilizar'"
                 icon="pi pi-check"
                 size="small"
                 (onClick)="confirmWriteOff(item)">
               </p-button>
               <p-button
-                *ngIf="item.status === 'DRAFT'"
+                *ngIf="canDiscardWriteOff(item)"
                 label="Descartar borrador"
                 icon="pi pi-trash"
                 size="small"
@@ -489,7 +527,16 @@
                 (onClick)="discardDraftWriteOff(item)">
               </p-button>
               <p-button
-                *ngIf="item.status === 'POSTED' || item.status === 'VOID_FAILED'"
+                *ngIf="canShowWriteOffAccounting(item)"
+                label="Ver asiento"
+                icon="pi pi-book"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                (onClick)="showWriteOffAccounting(item)">
+              </p-button>
+              <p-button
+                *ngIf="canVoidWriteOff(item)"
                 [label]="item.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular'"
                 icon="pi pi-times"
                 size="small"
@@ -505,7 +552,7 @@
       </ng-template>
       <ng-template pTemplate="emptymessage">
         <tr>
-          <td colspan="5" class="text-center py-8">
+          <td colspan="8" class="text-center py-8">
             <div class="flex flex-col items-center gap-3">
               <i class="pi pi-inbox text-4xl text-gray-400"></i>
               <p class="text-gray-600">No hay bajas de CxP</p>
@@ -1008,6 +1055,186 @@
         severity="danger"
         [disabled]="busy"
         (onClick)="confirmDiscardWriteOff()">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Detalle de baja de CxP"
+  [(visible)]="writeOffDetailDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(520px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelWriteOffDetailDialog()">
+  <div class="flex flex-col gap-3 text-sm" *ngIf="writeOffDetailTarget as item">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div>
+        <span class="text-gray-500">N.º</span>
+        <p class="font-mono font-semibold m-0">{{ writeOffNumberLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Fecha</span>
+        <p class="font-semibold m-0">{{ writeOffDateLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Proveedor</span>
+        <p class="font-semibold m-0">{{ writeOffSupplierLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Factura / referencia</span>
+        <p class="font-mono font-semibold text-blue-600 m-0">{{ writeOffInvoiceReference(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Saldo original</span>
+        <p class="font-semibold m-0">{{ writeOffOriginalBalanceLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Saldo disponible</span>
+        <p class="font-semibold m-0">{{ writeOffAvailableBalanceLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Monto de baja</span>
+        <p class="font-semibold m-0">{{ item.total | currency:'COP' }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Estado</span>
+        <p class="m-0">
+          <p-tag [value]="writeOffLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
+        </p>
+      </div>
+      <div>
+        <span class="text-gray-500">Cuenta CxP</span>
+        <p class="font-semibold m-0">{{ writeOffPayableAccountLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Cuenta contrapartida</span>
+        <p class="font-semibold m-0">{{ writeOffCounterpartLabel(item) }}</p>
+      </div>
+      <div *ngIf="canShowWriteOffAccounting(item)">
+        <span class="text-gray-500">Asiento</span>
+        <p class="font-semibold m-0">{{ writeOffAccountingEntryLabel(item) }}</p>
+      </div>
+    </div>
+    <div *ngIf="item.reason">
+      <span class="text-gray-500">Motivo</span>
+      <p class="m-0 mt-1">{{ item.reason }}</p>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end">
+      <p-button
+        label="Cerrar"
+        severity="secondary"
+        [outlined]="true"
+        (onClick)="cancelWriteOffDetailDialog()">
+      </p-button>
+      <p-button
+        *ngIf="writeOffDetailTarget && canShowWriteOffAccounting(writeOffDetailTarget)"
+        label="Ver asiento"
+        icon="pi pi-book"
+        (onClick)="showWriteOffAccounting(writeOffDetailTarget!)">
+      </p-button>
+    </div>
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Detalle de programación de pago"
+  [(visible)]="scheduleDetailDialogVisible"
+  [modal]="true"
+  [style]="{ width: 'min(560px, 95vw)' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cancelScheduleDetailDialog()">
+  <div class="flex flex-col gap-3 text-sm" *ngIf="scheduleDetailTarget as item">
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div>
+        <span class="text-gray-500">Programación</span>
+        <p class="font-mono font-semibold m-0">#{{ item.id }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Fecha de creación</span>
+        <p class="font-semibold m-0">{{ formatTreasuryInstant(item.createdAt) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Fecha de ejecución</span>
+        <p class="font-semibold m-0">{{ item.executionDate }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Tipo</span>
+        <p class="font-semibold m-0">{{ scheduleTypeLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Proveedor</span>
+        <p class="font-semibold m-0">{{ scheduleSuppliersLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Método</span>
+        <p class="font-semibold m-0">{{ scheduleMethodLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Cuenta origen</span>
+        <p class="font-semibold m-0">{{ scheduleBankLabel(item) }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Total</span>
+        <p class="font-semibold m-0">{{ scheduleTotal(item) | currency:'COP' }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Estado</span>
+        <p class="m-0">
+          <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
+        </p>
+      </div>
+      <div>
+        <span class="text-gray-500">Reintentos</span>
+        <p class="font-semibold m-0">{{ item.retryCount }}</p>
+      </div>
+      <div>
+        <span class="text-gray-500">Último intento</span>
+        <p class="font-semibold m-0">{{ formatTreasuryInstant(item.updatedAt) }}</p>
+      </div>
+      <div *ngIf="canViewScheduleVoucher(item)">
+        <span class="text-gray-500">Comprobante</span>
+        <p class="font-mono font-semibold text-blue-600 m-0">{{ scheduleVoucherLabel(item) }}</p>
+      </div>
+    </div>
+    <div>
+      <span class="text-gray-500">Factura(s)</span>
+      <p class="font-mono text-sm m-0 mt-1">{{ scheduleInvoicesLabel(item) }}</p>
+    </div>
+    <div *ngIf="item.observations">
+      <span class="text-gray-500">Observaciones</span>
+      <p class="m-0 mt-1">{{ item.observations }}</p>
+    </div>
+    <div *ngIf="item.failureReason">
+      <span class="text-gray-500">Motivo del error</span>
+      <p class="m-0 mt-1 text-red-700">{{ item.failureReason }}</p>
+    </div>
+  </div>
+  <ng-template pTemplate="footer">
+    <div class="flex gap-2 justify-end flex-wrap">
+      <p-button
+        label="Cerrar"
+        severity="secondary"
+        [outlined]="true"
+        (onClick)="cancelScheduleDetailDialog()">
+      </p-button>
+      <p-button
+        *ngIf="scheduleDetailTarget && canViewScheduleVoucher(scheduleDetailTarget)"
+        label="Ver comprobante"
+        icon="pi pi-file"
+        (onClick)="openScheduleVoucher(scheduleDetailTarget!)">
+      </p-button>
+      <p-button
+        *ngIf="scheduleDetailTarget && canCancelSchedule(scheduleDetailTarget)"
+        label="Cancelar"
+        icon="pi pi-ban"
+        severity="danger"
+        [outlined]="true"
+        (onClick)="cancel(scheduleDetailTarget!); cancelScheduleDetailDialog()">
       </p-button>
     </div>
   </ng-template>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -28,10 +28,12 @@ describe('TreasuryOperationsComponent PP8', () => {
       voidWriteOff: jasmine.createSpy('voidWriteOff').and.returnValue(NEVER),
       changeDueDate: jasmine.createSpy('changeDueDate').and.returnValue(of({})),
       pending: jasmine.createSpy('pending').and.returnValue(of([])),
+      payable: jasmine.createSpy('payable').and.returnValue(of(null)),
       vouchers: jasmine.createSpy('vouchers').and.returnValue(of({ content: [] })),
       schedules: jasmine.createSpy('schedules').and.returnValue(of([])),
       writeOffs: jasmine.createSpy('writeOffs').and.returnValue(of([])),
       writeOff: jasmine.createSpy('writeOff').and.returnValue(of({ id: 1, status: 'POSTED', total: 100 })),
+      accountingEntry: jasmine.createSpy('accountingEntry').and.returnValue(of({ code: 'AE-PWO-12', movements: [] })),
     };
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const exportService = {
@@ -47,6 +49,7 @@ describe('TreasuryOperationsComponent PP8', () => {
     const expenseReceiptService = {
       getSuppliers: jasmine.createSpy('getSuppliers').and.returnValue(of([])),
     };
+    const router = { navigate: jasmine.createSpy('navigate') };
     const value = new TreasuryOperationsComponent(
       api as any,
       storage as any,
@@ -57,6 +60,7 @@ describe('TreasuryOperationsComponent PP8', () => {
       exportService as any,
       messageService as any,
       expenseReceiptService as any,
+      router as any,
     );
     value.payables = [{
       id: 11, sourceInvoiceId: 50, reference: 'FC-50', enterpriseId: 'enterprise-a', supplierId: 7,
@@ -854,5 +858,123 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.searchVoucherSupplier({ query: 'Pep' });
     expect(expenseReceiptService.getSuppliers).toHaveBeenCalledWith('pep');
     expect(value.filteredVoucherSuppliers).toEqual([sampleSupplier(7, 'PEPSI')]);
+  });
+
+  function sampleWriteOff(overrides: Partial<any> = {}) {
+    return {
+      id: 12,
+      enterpriseId: 'enterprise-a',
+      reason: 'Condonación',
+      counterpartAccountId: 4295,
+      counterpartAccountCode: '429501',
+      total: 87360,
+      status: 'POSTED' as const,
+      accountingEntryId: 37,
+      accountingEntryCode: 'AE-PWO-12',
+      createdAt: '2026-08-14T10:00:00Z',
+      version: 0,
+      details: [{
+        supplierId: 7,
+        invoiceId: 11,
+        invoiceReference: '678151694',
+        payableAccountId: 2205,
+        payableAccountCode: '220501',
+        amount: 87360,
+      }],
+      ...overrides,
+    };
+  }
+
+  it('formats write-off table labels from API and catalog data', () => {
+    const { value } = component();
+    const item = sampleWriteOff();
+    expect(value.writeOffNumberLabel(item)).toBe('12');
+    expect(value.writeOffDateLabel(item)).toBe('14/08/2026');
+    expect(value.writeOffSupplierLabel(item)).toBe('Proveedor Demo');
+    expect(value.writeOffInvoiceReference(item)).toBe('678151694');
+    expect(value.writeOffCounterpartLabel(item)).toBe('429501 - Ingresos diversos');
+    expect(value.writeOffAccountingEntryLabel(item)).toBe('AE-PWO-12');
+    expect(value.writeOffSupplierLabel(item)).not.toContain('7');
+    expect(value.writeOffInvoiceReference(item)).not.toContain('11');
+  });
+
+  it('falls back to payable reference when invoiceReference is missing', () => {
+    const { value } = component();
+    const item = sampleWriteOff({
+      details: [{ supplierId: 7, invoiceId: 11, amount: 100 }],
+    });
+    expect(value.writeOffInvoiceReference(item)).toBe('FC-50');
+  });
+
+  it('shows fallback supplier label when third is not in catalogue', () => {
+    const { value } = component();
+    const item = sampleWriteOff({
+      details: [{ supplierId: 99, invoiceId: 11, invoiceReference: '678151694', amount: 100 }],
+    });
+    expect(value.writeOffSupplierLabel(item)).toBe('Proveedor 99');
+  });
+
+  it('formats write-off balances from API detail fields', () => {
+    const { value } = component();
+    const item = sampleWriteOff({
+      details: [{
+        supplierId: 7,
+        invoiceId: 11,
+        invoiceReference: '678151694',
+        amount: 100,
+        originalAmount: 5000,
+        availableAmount: 3000,
+      }],
+    });
+    expect(value.writeOffOriginalBalanceLabel(item)).toBe('$ 5.000');
+    expect(value.writeOffAvailableBalanceLabel(item)).toBe('$ 3.000');
+  });
+
+  it('exposes write-off actions according to status', () => {
+    const { value } = component();
+    const draft = sampleWriteOff({ status: 'DRAFT', accountingEntryId: undefined, accountingEntryCode: undefined });
+    expect(value.canPostWriteOff(draft)).toBeTrue();
+    expect(value.canDiscardWriteOff(draft)).toBeTrue();
+    expect(value.canVoidWriteOff(draft)).toBeFalse();
+    expect(value.canShowWriteOffAccounting(draft)).toBeFalse();
+
+    const posted = sampleWriteOff({ status: 'POSTED' });
+    expect(value.canPostWriteOff(posted)).toBeFalse();
+    expect(value.canDiscardWriteOff(posted)).toBeFalse();
+    expect(value.canVoidWriteOff(posted)).toBeTrue();
+    expect(value.canShowWriteOffAccounting(posted)).toBeTrue();
+
+    const voided = sampleWriteOff({ status: 'VOIDED' });
+    expect(value.canVoidWriteOff(voided)).toBeFalse();
+    expect(value.canShowWriteOffAccounting(voided)).toBeTrue();
+  });
+
+  it('loads write-off accounting entry with PAYABLE_WRITEOFF source type', () => {
+    const { value, api } = component();
+    const item = sampleWriteOff();
+    value.showWriteOffAccounting(item);
+    expect(api.accountingEntry).toHaveBeenCalledWith(12, 'PAYABLE_WRITEOFF');
+  });
+
+  it('opens write-off detail dialog and refreshes detail from API', () => {
+    const { value, api } = component();
+    const item = sampleWriteOff({ status: 'DRAFT', accountingEntryId: undefined });
+    const refreshed = sampleWriteOff({
+      status: 'DRAFT',
+      accountingEntryId: undefined,
+      details: [{
+        supplierId: 7,
+        invoiceId: 11,
+        invoiceReference: '678151694',
+        amount: 87360,
+        originalAmount: 5000,
+        availableAmount: 3000,
+      }],
+    });
+    api.writeOff.and.returnValue(of(refreshed));
+    value.showWriteOffDetail(item);
+    expect(value.writeOffDetailDialogVisible).toBeTrue();
+    expect(api.writeOff).toHaveBeenCalledWith(12);
+    expect(value.writeOffDetailTarget?.details?.[0]?.originalAmount).toBe(5000);
   });
 });

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -43,6 +43,7 @@ import {
   filterSelectablePaymentMethods,
 } from '../Shared/treasury-account.integration';
 import {
+  buildTreasuryScheduleDetailView,
   formatTreasuryInstant,
   scheduleInvoicesLabel,
   scheduleMethodLabel,
@@ -51,6 +52,7 @@ import {
   scheduleTypeLabel,
   scheduleVoucherLabel,
 } from '../Shared/treasury-schedule-display';
+import { TreasuryScheduleDetailPanelComponent } from '../Shared/treasury-schedule-detail-panel.component';
 import { buildThirdPartyNameMap, resolveSupplierName } from '../Shared/treasury-third-party.integration';
 import {
   AccountingEntryViewHeader,
@@ -109,6 +111,7 @@ import { Supplier } from '../ExpenseReceipts/Model/Models';
     ToastModule,
     ContextualHelpComponent,
     AutoCompleteModule,
+    TreasuryScheduleDetailPanelComponent,
   ],
   templateUrl: './treasury-operations.component.html',
   styleUrl: './treasury-operations.component.css',
@@ -1159,6 +1162,26 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       return '—';
     }
     return `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`;
+  }
+
+  scheduleDetailView(item?: PaymentSchedule) {
+    if (!item) {
+      return null;
+    }
+    return buildTreasuryScheduleDetailView(item, {
+      executionDate: item.executionDate,
+      type: scheduleTypeLabel(item),
+      supplier: scheduleSuppliersLabel(item, this.supplierNames),
+      method: scheduleMethodLabel(item, this.methods),
+      bank: this.scheduleBankLabel(item),
+      total: this.scheduleTotal(item).toLocaleString('es-CO', { style: 'currency', currency: 'COP' }),
+      statusLabel: scheduleStatusLabel(item.status),
+      statusSeverity: this.getStatusSeverity(item.status),
+      invoices: scheduleInvoicesLabel(item, this.payableReferenceMap(), (amount) =>
+        amount.toLocaleString('es-CO', { style: 'currency', currency: 'COP' })),
+      showVoucher: this.canViewScheduleVoucher(item),
+      voucher: scheduleVoucherLabel(item, this.voucherNumberById()),
+    });
   }
 
   openScheduleVoucher(item: PaymentSchedule) {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { forkJoin, Observable, of, Subject, timer, TimeoutError } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, filter, finalize, map, switchMap, take, takeUntil, takeWhile, timeout } from 'rxjs/operators';
@@ -42,10 +43,13 @@ import {
   filterSelectablePaymentMethods,
 } from '../Shared/treasury-account.integration';
 import {
+  formatTreasuryInstant,
   scheduleInvoicesLabel,
   scheduleMethodLabel,
   scheduleSuppliersLabel,
   scheduleTotal,
+  scheduleTypeLabel,
+  scheduleVoucherLabel,
 } from '../Shared/treasury-schedule-display';
 import { buildThirdPartyNameMap, resolveSupplierName } from '../Shared/treasury-third-party.integration';
 import {
@@ -139,7 +143,11 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   minExecutionDate!: Date;
   writeOffDialogVisible = false;
   writeOffDiscardDialogVisible = false;
+  writeOffDetailDialogVisible = false;
+  scheduleDetailDialogVisible = false;
   writeOffDiscardTarget?: PayableWriteOff;
+  writeOffDetailTarget?: PayableWriteOff;
+  scheduleDetailTarget?: PaymentSchedule;
   writeOffTarget?: Payable;
   writeOffAmount?: number;
   writeOffCounterpartAccountId?: number;
@@ -193,12 +201,217 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
   readonly voucherStatusOptions = voucherStatusFilterOptions();
   private supplierNames = new Map<number, string>();
+  private payableByInvoiceId = new Map<number, Payable>();
 
   statusLabel = voucherStatusLabel;
 
   voucherAccountingEntryLabel(voucher: PaymentVoucher): string {
     const code = voucher.accountingEntryCode?.trim();
     return code ? code : '—';
+  }
+
+  writeOffNumberLabel(item: PayableWriteOff): string {
+    return String(item.id);
+  }
+
+  writeOffAccountingEntryLabel(item: PayableWriteOff): string {
+    const code = item.accountingEntryCode?.trim();
+    return code ? code : '—';
+  }
+
+  writeOffDateLabel(item: PayableWriteOff): string {
+    const raw = item.createdAt;
+    if (!raw) {
+      return '—';
+    }
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    return `${day}/${month}/${year}`;
+  }
+
+  writeOffSupplierLabel(item: PayableWriteOff): string {
+    const detail = item.details?.[0];
+    let supplierId = detail?.supplierId != null ? Number(detail.supplierId) : undefined;
+    if (supplierId == null) {
+      const payable = this.findPayableForWriteOff(item);
+      if (payable?.supplierId != null) {
+        supplierId = Number(payable.supplierId);
+      }
+    }
+    if (supplierId == null) {
+      return '—';
+    }
+    return resolveSupplierName(this.supplierNames, supplierId);
+  }
+
+  writeOffInvoiceReference(item: PayableWriteOff): string {
+    const details = item.details ?? [];
+    if (!details.length) {
+      return '—';
+    }
+    const refs = details.map((detail) => {
+      const fromApi = detail.invoiceReference?.trim();
+      if (fromApi) {
+        return fromApi;
+      }
+      const payable = this.payables.find((entry) => entry.id === detail.invoiceId);
+      if (payable?.reference?.trim()) {
+        return payable.reference.trim();
+      }
+      return null;
+    }).filter((value): value is string => Boolean(value));
+    if (!refs.length) {
+      return '—';
+    }
+    return [...new Set(refs)].join(', ');
+  }
+
+  writeOffCounterpartLabel(item: PayableWriteOff): string {
+    const id = item.counterpartAccountId;
+    const account = id != null
+      ? this.accounts.find((entry) => Number(entry.id) === Number(id))
+      : undefined;
+    if (account) {
+      const code = this.resolveAccountCode(account);
+      return `${code} - ${account.description}`;
+    }
+    const code = item.counterpartAccountCode?.trim();
+    if (code) {
+      const byCode = this.accounts.find(
+        (entry) => this.resolveAccountCode(entry) === code,
+      );
+      if (byCode) {
+        return `${this.resolveAccountCode(byCode)} - ${byCode.description}`;
+      }
+      return code;
+    }
+    return '—';
+  }
+
+  writeOffPayableAccountLabel(item: PayableWriteOff): string {
+    const detail = item.details?.[0];
+    if (!detail) {
+      return '—';
+    }
+    const account = this.accounts.find(
+      (entry) => entry.id === detail.payableAccountId
+        || this.resolveAccountCode(entry) === detail.payableAccountCode,
+    );
+    if (account) {
+      return `${this.resolveAccountCode(account)} - ${account.description}`;
+    }
+    return detail.payableAccountCode?.trim() ?? '—';
+  }
+
+  writeOffAvailableBalanceLabel(item: PayableWriteOff): string {
+    const detail = item.details?.[0];
+    if (detail?.availableAmount != null) {
+      return this.formatMoney(Number(detail.availableAmount));
+    }
+    const payable = this.findPayableForWriteOff(item);
+    if (payable?.availableAmount != null) {
+      return this.formatMoney(Number(payable.availableAmount));
+    }
+    return '—';
+  }
+
+  writeOffOriginalBalanceLabel(item: PayableWriteOff): string {
+    const detail = item.details?.[0];
+    if (detail?.originalAmount != null) {
+      return this.formatMoney(Number(detail.originalAmount));
+    }
+    const payable = this.findPayableForWriteOff(item);
+    if (payable?.originalAmount != null) {
+      return this.formatMoney(Number(payable.originalAmount));
+    }
+    return '—';
+  }
+
+  canPostWriteOff(item: PayableWriteOff): boolean {
+    return item.status === 'DRAFT' || item.status === 'FAILED';
+  }
+
+  canDiscardWriteOff(item: PayableWriteOff): boolean {
+    return item.status === 'DRAFT';
+  }
+
+  canVoidWriteOff(item: PayableWriteOff): boolean {
+    return item.status === 'POSTED' || item.status === 'VOID_FAILED';
+  }
+
+  canShowWriteOffAccounting(item: PayableWriteOff): boolean {
+    return item.accountingEntryId != null && item.status !== 'DRAFT';
+  }
+
+  showWriteOffDetail(item: PayableWriteOff) {
+    this.writeOffDetailTarget = item;
+    this.writeOffDetailDialogVisible = true;
+    if (!item.id) {
+      return;
+    }
+    this.api.writeOff(item.id).subscribe({
+      next: (fresh) => {
+        const normalized = this.normalizeWriteOff(fresh);
+        this.writeOffDetailTarget = normalized;
+        this.upsertWriteOff(fresh);
+        this.ensurePayablesForWriteOffs([normalized]).subscribe();
+      },
+    });
+  }
+
+  cancelWriteOffDetailDialog() {
+    this.writeOffDetailDialogVisible = false;
+    this.writeOffDetailTarget = undefined;
+  }
+
+  showWriteOffAccounting(item: PayableWriteOff) {
+    if (!item.accountingEntryId) {
+      return;
+    }
+    this.busy = true;
+    this.accountingEntry = null;
+    this.accountingEntryHeader = {};
+    this.accountingMovements = [];
+    this.accountingDebitTotal = 0;
+    this.accountingCreditTotal = 0;
+    const accountLookup = buildAccountCatalogueLookup(this.accounts);
+    const supplierIds = [...new Set((item.details ?? []).map((detail) => detail.supplierId))];
+    const supplierLabel = supplierIds
+      .map((id) => this.supplierNames.get(Number(id)) ?? '—')
+      .join(', ');
+
+    this.api.accountingEntry(item.id, 'PAYABLE_WRITEOFF').subscribe({
+      next: (value) => {
+        const entry = value?.data ?? value;
+        const view = buildAccountingEntryView(
+          entry as Record<string, unknown>,
+          mapAccountingMovementsForView(entry?.movements ?? entry?.details ?? [], accountLookup),
+          {
+            documentTypeLabel: accountingSourceDocumentTypeLabel('PAYABLE_WRITEOFF'),
+            voucherNumber: this.writeOffNumberLabel(item),
+            supplierLabel,
+            entryCode: this.writeOffAccountingEntryLabel(item) !== '—'
+              ? this.writeOffAccountingEntryLabel(item)
+              : undefined,
+          },
+        );
+        this.accountingEntry = entry;
+        this.accountingEntryHeader = view.header;
+        this.accountingMovements = view.movements;
+        this.accountingDebitTotal = this.accountingMovements.reduce((sum, row) => sum + row.debit, 0);
+        this.accountingCreditTotal = this.accountingMovements.reduce((sum, row) => sum + row.credit, 0);
+        this.busy = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.message ?? 'No fue posible consultar el asiento.';
+        this.busy = false;
+      },
+    });
   }
   scheduleLabel = scheduleStatusLabel;
   writeOffLabel = voucherStatusLabel;
@@ -217,6 +430,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     private readonly exportService: TreasuryExportService,
     private readonly messageService: MessageService,
     private readonly expenseReceiptService: ExpenseReceiptService,
+    private readonly router: Router,
   ) {
     this.enterpriseId = this.storage.getIdEnterprise();
   }
@@ -356,6 +570,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         this.applyVoucherFilters();
         this.schedules = data.schedules;
         this.writeOffs = this.normalizeWriteOffList(data.writeOffs);
+        this.ensurePayablesForWriteOffs(this.writeOffs).subscribe();
         this.banks = data.banks.content;
         this.bankOptions = this.banks.map((bank: any) => ({
           id: bank.id,
@@ -406,6 +621,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     switch (status) {
       case 'POSTED':
       case 'SCHEDULED':
+      case 'EXECUTED':
         return 'success';
       case 'DRAFT':
       case 'POSTING':
@@ -909,6 +1125,57 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     return scheduleMethodLabel(item, this.methods);
   }
 
+  scheduleTypeLabel = scheduleTypeLabel;
+  formatTreasuryInstant = formatTreasuryInstant;
+
+  scheduleVoucherLabel(item: PaymentSchedule): string {
+    return scheduleVoucherLabel(item, this.voucherNumberById());
+  }
+
+  canCancelSchedule(item: PaymentSchedule): boolean {
+    return item.status === 'SCHEDULED';
+  }
+
+  canViewScheduleVoucher(item: PaymentSchedule): boolean {
+    return item.status === 'EXECUTED' && item.voucherId != null;
+  }
+
+  showScheduleDetail(item: PaymentSchedule) {
+    this.scheduleDetailTarget = item;
+    this.scheduleDetailDialogVisible = true;
+  }
+
+  cancelScheduleDetailDialog() {
+    this.scheduleDetailDialogVisible = false;
+    this.scheduleDetailTarget = undefined;
+  }
+
+  scheduleBankLabel(item: PaymentSchedule): string {
+    if (!item.bankAccountId) {
+      return '—';
+    }
+    const bank = this.banks.find((entry) => Number(entry.id) === Number(item.bankAccountId));
+    if (!bank) {
+      return '—';
+    }
+    return `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`;
+  }
+
+  openScheduleVoucher(item: PaymentSchedule) {
+    if (!item.voucherId) {
+      return;
+    }
+    this.router.navigate(['/financial/treasury/expense-receipts/details', item.voucherId]);
+  }
+
+  private voucherNumberById(): Map<number, string> {
+    return new Map(
+      this.allVouchers
+        .filter((voucher) => voucher.voucherNumber)
+        .map((voucher) => [voucher.id, voucher.voucherNumber]),
+    );
+  }
+
   private payableReferenceMap(): Map<number, string> {
     return new Map(this.payables.map((payable) => [payable.id, payable.reference]));
   }
@@ -1221,6 +1488,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       next: ({ updated, payables, writeOffs }) => {
         this.payables = payables;
         this.writeOffs = this.normalizeWriteOffList(writeOffs);
+        this.ensurePayablesForWriteOffs(this.writeOffs).subscribe();
         if (updated.status === 'POSTED') {
           const stillPending = invoiceId != null
             ? payables.some((payable) => payable.id === invoiceId)
@@ -1299,6 +1567,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       next: ({ updated, payables, writeOffs }) => {
         this.payables = payables;
         this.writeOffs = this.normalizeWriteOffList(writeOffs);
+        this.ensurePayablesForWriteOffs(this.writeOffs).subscribe();
         if (updated.status === 'VOIDED') {
           this.messageService.add({
             severity: 'success',
@@ -1332,6 +1601,48 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     return detail?.invoiceId != null ? Number(detail.invoiceId) : undefined;
   }
 
+  private findPayableForWriteOff(item: PayableWriteOff): Payable | undefined {
+    const invoiceId = this.writeOffInvoiceId(item);
+    if (invoiceId == null) {
+      return undefined;
+    }
+    const cached = this.payableByInvoiceId.get(invoiceId);
+    if (cached) {
+      return cached;
+    }
+    return this.payables.find((entry) => entry.id === invoiceId);
+  }
+
+  private ensurePayablesForWriteOffs(writeOffs: PayableWriteOff[]): Observable<void> {
+    const invoiceIds = [...new Set(
+      writeOffs.flatMap((writeOff) =>
+        (writeOff.details ?? [])
+          .map((detail) => detail.invoiceId)
+          .filter((invoiceId): invoiceId is number => invoiceId != null),
+      ),
+    )];
+    const missing = invoiceIds.filter((invoiceId) =>
+      !this.payables.some((payable) => payable.id === invoiceId)
+      && !this.payableByInvoiceId.has(invoiceId),
+    );
+    if (!missing.length) {
+      return of(void 0);
+    }
+    return forkJoin(
+      missing.map((invoiceId) =>
+        this.api.payable(invoiceId, this.enterpriseId).pipe(
+          catchError(() => of(null)),
+          map((payable) => {
+            if (payable) {
+              this.payableByInvoiceId.set(payable.id, payable);
+            }
+            return payable;
+          }),
+        ),
+      ),
+    ).pipe(map(() => void 0));
+  }
+
   private waitForWriteOffPosting(writeOffId: number) {
     return timer(0, TreasuryOperationsComponent.POST_POLL_INTERVAL_MS).pipe(
       take(TreasuryOperationsComponent.POST_POLL_MAX_ATTEMPTS),
@@ -1356,11 +1667,17 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     const record = raw as Record<string, unknown>;
     const rawStatus = record['status'];
     const status = typeof rawStatus === 'string' ? rawStatus : 'DRAFT';
+    const createdAt = typeof record['createdAt'] === 'string' ? record['createdAt'] : undefined;
+    const accountingEntryCode = typeof record['accountingEntryCode'] === 'string'
+      ? record['accountingEntryCode']
+      : undefined;
     return {
       ...(raw as PayableWriteOff),
       id: Number(record['id']),
       total: Number(record['total'] ?? 0),
       status,
+      createdAt,
+      accountingEntryCode,
     };
   }
 
@@ -1655,17 +1972,20 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           this.scheduleLabel(item.status),
           this.scheduleTotal(item),
           item.retryCount,
-          item.voucherId || '-',
+          this.scheduleVoucherLabel(item),
         ]),
       },
       {
         title: 'Bajas de CxP',
-        headers: ['N.º', 'Estado', 'Total', 'Motivo'],
+        headers: ['N.º', 'Fecha', 'Proveedor', 'Factura / referencia', 'Total', 'Cuenta contrapartida', 'Estado'],
         rows: this.writeOffs.map((item) => [
-          item.id,
-          this.writeOffLabel(item.status),
+          this.writeOffNumberLabel(item),
+          this.writeOffDateLabel(item),
+          this.writeOffSupplierLabel(item),
+          this.writeOffInvoiceReference(item),
           item.total,
-          item.reason || '-',
+          this.writeOffCounterpartLabel(item),
+          this.writeOffLabel(item.status),
         ]),
       },
     ];

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
@@ -146,11 +146,28 @@
           </td>
           <td class="text-right font-semibold">{{ formatCurrency(scheduleTotalFn(item)) }}</td>
           <td>{{ item.retryCount }}</td>
-          <td>{{ item.voucherId || '—' }}</td>
+          <td>
+            <button
+              *ngIf="canViewScheduleVoucher(item)"
+              type="button"
+              class="font-mono font-semibold text-blue-600 hover:underline bg-transparent border-0 p-0"
+              (click)="openScheduleVoucher(item)">
+              {{ scheduleVoucherLabel(item) }}
+            </button>
+            <span *ngIf="!canViewScheduleVoucher(item)">—</span>
+          </td>
           <td>
             <div class="flex flex-wrap gap-1">
               <p-button
-                *ngIf="item.status === 'SCHEDULED'"
+                label="Ver detalle"
+                icon="pi pi-eye"
+                size="small"
+                severity="secondary"
+                [outlined]="true"
+                (onClick)="showScheduleDetail(item)">
+              </p-button>
+              <p-button
+                *ngIf="canCancelSchedule(item)"
                 label="Cancelar"
                 icon="pi pi-ban"
                 size="small"
@@ -158,6 +175,14 @@
                 [outlined]="true"
                 [disabled]="actionBusy"
                 (onClick)="cancelSchedule(item)">
+              </p-button>
+              <p-button
+                *ngIf="canViewScheduleVoucher(item)"
+                label="Ver comprobante"
+                icon="pi pi-file"
+                size="small"
+                [disabled]="actionBusy"
+                (onClick)="openScheduleVoucher(item)">
               </p-button>
               <p-button
                 *ngIf="item.status === 'FAILED'"
@@ -236,6 +261,107 @@
       </div>
     </p-card>
   </div>
+
+  <p-dialog
+    header="Detalle de programación de pago"
+    [(visible)]="scheduleDetailDialogVisible"
+    [modal]="true"
+    [style]="{ width: 'min(560px, 95vw)' }"
+    [draggable]="false"
+    [resizable]="false"
+    (onHide)="cancelScheduleDetailDialog()">
+    <div class="flex flex-col gap-3 text-sm" *ngIf="scheduleDetailTarget as item">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <span class="text-gray-500">Programación</span>
+          <p class="font-mono font-semibold m-0">#{{ item.id }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Fecha de creación</span>
+          <p class="font-semibold m-0">{{ formatTreasuryInstant(item.createdAt) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Fecha de ejecución</span>
+          <p class="font-semibold m-0">{{ formatDate(item.executionDate) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Tipo</span>
+          <p class="font-semibold m-0">{{ scheduleTypeLabel(item) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Proveedor</span>
+          <p class="font-semibold m-0">{{ suppliersLabel(item) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Método</span>
+          <p class="font-semibold m-0">{{ methodLabel(item) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Cuenta origen</span>
+          <p class="font-semibold m-0">{{ scheduleBankLabel(item) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Total</span>
+          <p class="font-semibold m-0">{{ formatCurrency(scheduleTotalFn(item)) }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Estado</span>
+          <p class="m-0">
+            <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
+          </p>
+        </div>
+        <div>
+          <span class="text-gray-500">Reintentos</span>
+          <p class="font-semibold m-0">{{ item.retryCount }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Último intento</span>
+          <p class="font-semibold m-0">{{ formatTreasuryInstant(item.updatedAt) }}</p>
+        </div>
+        <div *ngIf="canViewScheduleVoucher(item)">
+          <span class="text-gray-500">Comprobante</span>
+          <p class="font-mono font-semibold text-blue-600 m-0">{{ scheduleVoucherLabel(item) }}</p>
+        </div>
+      </div>
+      <div>
+        <span class="text-gray-500">Factura(s)</span>
+        <p class="font-mono text-sm m-0 mt-1">{{ invoicesLabel(item) }}</p>
+      </div>
+      <div *ngIf="item.observations">
+        <span class="text-gray-500">Observaciones</span>
+        <p class="m-0 mt-1">{{ item.observations }}</p>
+      </div>
+      <div *ngIf="item.failureReason">
+        <span class="text-gray-500">Motivo del error</span>
+        <p class="m-0 mt-1 text-red-700">{{ item.failureReason }}</p>
+      </div>
+    </div>
+    <ng-template pTemplate="footer">
+      <div class="flex gap-2 justify-end flex-wrap">
+        <p-button
+          label="Cerrar"
+          severity="secondary"
+          [outlined]="true"
+          (onClick)="cancelScheduleDetailDialog()">
+        </p-button>
+        <p-button
+          *ngIf="scheduleDetailTarget && canViewScheduleVoucher(scheduleDetailTarget)"
+          label="Ver comprobante"
+          icon="pi pi-file"
+          (onClick)="openScheduleVoucher(scheduleDetailTarget!)">
+        </p-button>
+        <p-button
+          *ngIf="scheduleDetailTarget && canCancelSchedule(scheduleDetailTarget)"
+          label="Cancelar"
+          icon="pi pi-ban"
+          severity="danger"
+          [outlined]="true"
+          [disabled]="actionBusy"
+          (onClick)="cancelSchedule(scheduleDetailTarget!); cancelScheduleDetailDialog()">
+        </p-button>
+      </div>
+    </ng-template>
+  </p-dialog>
 
   <p-toast></p-toast>
 </div>

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.html
@@ -123,15 +123,15 @@
 
       <ng-template pTemplate="header">
         <tr>
-          <th>Fecha ejecución</th>
-          <th>Proveedor</th>
-          <th>Factura(s)</th>
-          <th>Método</th>
-          <th>Estado</th>
-          <th class="text-right">Total</th>
-          <th>Reintentos</th>
-          <th>Comprobante</th>
-          <th style="min-width: 10rem">Acciones</th>
+          <th scope="col">Fecha ejecución</th>
+          <th scope="col">Proveedor</th>
+          <th scope="col">Factura(s)</th>
+          <th scope="col">Método</th>
+          <th scope="col">Estado</th>
+          <th scope="col" class="text-right">Total</th>
+          <th scope="col">Reintentos</th>
+          <th scope="col">Comprobante</th>
+          <th scope="col" style="min-width: 10rem">Acciones</th>
         </tr>
       </ng-template>
 
@@ -270,72 +270,10 @@
     [draggable]="false"
     [resizable]="false"
     (onHide)="cancelScheduleDetailDialog()">
-    <div class="flex flex-col gap-3 text-sm" *ngIf="scheduleDetailTarget as item">
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <span class="text-gray-500">Programación</span>
-          <p class="font-mono font-semibold m-0">#{{ item.id }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Fecha de creación</span>
-          <p class="font-semibold m-0">{{ formatTreasuryInstant(item.createdAt) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Fecha de ejecución</span>
-          <p class="font-semibold m-0">{{ formatDate(item.executionDate) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Tipo</span>
-          <p class="font-semibold m-0">{{ scheduleTypeLabel(item) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Proveedor</span>
-          <p class="font-semibold m-0">{{ suppliersLabel(item) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Método</span>
-          <p class="font-semibold m-0">{{ methodLabel(item) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Cuenta origen</span>
-          <p class="font-semibold m-0">{{ scheduleBankLabel(item) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Total</span>
-          <p class="font-semibold m-0">{{ formatCurrency(scheduleTotalFn(item)) }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Estado</span>
-          <p class="m-0">
-            <p-tag [value]="scheduleLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
-          </p>
-        </div>
-        <div>
-          <span class="text-gray-500">Reintentos</span>
-          <p class="font-semibold m-0">{{ item.retryCount }}</p>
-        </div>
-        <div>
-          <span class="text-gray-500">Último intento</span>
-          <p class="font-semibold m-0">{{ formatTreasuryInstant(item.updatedAt) }}</p>
-        </div>
-        <div *ngIf="canViewScheduleVoucher(item)">
-          <span class="text-gray-500">Comprobante</span>
-          <p class="font-mono font-semibold text-blue-600 m-0">{{ scheduleVoucherLabel(item) }}</p>
-        </div>
-      </div>
-      <div>
-        <span class="text-gray-500">Factura(s)</span>
-        <p class="font-mono text-sm m-0 mt-1">{{ invoicesLabel(item) }}</p>
-      </div>
-      <div *ngIf="item.observations">
-        <span class="text-gray-500">Observaciones</span>
-        <p class="m-0 mt-1">{{ item.observations }}</p>
-      </div>
-      <div *ngIf="item.failureReason">
-        <span class="text-gray-500">Motivo del error</span>
-        <p class="m-0 mt-1 text-red-700">{{ item.failureReason }}</p>
-      </div>
-    </div>
+    <app-treasury-schedule-detail-panel
+      [item]="scheduleDetailTarget ?? null"
+      [view]="scheduleDetailView(scheduleDetailTarget)">
+    </app-treasury-schedule-detail-panel>
     <ng-template pTemplate="footer">
       <div class="flex gap-2 justify-end flex-wrap">
         <p-button

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.spec.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.spec.ts
@@ -27,13 +27,21 @@ describe('BillListComponent schedules', () => {
       downloadCsv: jasmine.createSpy('downloadCsv'),
       downloadPdf: jasmine.createSpy('downloadPdf'),
     };
+    const bankAccounts = {
+      findAllActive: jasmine.createSpy('findAllActive').and.returnValue(of({ content: [] })),
+    };
+    const router = { navigate: jasmine.createSpy('navigate') };
+    const route = { snapshot: { queryParamMap: { get: () => null } }, queryParamMap: of({ get: () => null }) };
     const value = new BillListComponent(
       new FormBuilder(),
       api as any,
       paymentMethods as any,
       thirds as any,
+      bankAccounts as any,
       messageService as any,
       exportService as any,
+      router as any,
+      route as any,
     );
     value.ngOnInit();
     return { value, api, messageService };

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -12,6 +13,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TagModule } from 'primeng/tag';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
+import { DialogModule } from 'primeng/dialog';
 
 import { LocalStorageMethods } from '../../../../../Shared/Methods/local-storage.method';
 import { MessageService } from 'primeng/api';
@@ -31,11 +33,15 @@ import { PaymentMethodsServiceService } from '../../../../../GeneralMasters/Paym
 import { ThirdService } from '../../../../../GeneralMasters/ThirdParties/Services/third.service';
 import { buildThirdPartyNameMap } from '../../../Shared/treasury-third-party.integration';
 import {
+  formatTreasuryInstant,
   scheduleInvoicesLabel,
   scheduleMethodLabel,
   scheduleSuppliersLabel,
   scheduleTotal,
+  scheduleTypeLabel,
+  scheduleVoucherLabel,
 } from '../../../Shared/treasury-schedule-display';
+import { BankAccountsService } from '../../../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
 
 interface SupplierFilterOption {
   label: string;
@@ -56,6 +62,7 @@ interface SupplierFilterOption {
     TagModule,
     CardModule,
     ToastModule,
+    DialogModule,
     ContextualHelpComponent,
   ],
   templateUrl: './bill-list.component.html',
@@ -73,6 +80,11 @@ export class BillListComponent implements OnInit {
   supplierNames = new Map<number, string>();
   payableReferences = new Map<number, string>();
   methods: any[] = [];
+  banks: any[] = [];
+  scheduleDetailDialogVisible = false;
+  scheduleDetailTarget?: PaymentSchedule;
+  scheduleTypeLabel = scheduleTypeLabel;
+  formatTreasuryInstant = formatTreasuryInstant;
 
   loading = false;
   actionBusy = false;
@@ -88,8 +100,11 @@ export class BillListComponent implements OnInit {
     private readonly api: TreasuryApiService,
     private readonly paymentMethods: PaymentMethodsServiceService,
     private readonly thirds: ThirdService,
+    private readonly bankAccounts: BankAccountsService,
     private readonly messageService: MessageService,
     private readonly exportService: TreasuryExportService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -120,10 +135,12 @@ export class BillListComponent implements OnInit {
       methods: this.paymentMethods.findAllActive(enterpriseId),
       thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
       payables: this.api.pending(enterpriseId),
+      banks: this.bankAccounts.findAllActive(enterpriseId).pipe(catchError(() => of({ content: [] } as any))),
     }).subscribe({
       next: (data) => {
         this.allSchedules = data.schedules ?? [];
         this.methods = data.methods?.content ?? [];
+        this.banks = data.banks?.content ?? [];
         this.supplierNames = buildThirdPartyNameMap(data.thirds?.content || []);
         this.payableReferences = new Map(
           (data.payables ?? []).map((payable: Payable) => [payable.id, payable.reference]),
@@ -132,6 +149,13 @@ export class BillListComponent implements OnInit {
         this.filteredSchedules = [...this.allSchedules];
         this.applyFilters();
         this.loading = false;
+        const scheduleId = Number(this.route.snapshot.queryParamMap.get('scheduleId'));
+        if (scheduleId) {
+          const schedule = this.allSchedules.find((item) => item.id === scheduleId);
+          if (schedule) {
+            this.showScheduleDetail(schedule);
+          }
+        }
       },
       error: (error) => {
         console.error('Error al cargar programaciones:', error);
@@ -213,6 +237,46 @@ export class BillListComponent implements OnInit {
 
   methodLabel(item: PaymentSchedule): string {
     return scheduleMethodLabel(item, this.methods);
+  }
+
+  scheduleVoucherLabel(item: PaymentSchedule): string {
+    return scheduleVoucherLabel(item);
+  }
+
+  canCancelSchedule(item: PaymentSchedule): boolean {
+    return item.status === 'SCHEDULED';
+  }
+
+  canViewScheduleVoucher(item: PaymentSchedule): boolean {
+    return item.status === 'EXECUTED' && item.voucherId != null;
+  }
+
+  showScheduleDetail(item: PaymentSchedule): void {
+    this.scheduleDetailTarget = item;
+    this.scheduleDetailDialogVisible = true;
+  }
+
+  cancelScheduleDetailDialog(): void {
+    this.scheduleDetailDialogVisible = false;
+    this.scheduleDetailTarget = undefined;
+  }
+
+  scheduleBankLabel(item: PaymentSchedule): string {
+    if (!item.bankAccountId) {
+      return '—';
+    }
+    const bank = this.banks.find((entry) => Number(entry.id) === Number(item.bankAccountId));
+    if (!bank) {
+      return '—';
+    }
+    return `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`;
+  }
+
+  openScheduleVoucher(item: PaymentSchedule): void {
+    if (!item.voucherId) {
+      return;
+    }
+    this.router.navigate(['/financial/treasury/expense-receipts/details', item.voucherId]);
   }
 
   cancelSchedule(schedule: PaymentSchedule): void {
@@ -312,7 +376,7 @@ export class BillListComponent implements OnInit {
       this.scheduleLabel(item.status),
       scheduleTotal(item),
       item.retryCount,
-      item.voucherId || '—',
+      this.scheduleVoucherLabel(item),
     ]);
     const options = {
       title: 'Programación de pagos',

--- a/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
+++ b/src/app/Financial/Treasury/PurchaseBills/Components/bill-list/bill-list.component.ts
@@ -34,6 +34,7 @@ import { ThirdService } from '../../../../../GeneralMasters/ThirdParties/Service
 import { buildThirdPartyNameMap } from '../../../Shared/treasury-third-party.integration';
 import {
   formatTreasuryInstant,
+  buildTreasuryScheduleDetailView,
   scheduleInvoicesLabel,
   scheduleMethodLabel,
   scheduleSuppliersLabel,
@@ -41,6 +42,7 @@ import {
   scheduleTypeLabel,
   scheduleVoucherLabel,
 } from '../../../Shared/treasury-schedule-display';
+import { TreasuryScheduleDetailPanelComponent } from '../../../Shared/treasury-schedule-detail-panel.component';
 import { BankAccountsService } from '../../../../../GeneralMasters/BankAccounts/services/bank-accounts.service';
 
 interface SupplierFilterOption {
@@ -64,6 +66,7 @@ interface SupplierFilterOption {
     ToastModule,
     DialogModule,
     ContextualHelpComponent,
+    TreasuryScheduleDetailPanelComponent,
   ],
   templateUrl: './bill-list.component.html',
   styleUrls: ['./bill-list.component.css'],
@@ -270,6 +273,25 @@ export class BillListComponent implements OnInit {
       return '—';
     }
     return `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`;
+  }
+
+  scheduleDetailView(item?: PaymentSchedule) {
+    if (!item) {
+      return null;
+    }
+    return buildTreasuryScheduleDetailView(item, {
+      executionDate: this.formatDate(item.executionDate),
+      type: this.scheduleTypeLabel(item),
+      supplier: this.suppliersLabel(item),
+      method: this.methodLabel(item),
+      bank: this.scheduleBankLabel(item),
+      total: this.formatCurrency(this.scheduleTotalFn(item)),
+      statusLabel: this.scheduleLabel(item.status),
+      statusSeverity: this.getStatusSeverity(item.status),
+      invoices: this.invoicesLabel(item),
+      showVoucher: this.canViewScheduleVoucher(item),
+      voucher: this.scheduleVoucherLabel(item),
+    });
   }
 
   openScheduleVoucher(item: PaymentSchedule): void {

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -151,7 +151,7 @@
           </p>
         </div>
         <div>
-          <p class="text-sm text-gray-600">Total débitos (pagos)</p>
+          <p class="text-sm text-gray-600">Pagos del período</p>
           <p class="font-mono font-semibold text-green-700">{{ formatCurrency(vendorReport.periodTotals.totalDebits) }}</p>
         </div>
         <div>
@@ -248,13 +248,21 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
       <p-card header="Totales del período" styleClass="bg-gray-50">
         <div class="space-y-3">
-          <div class="flex justify-between items-center">
-            <span>Total débitos (pagos):</span>
-            <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.totalDebits) }}</span>
+          <div class="flex justify-between items-center" *ngIf="vendorReport.periodTotals.openingBalance !== 0">
+            <span>Saldo inicial:</span>
+            <span class="font-mono font-bold">{{ formatCurrency(vendorReport.periodTotals.openingBalance) }}</span>
           </div>
           <div class="flex justify-between items-center">
-            <span>Total créditos (facturas):</span>
+            <span>Facturas del período:</span>
             <span class="font-mono text-red-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.totalCredits) }}</span>
+          </div>
+          <div class="flex justify-between items-center">
+            <span>Pagos del período:</span>
+            <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.totalDebits - vendorReport.periodTotals.writeOffTotal) }}</span>
+          </div>
+          <div class="flex justify-between items-center" *ngIf="vendorReport.periodTotals.writeOffTotal > 0">
+            <span>Total bajas CxP:</span>
+            <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.writeOffTotal) }}</span>
           </div>
           <p-divider></p-divider>
           <div class="flex justify-between items-center">

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -271,7 +271,7 @@ export class VendorReportComponent implements OnInit {
         transaction.reference || '-',
         transaction.documentNumber || '-',
         transaction.expenseReceiptNumber || '-',
-        transaction.type === 'Bill' ? 'Factura' : 'Pago',
+        transaction.type === 'Bill' ? 'Factura' : transaction.type === 'Payment' ? 'Pago' : 'Baja CxP',
         transaction.description || '-',
         transaction.debits || 0,
         transaction.credits || 0,
@@ -308,12 +308,13 @@ export class VendorReportComponent implements OnInit {
     return `estado_cuenta_${safeName}_${new Date().toISOString().slice(0, 10)}.${ext}`;
   }
 
-  getTransactionTypeTag(type: 'Bill' | 'Payment'): {
+  getTransactionTypeTag(type: 'Bill' | 'Payment' | 'WriteOff'): {
     severity: 'success' | 'info' | 'warning' | 'danger';
     text: string;
   } {
     const text = transactionTypeLabel(type);
-    const severity = type === 'Payment' ? 'success' : 'info';
+    const severity =
+      type === 'Payment' ? 'success' : type === 'WriteOff' ? 'warning' : 'info';
     return { severity, text };
   }
 

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -14,7 +14,7 @@ export interface VendorReportTransaction {
   reference: string;
   documentNumber?: string;
   expenseReceiptNumber?: string;
-  type: 'Bill' | 'Payment';
+  type: 'Bill' | 'Payment' | 'WriteOff';
   description: string;
   debits: number;
   credits: number;
@@ -32,8 +32,10 @@ export interface VendorReport {
   };
   transactions: VendorReportTransaction[];
   periodTotals: {
+    openingBalance: number;
     totalDebits: number;
     totalCredits: number;
+    writeOffTotal: number;
     netBalance: number;
   };
   totalDue: number;

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -47,6 +47,60 @@ describe('VendorReportService summaries', () => {
     });
   });
 
+  it('reconciles statement totals with detail movements', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 22436,
+        invoiced: 97566,
+        paid: 115376,
+        writeOffTotal: 0,
+        pending: 4646,
+        invoices: [{
+          issueDate: '2026-08-05',
+          dueDate: '2026-09-05',
+          reference: 'FC-1',
+          originalAmount: 97566,
+          pendingAmount: 4646,
+        }],
+        vouchers: [{
+          issueDate: '2026-08-10',
+          voucherNumber: 'CE-001',
+          observations: '12',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-OLD',
+            amountPaid: 115376,
+            remainingBalance: 0,
+          }],
+        }],
+        writeOffs: [],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.periodTotals.openingBalance).toBe(22436);
+      expect(report.periodTotals.totalCredits).toBe(97566);
+      expect(report.periodTotals.totalDebits).toBe(115376);
+      expect(report.totalDue).toBe(4646);
+      expect(report.transactions.find((row) => row.type === 'Payment')?.description)
+        .toBe('Pago comprobante CE-001');
+      const detailCredits = report.transactions.reduce((sum, row) => sum + row.credits, 0);
+      const detailDebits = report.transactions.reduce((sum, row) => sum + row.debits, 0);
+      expect(
+        report.periodTotals.openingBalance + detailCredits - detailDebits - report.periodTotals.writeOffTotal,
+      ).toBe(report.totalDue);
+      const lastBalance = report.transactions.at(-1)?.balance;
+      expect(lastBalance).toBe(report.totalDue);
+      done();
+    });
+  });
+
   it('passes supplier and date filters to statement API', (done) => {
     const { value, api } = service();
     const dateFrom = new Date(2026, 7, 1);

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -11,7 +11,7 @@ import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/e
 import { eThirdType } from '../../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { TreasuryApiService } from '../../../Shared/treasury-api.service';
 import { educationalDescription } from '../../../Shared/treasury-status-labels';
-import { VendorListFilter, VendorReport, VendorReportSummary } from '../Models/VendorReport';
+import { VendorListFilter, VendorReport, VendorReportSummary, VendorReportTransaction } from '../Models/VendorReport';
 
 export type VendorSupplierOption = Third & { displayName: string };
 
@@ -123,7 +123,16 @@ export class VendorReportService {
       )
       .pipe(
         map((statement) => {
-          const bills = (statement.invoices || []).map((inv: any) => ({
+          const openingBalance = Number(statement.openingBalance || 0);
+          const writeOffTotal = Number(statement.writeOffTotal || 0);
+          const totalCredits = Number(statement.invoiced || 0);
+          const periodPayments = Number(statement.paid || 0);
+          const totalDebits = periodPayments + writeOffTotal;
+          const closingBalance = Number(statement.pending || 0);
+          const startIso = this.toIsoDate(startDate);
+          const endIso = this.toIsoDate(endDate);
+
+          const bills: VendorReportTransaction[] = (statement.invoices || []).map((inv: any) => ({
             date: new Date(inv.issueDate),
             dueDate: new Date(inv.dueDate),
             reference: inv.reference,
@@ -132,10 +141,10 @@ export class VendorReportService {
             description: 'Factura de compra',
             debits: 0,
             credits: Number(inv.originalAmount || 0),
-            balance: Number(inv.pendingAmount || 0),
+            balance: 0,
           }));
 
-          const payments = (statement.vouchers || []).flatMap((voucher: any) =>
+          const payments: VendorReportTransaction[] = (statement.vouchers || []).flatMap((voucher: any) =>
             (voucher.details || [])
               .filter((detail: any) => detail.supplierId === vendorId)
               .map((detail: any) => ({
@@ -143,44 +152,54 @@ export class VendorReportService {
                 reference: detail.invoiceReference,
                 expenseReceiptNumber: voucher.voucherNumber,
                 type: 'Payment' as const,
-                description: educationalDescription(voucher.observations, 'Pago a proveedor'),
-                debits: Number(detail.amountPaid || 0),
+                description: this.paymentDescription(voucher.observations, voucher.voucherNumber),
+                debits: Number(detail.amountPaid ?? detail.amount ?? 0),
                 credits: 0,
-                balance: Number(detail.remainingBalance || 0),
+                balance: 0,
               })),
           );
 
-          const start = new Date(startDate);
-          start.setHours(0, 0, 0, 0);
-          const end = new Date(endDate);
-          end.setHours(23, 59, 59, 999);
+          const writeOffRows: VendorReportTransaction[] = (statement.writeOffs || []).flatMap((writeOff: any) =>
+            (writeOff.details || [])
+              .filter((detail: any) => detail.supplierId === vendorId)
+              .map((detail: any) => ({
+                date: new Date(writeOff.createdAt),
+                reference: detail.invoiceReference || '',
+                type: 'WriteOff' as const,
+                description: (writeOff.reason || '').trim() || 'Baja de cuenta por pagar',
+                debits: Number(detail.amount || 0),
+                credits: 0,
+                balance: 0,
+              })),
+          );
 
-          const transactions = [...bills, ...payments]
-            .filter((row) => row.date >= start && row.date <= end)
-            .sort((a, b) => a.date.getTime() - b.date.getTime());
-
-          const totalDebits = payments.reduce((s, p) => s + p.debits, 0);
-          const totalCredits = bills.reduce((s, b) => s + b.credits, 0);
-          const pending = Number(statement.pending || 0);
+          const transactions = this.applyRunningBalance(
+            [...bills, ...payments, ...writeOffRows]
+              .filter((row) => this.inIsoDateRange(row.date, startIso, endIso))
+              .sort((a, b) => a.date.getTime() - b.date.getTime()),
+            openingBalance,
+          );
 
           return {
             vendor: { id: vendorId, name: vendorName || `Proveedor ${vendorId}` },
             dateRange: { startDate, endDate },
             transactions,
             periodTotals: {
+              openingBalance,
               totalDebits,
               totalCredits,
-              netBalance: pending,
+              writeOffTotal,
+              netBalance: closingBalance,
             },
-            totalDue: pending,
+            totalDue: closingBalance,
             agingReport: {
               prePaid: 0,
-              current: pending,
+              current: closingBalance,
               days0to30: 0,
               days31to60: 0,
               days61to90: 0,
               days91Plus: 0,
-              total: pending,
+              total: closingBalance,
             },
           };
         }),
@@ -233,7 +252,7 @@ export class VendorReportService {
         t.reference || '-',
         t.documentNumber || '-',
         t.expenseReceiptNumber || '-',
-        t.type === 'Bill' ? 'Factura' : 'Pago',
+        t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : 'Baja CxP',
         t.description || '-',
         t.debits > 0 ? fmt(t.debits) : '-',
         t.credits > 0 ? fmt(t.credits) : '-',
@@ -254,8 +273,14 @@ export class VendorReportService {
       startY: finalY + 16,
       theme: 'plain',
       body: [
-        ['Total débitos (pagos)', fmt(report.periodTotals.totalDebits)],
-        ['Total créditos (facturas)', fmt(report.periodTotals.totalCredits)],
+        ...(report.periodTotals.openingBalance !== 0
+          ? [['Saldo inicial', fmt(report.periodTotals.openingBalance)]]
+          : []),
+        ['Pagos del período', fmt(report.periodTotals.totalDebits - report.periodTotals.writeOffTotal)],
+        ...(report.periodTotals.writeOffTotal > 0
+          ? [['Total bajas CxP', fmt(report.periodTotals.writeOffTotal)]]
+          : []),
+        ['Facturas del período', fmt(report.periodTotals.totalCredits)],
         ['Saldo pendiente', fmt(report.totalDue)],
       ],
       styles: { fontSize: 10 },
@@ -303,8 +328,14 @@ export class VendorReportService {
       ],
       ['Generado:', fmtDate(new Date())],
       [],
-      ['Total débitos (pagos)', report.periodTotals.totalDebits],
-      ['Total créditos (facturas)', report.periodTotals.totalCredits],
+      ...(report.periodTotals.openingBalance !== 0
+        ? [['Saldo inicial', report.periodTotals.openingBalance]]
+        : []),
+      ['Pagos del período', report.periodTotals.totalDebits - report.periodTotals.writeOffTotal],
+      ...(report.periodTotals.writeOffTotal > 0
+        ? [['Total bajas CxP', report.periodTotals.writeOffTotal]]
+        : []),
+      ['Facturas del período', report.periodTotals.totalCredits],
       ['Saldo pendiente', report.totalDue],
       [],
     ];
@@ -332,7 +363,7 @@ export class VendorReportService {
       t.reference || '',
       t.documentNumber || '',
       t.expenseReceiptNumber || '',
-      t.type === 'Bill' ? 'Factura' : 'Pago',
+      t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : 'Baja CxP',
       t.description || '',
       t.debits || 0,
       t.credits || 0,
@@ -384,6 +415,30 @@ export class VendorReportService {
 
   exportToExcel(report: VendorReport): Blob {
     return this.buildExcel(report);
+  }
+
+  private paymentDescription(observations?: string | null, voucherNumber?: string | null): string {
+    const fallback = voucherNumber
+      ? `Pago comprobante ${voucherNumber}`
+      : 'Pago a proveedor';
+    return educationalDescription(observations, fallback);
+  }
+
+  private applyRunningBalance(
+    rows: VendorReportTransaction[],
+    openingBalance: number,
+  ): VendorReportTransaction[] {
+    let running = openingBalance;
+    return rows.map((row) => {
+      if (row.credits > 0) running += row.credits;
+      if (row.debits > 0) running -= row.debits;
+      return { ...row, balance: running };
+    });
+  }
+
+  private inIsoDateRange(date: Date, startIso: string, endIso: string): boolean {
+    const value = this.toIsoDate(date);
+    return value >= startIso && value <= endIso;
   }
 
   private formatMoney(amount: number): string {

--- a/src/app/Financial/Treasury/Shared/treasury-api.models.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.models.ts
@@ -15,11 +15,14 @@ export interface VoucherDetail {
   id: number; supplierId: number; invoiceId: number; invoiceReference: string;
   payableAccountId: number; payableAccountCode: string; previousBalance: number;
   amountPaid: number; remainingBalance: number;
+  /** Alias legacy en algunas respuestas */
+  amount?: number;
 }
 export interface PaymentVoucher {
   id: number; voucherNumber: string; enterpriseId: string; issueDate: string;
   status: VoucherStatus; paymentMethodId: number; bankAccountId?: number; total: number;
   observations?: string; accountingEntryId?: number; accountingEntryCode?: string; failureReason?: string; voidReason?: string;
+  createdAt?: string; updatedAt?: string;
   version: number; details: VoucherDetail[];
 }
 export interface Payable {
@@ -38,7 +41,9 @@ export interface ScheduleDetail {
 export interface PaymentSchedule {
   id: number; enterpriseId: string; executionDate: string; status: ScheduleStatus;
   paymentMethodId: number; bankAccountId?: number; total?: number; observations?: string;
-  retryCount: number; voucherId?: number; failureReason?: string; details: ScheduleDetail[];
+  retryCount: number; voucherId?: number; voucherNumber?: string; failureReason?: string;
+  createdAt?: string; updatedAt?: string;
+  details: ScheduleDetail[];
 }
 export interface AgingLine {
   supplierId: number; invoiceId: number; reference: string; accountCode: string; dueDate: string;
@@ -46,12 +51,30 @@ export interface AgingLine {
   days61to90: number; days91Plus: number;
 }
 export interface SupplierStatement {
-  supplierId: number; invoiced: number; paid: number; pending: number;
-  invoices: Payable[]; vouchers: PaymentVoucher[];
+  supplierId: number;
+  invoiced: number;
+  paid: number;
+  pending: number;
+  openingBalance?: number;
+  writeOffTotal?: number;
+  invoices: Payable[];
+  vouchers: PaymentVoucher[];
+  writeOffs?: PayableWriteOff[];
 }
 export interface WriteOffRequest {
   enterpriseId: string; reason: string; counterpartAccountId: number;
   counterpartAccountCode: string; details: VoucherDetailRequest[];
+}
+export interface PayableWriteOffDetail {
+  id?: number;
+  supplierId: number;
+  invoiceId: number;
+  invoiceReference?: string;
+  payableAccountId?: number;
+  payableAccountCode?: string;
+  amount: number;
+  originalAmount?: number;
+  availableAmount?: number;
 }
 export interface PayableWriteOff {
   id: number;
@@ -62,6 +85,8 @@ export interface PayableWriteOff {
   total: number;
   status: WriteOffStatus | string;
   accountingEntryId?: number;
+  accountingEntryCode?: string;
+  createdAt?: string;
   version?: number;
-  details?: { id?: number; supplierId: number; invoiceId: number; amount: number }[];
+  details?: PayableWriteOffDetail[];
 }

--- a/src/app/Financial/Treasury/Shared/treasury-api.service.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.service.ts
@@ -40,10 +40,14 @@ export class TreasuryApiService {
     if (supplierId != null) params = params.set('supplierId', supplierId);
     return this.http.get<Payable[]>(`${this.base}/payables/pending`, { params });
   }
+  payable(id: number, enterpriseId: string) {
+    return this.http.get<Payable>(`${this.base}/payables/${id}`, { params: { enterpriseId } });
+  }
   changeDueDate(id: number, enterpriseId: string, dueDate: string, reason: string) {
     return this.http.patch<Payable>(`${this.base}/payables/${id}/due-date`, { dueDate, reason }, { params: { enterpriseId } });
   }
   schedules(enterpriseId: string) { return this.http.get<PaymentSchedule[]>(`${this.base}/payment-schedules`, { params: { enterpriseId } }); }
+  schedule(id: number) { return this.http.get<PaymentSchedule>(`${this.base}/payment-schedules/${id}`); }
   createSchedule(request: ScheduleRequest) { return this.http.post<PaymentSchedule>(`${this.base}/payment-schedules`, request); }
   updateSchedule(id: number, request: ScheduleRequest) { return this.http.put<PaymentSchedule>(`${this.base}/payment-schedules/${id}`, request); }
   deleteSchedule(id: number) { return this.http.delete<void>(`${this.base}/payment-schedules/${id}`); }
@@ -63,8 +67,8 @@ export class TreasuryApiService {
   writeOff(id: number) {
     return this.http.get<PayableWriteOff>(`${this.base}/payable-write-offs/${id}`);
   }
-  accountingEntry(sourceDocumentId: number) {
-    return this.http.get<any>(`${environment.API_URL}accountCatalogue/accounting/entries/by-source/${sourceDocumentId}/PAYMENT_VOUCHER`);
+  accountingEntry(sourceDocumentId: number, sourceType = 'PAYMENT_VOUCHER') {
+    return this.http.get<any>(`${environment.API_URL}accountCatalogue/accounting/entries/by-source/${sourceDocumentId}/${sourceType}`);
   }
   createWriteOff(request: WriteOffRequest) {
     return this.http.post<PayableWriteOff>(`${this.base}/payable-write-offs`, request);

--- a/src/app/Financial/Treasury/Shared/treasury-purchase-invoice-lines.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-purchase-invoice-lines.spec.ts
@@ -1,0 +1,49 @@
+import {
+  mapSkeletonProductLine,
+  mapSkeletonProductsToLineViews,
+} from './treasury-purchase-invoice-lines';
+
+describe('treasury-purchase-invoice-lines', () => {
+  it('maps skeleton product fields to line view', () => {
+    const line = mapSkeletonProductLine({
+      productId: 42,
+      amount: 2,
+      unitPrice: 50000,
+      subtotal: 100000,
+      discount: 10,
+      description: 'Servicio de consultoría',
+      taxPercentage: [19],
+    });
+
+    expect(line.productLabel).toBe('Servicio de consultoría');
+    expect(line.quantity).toBe(2);
+    expect(line.unitPrice).toBe(50000);
+    expect(line.subtotal).toBe(100000);
+    expect(line.discountPercent).toBe(10);
+    expect(line.discountAmount).toBe(10000);
+    expect(line.taxLabel).toBe('19%');
+    expect(line.taxAmount).toBe(19000);
+    expect(line.lineTotal).toBe(119000);
+  });
+
+  it('uses product name map when available', () => {
+    const names = new Map<number, string>([[42, 'Licencia anual']]);
+    const line = mapSkeletonProductLine({
+      productId: 42,
+      amount: 1,
+      unitPrice: 1000,
+      subtotal: 1000,
+      discount: 0,
+      description: 'fallback',
+      taxPercentage: [],
+    }, names);
+
+    expect(line.productLabel).toBe('Licencia anual');
+    expect(line.description).toBe('fallback');
+  });
+
+  it('returns empty array for missing products', () => {
+    expect(mapSkeletonProductsToLineViews(null)).toEqual([]);
+    expect(mapSkeletonProductsToLineViews([])).toEqual([]);
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-purchase-invoice-lines.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-purchase-invoice-lines.ts
@@ -1,0 +1,63 @@
+import { PurchaseInvoiceProductLine } from '../../../Commercial/PurchaseInvoice/models/purchase-invoice-payload';
+
+export interface PaidInvoiceLineView {
+  productId?: number;
+  productLabel: string;
+  description?: string;
+  quantity: number;
+  unitPrice: number;
+  subtotal: number;
+  discountPercent: number;
+  discountAmount: number;
+  taxLabel: string;
+  taxAmount: number;
+  lineTotal: number;
+}
+
+export function mapSkeletonProductsToLineViews(
+  products: PurchaseInvoiceProductLine[] | null | undefined,
+  productNames?: Map<number, string>,
+): PaidInvoiceLineView[] {
+  if (!products?.length) {
+    return [];
+  }
+  return products.map((product) => mapSkeletonProductLine(product, productNames));
+}
+
+export function mapSkeletonProductLine(
+  product: PurchaseInvoiceProductLine,
+  productNames?: Map<number, string>,
+): PaidInvoiceLineView {
+  const quantity = Number(product.amount ?? 0);
+  const unitPrice = Number(product.unitPrice ?? 0);
+  const subtotal = Number(product.subtotal ?? 0);
+  const discountPercent = Number(product.discount ?? 0);
+  const gross = unitPrice * quantity;
+  const discountAmount = gross > 0 && discountPercent > 0
+    ? gross * (discountPercent / 100)
+    : 0;
+  const taxPercentages = (product.taxPercentage ?? []).map((value) => Number(value)).filter((value) => value > 0);
+  const taxLabel = taxPercentages.length
+    ? taxPercentages.map((value) => `${value}%`).join(', ')
+    : '—';
+  const taxAmount = taxPercentages.reduce((sum, percentage) => sum + (subtotal * percentage / 100), 0);
+  const productId = product.productId != null ? Number(product.productId) : undefined;
+  const resolvedName = productId != null ? productNames?.get(productId) : undefined;
+  const description = (product.description ?? '').trim();
+  const productLabel = resolvedName
+    ?? (description ? description : (productId != null ? `Producto ${productId}` : 'Producto/servicio'));
+
+  return {
+    productId,
+    productLabel,
+    description: description || undefined,
+    quantity,
+    unitPrice,
+    subtotal,
+    discountPercent,
+    discountAmount,
+    taxLabel,
+    taxAmount,
+    lineTotal: subtotal + taxAmount,
+  };
+}

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-detail-panel.component.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-detail-panel.component.ts
@@ -1,0 +1,83 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TagModule } from 'primeng/tag';
+import { PaymentSchedule } from './treasury-api.models';
+import { TreasuryScheduleDetailView } from './treasury-schedule-display';
+
+@Component({
+  selector: 'app-treasury-schedule-detail-panel',
+  standalone: true,
+  imports: [CommonModule, TagModule],
+  template: `
+    <div class="flex flex-col gap-3 text-sm" *ngIf="item && view">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <span class="text-gray-500">Programación</span>
+          <p class="font-mono font-semibold m-0">#{{ item.id }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Fecha de creación</span>
+          <p class="font-semibold m-0">{{ view.createdAt }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Fecha de ejecución</span>
+          <p class="font-semibold m-0">{{ view.executionDate }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Tipo</span>
+          <p class="font-semibold m-0">{{ view.type }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Proveedor</span>
+          <p class="font-semibold m-0">{{ view.supplier }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Método</span>
+          <p class="font-semibold m-0">{{ view.method }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Cuenta origen</span>
+          <p class="font-semibold m-0">{{ view.bank }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Total</span>
+          <p class="font-semibold m-0">{{ view.total }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Estado</span>
+          <p class="m-0">
+            <p-tag [value]="view.statusLabel" [severity]="view.statusSeverity"></p-tag>
+          </p>
+        </div>
+        <div>
+          <span class="text-gray-500">Reintentos</span>
+          <p class="font-semibold m-0">{{ item.retryCount }}</p>
+        </div>
+        <div>
+          <span class="text-gray-500">Último intento</span>
+          <p class="font-semibold m-0">{{ view.lastAttempt }}</p>
+        </div>
+        <div *ngIf="view.showVoucher">
+          <span class="text-gray-500">Comprobante</span>
+          <p class="font-mono font-semibold text-blue-600 m-0">{{ view.voucher }}</p>
+        </div>
+      </div>
+      <div>
+        <span class="text-gray-500">Factura(s)</span>
+        <p class="font-mono text-sm m-0 mt-1">{{ view.invoices }}</p>
+      </div>
+      <div *ngIf="view.observations">
+        <span class="text-gray-500">Observaciones</span>
+        <p class="m-0 mt-1">{{ view.observations }}</p>
+      </div>
+      <div *ngIf="view.failureReason">
+        <span class="text-gray-500">Motivo del error</span>
+        <p class="m-0 mt-1 text-red-700">{{ view.failureReason }}</p>
+      </div>
+    </div>
+  `,
+})
+export class TreasuryScheduleDetailPanelComponent {
+  @Input({ required: true }) item!: PaymentSchedule | null;
+  @Input({ required: true }) view!: TreasuryScheduleDetailView | null;
+}

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
@@ -86,3 +86,56 @@ export function scheduleVoucherLabel(
   }
   return '—';
 }
+
+export interface TreasuryScheduleDetailView {
+  createdAt: string;
+  executionDate: string;
+  type: string;
+  supplier: string;
+  method: string;
+  bank: string;
+  total: string;
+  statusLabel: string;
+  statusSeverity: 'success' | 'secondary' | 'info' | 'warn' | 'warning' | 'danger' | 'contrast' | undefined;
+  lastAttempt: string;
+  voucher?: string;
+  showVoucher: boolean;
+  invoices: string;
+  observations?: string;
+  failureReason?: string;
+}
+
+export function buildTreasuryScheduleDetailView(
+  item: PaymentSchedule,
+  options: {
+    executionDate: string;
+    type: string;
+    supplier: string;
+    method: string;
+    bank: string;
+    total: string;
+    statusLabel: string;
+    statusSeverity: TreasuryScheduleDetailView['statusSeverity'];
+    invoices: string;
+    showVoucher: boolean;
+    voucher?: string;
+  },
+): TreasuryScheduleDetailView {
+  return {
+    createdAt: formatTreasuryInstant(item.createdAt),
+    executionDate: options.executionDate,
+    type: options.type,
+    supplier: options.supplier,
+    method: options.method,
+    bank: options.bank,
+    total: options.total,
+    statusLabel: options.statusLabel,
+    statusSeverity: options.statusSeverity,
+    lastAttempt: formatTreasuryInstant(item.updatedAt),
+    voucher: options.voucher,
+    showVoucher: options.showVoucher,
+    invoices: options.invoices,
+    observations: item.observations ?? undefined,
+    failureReason: item.failureReason ?? undefined,
+  };
+}

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
@@ -47,3 +47,42 @@ export function scheduleMethodLabel(
   const method = methods.find((entry) => entry.id === Number(item.paymentMethodId));
   return method ? translatePaymentMethodName(method.name) : `#${item.paymentMethodId}`;
 }
+
+export function scheduleTypeLabel(item: PaymentSchedule): string {
+  const details = item.details ?? [];
+  if (details.length <= 1) {
+    return 'Individual';
+  }
+  const supplierIds = new Set(details.map((detail) => detail.supplierId));
+  return supplierIds.size <= 1 ? 'Agrupada' : 'Agrupada multi-proveedor';
+}
+
+export function formatTreasuryInstant(value?: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${day}/${month}/${year} ${hours}:${minutes}`;
+}
+
+export function scheduleVoucherLabel(
+  item: PaymentSchedule,
+  voucherNumberById?: Map<number, string>,
+): string {
+  const fromApi = item.voucherNumber?.trim();
+  if (fromApi) {
+    return fromApi;
+  }
+  if (item.voucherId != null && voucherNumberById?.has(item.voucherId)) {
+    return voucherNumberById.get(item.voucherId)!;
+  }
+  return '—';
+}

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
@@ -29,6 +29,7 @@ const PAYABLE_LABELS: Record<string, string> = {
 const TRANSACTION_TYPE_LABELS: Record<string, string> = {
   Bill: 'Factura de compra',
   Payment: 'Pago a proveedor',
+  WriteOff: 'Baja CxP',
 };
 
 const ACCOUNTING_ENTRY_LABELS: Record<string, string> = {
@@ -145,6 +146,7 @@ const LAB_DESCRIPTION_PATTERNS: Array<{ test: RegExp; label: string }> = [
 export function educationalDescription(raw?: string | null, fallback = 'Pago a proveedor'): string {
   const text = (raw ?? '').trim();
   if (!text) return fallback;
+  if (/^\d+$/.test(text)) return fallback;
 
   for (const { test, label } of LAB_DESCRIPTION_PATTERNS) {
     if (test.test(text)) return label;

--- a/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
@@ -19,3 +19,27 @@ export function buildThirdPartyNameMap(thirds: Array<{
 export function resolveSupplierName(map: Map<number, string>, supplierId: number): string {
   return map.get(Number(supplierId)) || `Proveedor ${supplierId}`;
 }
+
+export function buildThirdPartyIdentificationMap(thirds: Array<{
+  thId?: number;
+  idNumber?: number;
+  verificationNumber?: number;
+}>): Map<number, string> {
+  return new Map(
+    (thirds || []).map((third) => {
+      const id = Number(third.thId);
+      const base = third.idNumber != null ? String(third.idNumber) : '';
+      const label = base
+        ? `${base}${third.verificationNumber != null ? `-${third.verificationNumber}` : ''}`
+        : '—';
+      return [id, label] as [number, string];
+    }),
+  );
+}
+
+export function resolveSupplierIdentification(
+  map: Map<number, string>,
+  supplierId: number,
+): string {
+  return map.get(Number(supplierId)) ?? '—';
+}


### PR DESCRIPTION
## Summary
- Integrate treasury operations UI with payables APIs (payments, voids, write-offs).
- Improve vendor statement/aging views and purchase bill list.
- Add unit specs for treasury services and operations.

## Test plan
- [x] ng build PASS locally
- [ ] Karma tests (ChromeHeadless timeout in local env)
- [ ] CI

## Impact
Treasury UI modules only.