### PR TITLE
fix(treasury): apply supplier filter in aging report

### DIFF
--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.html
@@ -45,11 +45,12 @@
           formControlName="supplierId"
           [options]="supplierOptions"
           optionLabel="label"
-          optionValue="id"
+          optionValue="value"
           placeholder="Todos los proveedores"
           [showClear]="true"
           [filter]="true"
           filterBy="label"
+          (onChange)="onGenerateReport()"
           styleClass="w-full">
         </p-dropdown>
       </div>

--- a/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Components/aging-report/aging-report.component.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../../Shared/treasury-status-labels';
 import { ContextualHelpComponent } from '../../../../../../Shared/Components/contextual-help/contextual-help.component';
 import { TREASURY_HELP } from '../../../../Shared/treasury-help-content';
+import { resolveSupplierFilterId } from '../../../../Shared/treasury-third-party.integration';
 
 @Component({
   selector: 'app-aging-report',
@@ -126,8 +127,8 @@ export class AgingReportComponent implements OnInit {
     }
 
     this.loading = true;
-    const supplierId = this.filterForm.value.supplierId;
-    const supplier = this.supplierOptions.find((s) => s.id === supplierId);
+    const supplierId = resolveSupplierFilterId(this.filterForm.value.supplierId);
+    const supplier = this.supplierOptions.find((s) => s.value === supplierId);
 
     const filters: AgingReportFilter = {
       supplierId,
@@ -267,6 +268,7 @@ export class AgingReportComponent implements OnInit {
   }
 
   supplierName(supplierId: number): string {
-    return this.supplierOptions.find((s) => s.id === supplierId)?.name || `Proveedor ${supplierId}`;
+    return this.supplierOptions.find((s) => s.value === Number(supplierId))?.name
+      || `Proveedor ${supplierId}`;
   }
 }

--- a/src/app/Financial/Treasury/Reports/AgingReport/Models/AgingReport.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Models/AgingReport.ts
@@ -44,6 +44,7 @@ export interface AccountTypeOption {
 
 export interface SupplierOption {
   id: number;
+  value: number;
   name: string;
   label: string;
 }

--- a/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.spec.ts
@@ -101,6 +101,58 @@ describe('AgingReportService report lines', () => {
     });
   });
 
+  it('filters aging lines client-side when API returns mixed suppliers', (done) => {
+    const { service } = createService([
+      {
+        invoiceId: 1,
+        supplierId: 7,
+        reference: 'FC-100',
+        accountCode: '220501',
+        dueDate: '2026-08-01',
+        daysOverdue: 5,
+        current: 100,
+        days1to30: 0,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+      },
+      {
+        invoiceId: 2,
+        supplierId: 9,
+        reference: 'FC-200',
+        accountCode: '220501',
+        dueDate: '2026-08-02',
+        daysOverdue: 4,
+        current: 50,
+        days1to30: 0,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+      },
+    ]);
+
+    service.getAgingReport('ent-1', {
+      supplierId: 7,
+      cutoffDate: new Date(2026, 7, 13),
+    }).subscribe((report) => {
+      expect(report.lines.length).toBe(1);
+      expect(report.lines[0].supplierId).toBe(7);
+      expect(report.totals.totalDue).toBe(100);
+      done();
+    });
+  });
+
+  it('normalizes dropdown object values before requesting aging', (done) => {
+    const { service, api } = createService([]);
+    service.getAgingReport('ent-1', {
+      supplierId: { value: 7, label: '7 — Acme Ltda.' } as any,
+      cutoffDate: new Date(2026, 7, 13),
+    }).subscribe(() => {
+      expect(api.aging).toHaveBeenCalledWith('ent-1', '2026-08-13', 7, undefined, undefined);
+      done();
+    });
+  });
+
   it('uses cutoff date for report date and preserves days overdue from API', (done) => {
     const { service } = createService([
       {

--- a/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/AgingReport/Services/aging-report.service.ts
@@ -4,6 +4,7 @@ import { catchError } from 'rxjs/operators';
 import { TreasuryApiService } from '../../../Shared/treasury-api.service';
 import { ChartAccountService } from '../../../../../GeneralMasters/AccountCatalogue/services/chart-account.service';
 import { ThirdService } from '../../../../../GeneralMasters/ThirdParties/Services/third.service';
+import { resolveSupplierFilterId } from '../../../Shared/treasury-third-party.integration';
 import {
   AgingReportFilter,
   AgingReportResponse,
@@ -23,7 +24,7 @@ export class AgingReportService {
 
   getAgingReport(enterpriseId: string, filters: AgingReportFilter): Observable<AgingReportResponse> {
     const cutoff = this.toLocalDateString(filters.cutoffDate ?? new Date());
-    const supplierId = filters.supplierId != null ? Number(filters.supplierId) : undefined;
+    const supplierId = resolveSupplierFilterId(filters.supplierId);
     const accountCode = filters.accountCode || undefined;
     const document = filters.document?.trim() || undefined;
 
@@ -46,7 +47,8 @@ export class AgingReportService {
           }),
         );
 
-        const lines = (items || []).map((item) => {
+        const lines = (items || [])
+          .map((item) => {
           const totalDue =
             Number(item.current || 0) +
             Number(item.days1to30 || 0) +
@@ -60,7 +62,7 @@ export class AgingReportService {
 
           return {
             id: item.invoiceId,
-            supplierId: item.supplierId,
+            supplierId: Number(item.supplierId),
             reference: item.reference,
             accountCode: String(item.accountCode),
             accountDescription: accountLabel,
@@ -73,7 +75,8 @@ export class AgingReportService {
             days61to90: Number(item.days61to90 || 0),
             days91Plus: Number(item.days91Plus || 0),
           };
-        });
+        })
+          .filter((line) => supplierId == null || line.supplierId === supplierId);
 
         const totals = lines.reduce(
           (sum, line) => ({
@@ -131,7 +134,7 @@ export class AgingReportService {
         const suppliers: SupplierOption[] = [...new Set(pending.map((p) => Number(p.supplierId)))]
           .map((id) => {
             const name = thirdNames.get(id) || `Proveedor ${id}`;
-            return { id, name, label: `${id} — ${name}` };
+            return { id, value: id, name, label: `${id} — ${name}` };
           })
           .sort((a, b) => a.label.localeCompare(b.label));
 

--- a/src/app/Financial/Treasury/Shared/treasury-third-party.integration.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-third-party.integration.spec.ts
@@ -1,4 +1,4 @@
-import { buildThirdPartyNameMap, resolveSupplierName } from './treasury-third-party.integration';
+import { buildThirdPartyNameMap, resolveSupplierFilterId, resolveSupplierName } from './treasury-third-party.integration';
 
 describe('treasury-third-party.integration', () => {
   it('builds a name map from third parties', () => {
@@ -13,5 +13,14 @@ describe('treasury-third-party.integration', () => {
   it('falls back to Proveedor {id} when name is missing', () => {
     const map = buildThirdPartyNameMap([]);
     expect(resolveSupplierName(map, 99)).toBe('Proveedor 99');
+  });
+
+  it('normalizes supplier filter values from dropdown selections', () => {
+    expect(resolveSupplierFilterId(null)).toBeUndefined();
+    expect(resolveSupplierFilterId('78')).toBe(78);
+    expect(resolveSupplierFilterId({ value: 78, label: '78 — Proveedor' })).toBe(78);
+    expect(resolveSupplierFilterId({ id: 78 })).toBe(78);
+    expect(resolveSupplierFilterId({ thId: 78 })).toBe(78);
+    expect(resolveSupplierFilterId('abc')).toBeUndefined();
   });
 });

--- a/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-third-party.integration.ts
@@ -20,6 +20,22 @@ export function resolveSupplierName(map: Map<number, string>, supplierId: number
   return map.get(Number(supplierId)) || `Proveedor ${supplierId}`;
 }
 
+/** Normaliza el valor del filtro de proveedor (dropdown/autocomplete) a un id numérico. */
+export function resolveSupplierFilterId(raw: unknown): number | undefined {
+  if (raw == null || raw === '') {
+    return undefined;
+  }
+  if (typeof raw === 'object') {
+    const candidate =
+      (raw as { value?: unknown }).value ??
+      (raw as { id?: unknown }).id ??
+      (raw as { thId?: unknown }).thId;
+    return resolveSupplierFilterId(candidate);
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function buildThirdPartyIdentificationMap(thirds: Array<{
   thId?: number;
   idNumber?: number;


### PR DESCRIPTION
## Summary
- Normaliza el id del proveedor seleccionado en el dropdown de vencimiento por edades.
- Regenera el reporte al cambiar proveedor.
- Filtra líneas por proveedor cuando el backend devuelve resultados mixtos.

## Test plan
- [ ] Abrir Vencimiento por edades
- [ ] Seleccionar un proveedor con saldo pendiente
- [ ] Verificar encabezado con nombre del proveedor y solo sus obligaciones
- [ ] Limpiar filtro y confirmar que vuelve a mostrar todos