### PR TITLE
fix(treasury): show voided CxP write-offs in supplier statement detail

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -188,7 +188,7 @@
         </ng-template>
 
         <ng-template pTemplate="body" let-transaction>
-          <tr>
+          <tr [class.opacity-70]="transaction.informational">
             <td>{{ transaction.date | date:'dd/MM/yyyy' }}</td>
             <td>
               <span *ngIf="transaction.dueDate">{{ transaction.dueDate | date:'dd/MM/yyyy' }}</span>
@@ -210,8 +210,8 @@
             </td>
             <td>
               <p-tag
-                [value]="getTransactionTypeTag(transaction.type).text"
-                [severity]="getTransactionTypeTag(transaction.type).severity"
+                [value]="getTransactionTypeTag(transaction.type, transaction.voided).text"
+                [severity]="getTransactionTypeTag(transaction.type, transaction.voided).severity"
                 styleClass="text-xs">
               </p-tag>
             </td>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -16,7 +16,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { InputTextModule } from 'primeng/inputtext';
 
 import { VendorReportService } from '../../Services/vendor-report.service';
-import { VendorReport } from '../../Models/VendorReport';
+import { VendorReport, VendorReportTransaction } from '../../Models/VendorReport';
 import { MessageService } from 'primeng/api';
 import {
   exportErrorDetail,
@@ -308,13 +308,22 @@ export class VendorReportComponent implements OnInit {
     return `estado_cuenta_${safeName}_${new Date().toISOString().slice(0, 10)}.${ext}`;
   }
 
-  getTransactionTypeTag(type: 'Bill' | 'Payment' | 'WriteOff'): {
-    severity: 'success' | 'info' | 'warning' | 'danger';
+  getTransactionTypeTag(type: VendorReportTransaction['type'], voided?: boolean): {
+    severity: 'success' | 'info' | 'warn' | 'warning' | 'danger' | 'secondary' | 'contrast';
     text: string;
   } {
     const text = transactionTypeLabel(type);
+    if (voided && type === 'WriteOff') {
+      return { severity: 'danger', text: `${text} (Anulada)` };
+    }
     const severity =
-      type === 'Payment' ? 'success' : type === 'WriteOff' ? 'warning' : 'info';
+      type === 'Payment'
+        ? 'success'
+        : type === 'WriteOffReversal'
+          ? 'warn'
+          : type === 'WriteOff'
+            ? 'warning'
+            : 'info';
     return { severity, text };
   }
 

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -14,11 +14,13 @@ export interface VendorReportTransaction {
   reference: string;
   documentNumber?: string;
   expenseReceiptNumber?: string;
-  type: 'Bill' | 'Payment' | 'WriteOff';
+  type: 'Bill' | 'Payment' | 'WriteOff' | 'WriteOffReversal';
   description: string;
   debits: number;
   credits: number;
   balance: number;
+  voided?: boolean;
+  informational?: boolean;
 }
 
 export interface VendorReport {

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -110,4 +110,51 @@ describe('VendorReportService summaries', () => {
       done();
     });
   });
+
+  it('shows voided write-off history without affecting effective totals', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 357000,
+        }],
+        vouchers: [],
+        writeOffs: [{
+          id: 5,
+          status: 'VOIDED',
+          reason: 'Ajuste',
+          createdAt: '2026-08-10T12:00:00Z',
+          updatedAt: '2026-08-12T15:00:00Z',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amount: 100000,
+          }],
+        }],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.periodTotals.writeOffTotal).toBe(0);
+      expect(report.totalDue).toBe(357000);
+      expect(report.transactions.some((row) => row.type === 'WriteOff' && row.voided)).toBeTrue();
+      expect(report.transactions.some((row) => row.type === 'WriteOffReversal')).toBeTrue();
+      expect(report.transactions.at(-1)?.balance).toBe(357000);
+      done();
+    });
+  });
 });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -10,7 +10,8 @@ import { Third } from '../../../../../GeneralMasters/ThirdParties/models/Third';
 import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/ePersonType';
 import { eThirdType } from '../../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { TreasuryApiService } from '../../../Shared/treasury-api.service';
-import { educationalDescription } from '../../../Shared/treasury-status-labels';
+import { PayableWriteOff } from '../../../Shared/treasury-api.models';
+import { educationalDescription, transactionTypeLabel } from '../../../Shared/treasury-status-labels';
 import { VendorListFilter, VendorReport, VendorReportSummary, VendorReportTransaction } from '../Models/VendorReport';
 
 export type VendorSupplierOption = Third & { displayName: string };
@@ -159,24 +160,19 @@ export class VendorReportService {
               })),
           );
 
-          const writeOffRows: VendorReportTransaction[] = (statement.writeOffs || []).flatMap((writeOff: any) =>
-            (writeOff.details || [])
-              .filter((detail: any) => detail.supplierId === vendorId)
-              .map((detail: any) => ({
-                date: new Date(writeOff.createdAt),
-                reference: detail.invoiceReference || '',
-                type: 'WriteOff' as const,
-                description: (writeOff.reason || '').trim() || 'Baja de cuenta por pagar',
-                debits: Number(detail.amount || 0),
-                credits: 0,
-                balance: 0,
-              })),
+          const writeOffRows = this.buildWriteOffTransactions(
+            statement.writeOffs,
+            vendorId,
+            startIso,
+            endIso,
           );
 
           const transactions = this.applyRunningBalance(
-            [...bills, ...payments, ...writeOffRows]
-              .filter((row) => this.inIsoDateRange(row.date, startIso, endIso))
-              .sort((a, b) => a.date.getTime() - b.date.getTime()),
+            [
+              ...bills.filter((row) => this.inIsoDateRange(row.date, startIso, endIso)),
+              ...payments.filter((row) => this.inIsoDateRange(row.date, startIso, endIso)),
+              ...writeOffRows,
+            ].sort((a, b) => a.date.getTime() - b.date.getTime()),
             openingBalance,
           );
 
@@ -252,7 +248,7 @@ export class VendorReportService {
         t.reference || '-',
         t.documentNumber || '-',
         t.expenseReceiptNumber || '-',
-        t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : 'Baja CxP',
+        t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : transactionTypeLabel(t.type),
         t.description || '-',
         t.debits > 0 ? fmt(t.debits) : '-',
         t.credits > 0 ? fmt(t.credits) : '-',
@@ -363,7 +359,7 @@ export class VendorReportService {
       t.reference || '',
       t.documentNumber || '',
       t.expenseReceiptNumber || '',
-      t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : 'Baja CxP',
+      t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : transactionTypeLabel(t.type),
       t.description || '',
       t.debits || 0,
       t.credits || 0,
@@ -417,6 +413,61 @@ export class VendorReportService {
     return this.buildExcel(report);
   }
 
+  private buildWriteOffTransactions(
+    writeOffs: PayableWriteOff[] | undefined,
+    vendorId: number,
+    startIso: string,
+    endIso: string,
+  ): VendorReportTransaction[] {
+    return (writeOffs || []).flatMap((writeOff) => {
+      const status = String(writeOff.status || '');
+      const isVoided = status === 'VOIDED';
+      const createdInPeriod = writeOff.createdAt
+        ? this.inIsoDateRange(new Date(writeOff.createdAt), startIso, endIso)
+        : false;
+      const voidedInPeriod = isVoided && writeOff.updatedAt
+        ? this.inIsoDateRange(new Date(writeOff.updatedAt), startIso, endIso)
+        : false;
+      const reason = (writeOff.reason || '').trim();
+
+      return (writeOff.details || [])
+        .filter((detail) => Number(detail.supplierId) === vendorId)
+        .flatMap((detail) => {
+          const amount = Number(detail.amount || 0);
+          const reference = detail.invoiceReference || '';
+          const postedRow: VendorReportTransaction = {
+            date: new Date(writeOff.createdAt!),
+            reference,
+            type: 'WriteOff',
+            description: reason || 'Baja de cuenta por pagar',
+            debits: amount,
+            credits: 0,
+            balance: 0,
+            voided: isVoided,
+            informational: isVoided && !createdInPeriod,
+          };
+
+          if (!isVoided) {
+            return [{ ...postedRow, informational: !createdInPeriod }];
+          }
+
+          const reversalRow: VendorReportTransaction = {
+            date: new Date(writeOff.updatedAt || writeOff.createdAt!),
+            reference,
+            type: 'WriteOffReversal',
+            description: `Reversión Baja CxP${reason ? `: ${reason}` : ''} (Anulada)`,
+            debits: 0,
+            credits: amount,
+            balance: 0,
+            voided: true,
+            informational: !(createdInPeriod && voidedInPeriod),
+          };
+
+          return [postedRow, reversalRow];
+        });
+    });
+  }
+
   private paymentDescription(observations?: string | null, voucherNumber?: string | null): string {
     const fallback = voucherNumber
       ? `Pago comprobante ${voucherNumber}`
@@ -430,8 +481,10 @@ export class VendorReportService {
   ): VendorReportTransaction[] {
     let running = openingBalance;
     return rows.map((row) => {
-      if (row.credits > 0) running += row.credits;
-      if (row.debits > 0) running -= row.debits;
+      if (!row.informational) {
+        if (row.credits > 0) running += row.credits;
+        if (row.debits > 0) running -= row.debits;
+      }
       return { ...row, balance: running };
     });
   }

--- a/src/app/Financial/Treasury/Shared/treasury-api.models.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.models.ts
@@ -87,6 +87,7 @@ export interface PayableWriteOff {
   accountingEntryId?: number;
   accountingEntryCode?: string;
   createdAt?: string;
+  updatedAt?: string;
   version?: number;
   details?: PayableWriteOffDetail[];
 }

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
@@ -30,6 +30,7 @@ const TRANSACTION_TYPE_LABELS: Record<string, string> = {
   Bill: 'Factura de compra',
   Payment: 'Pago a proveedor',
   WriteOff: 'Baja CxP',
+  WriteOffReversal: 'Reversión Baja CxP',
 };
 
 const ACCOUNTING_ENTRY_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Render Baja CxP + Reversión Baja CxP rows for annulled write-offs in Estado de cuenta.
- Mark voided rows and keep effective totals unchanged (writeOffTotal=0, final balance preserved).

## Test plan
- [x] vendor-report.service.spec voided write-off scenario
- [x] ng build
- [ ] UI shows Baja CxP (Anulada) and Reversión rows with final saldo 357.000