### PR TITLE
fix(treasury): show API paid in supplier statement header

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -152,7 +152,7 @@
         </div>
         <div>
           <p class="text-sm text-gray-600">Pagos del período</p>
-          <p class="font-mono font-semibold text-green-700">{{ formatCurrency(vendorReport.periodTotals.totalDebits) }}</p>
+          <p class="font-mono font-semibold text-green-700">{{ formatCurrency(vendorReport.periodTotals.periodPayments) }}</p>
         </div>
         <div>
           <p class="text-sm text-gray-600">Saldo pendiente</p>
@@ -258,7 +258,7 @@
           </div>
           <div class="flex justify-between items-center">
             <span>Pagos del período:</span>
-            <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.totalDebits - vendorReport.periodTotals.writeOffTotal) }}</span>
+            <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.periodPayments) }}</span>
           </div>
           <div class="flex justify-between items-center" *ngIf="vendorReport.periodTotals.writeOffTotal > 0">
             <span>Total bajas CxP:</span>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -35,6 +35,7 @@ export interface VendorReport {
   transactions: VendorReportTransaction[];
   periodTotals: {
     openingBalance: number;
+    periodPayments: number;
     totalDebits: number;
     totalCredits: number;
     writeOffTotal: number;

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -157,4 +157,92 @@ describe('VendorReportService summaries', () => {
       done();
     });
   });
+
+  it('maps period payments from API paid without mixing write-offs', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 100000,
+        pending: 257000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 257000,
+        }],
+        vouchers: [],
+        writeOffs: [{
+          id: 5,
+          status: 'POSTED',
+          reason: 'Ajuste',
+          createdAt: '2026-08-10T12:00:00Z',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amount: 100000,
+          }],
+        }],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.periodTotals.periodPayments).toBe(0);
+      expect(report.periodTotals.writeOffTotal).toBe(100000);
+      expect(report.periodTotals.totalDebits).toBe(100000);
+      expect(report.totalDue).toBe(257000);
+      done();
+    });
+  });
+
+  it('keeps payments and write-offs separated when both exist', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 50000,
+        writeOffTotal: 100000,
+        pending: 207000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 207000,
+        }],
+        vouchers: [{
+          issueDate: '2026-08-08',
+          voucherNumber: 'CE-001',
+          observations: 'Pago',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amountPaid: 50000,
+          }],
+        }],
+        writeOffs: [],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.periodTotals.periodPayments).toBe(50000);
+      expect(report.periodTotals.writeOffTotal).toBe(100000);
+      expect(report.totalDue).toBe(207000);
+      done();
+    });
+  });
 });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -182,6 +182,7 @@ export class VendorReportService {
             transactions,
             periodTotals: {
               openingBalance,
+              periodPayments,
               totalDebits,
               totalCredits,
               writeOffTotal,
@@ -272,7 +273,7 @@ export class VendorReportService {
         ...(report.periodTotals.openingBalance !== 0
           ? [['Saldo inicial', fmt(report.periodTotals.openingBalance)]]
           : []),
-        ['Pagos del período', fmt(report.periodTotals.totalDebits - report.periodTotals.writeOffTotal)],
+        ['Pagos del período', fmt(report.periodTotals.periodPayments)],
         ...(report.periodTotals.writeOffTotal > 0
           ? [['Total bajas CxP', fmt(report.periodTotals.writeOffTotal)]]
           : []),
@@ -327,7 +328,7 @@ export class VendorReportService {
       ...(report.periodTotals.openingBalance !== 0
         ? [['Saldo inicial', report.periodTotals.openingBalance]]
         : []),
-      ['Pagos del período', report.periodTotals.totalDebits - report.periodTotals.writeOffTotal],
+      ['Pagos del período', report.periodTotals.periodPayments],
       ...(report.periodTotals.writeOffTotal > 0
         ? [['Total bajas CxP', report.periodTotals.writeOffTotal]]
         : []),


### PR DESCRIPTION
Header Pagos del periodo now uses statement.paid via periodTotals.periodPayments. Write-offs remain in writeOffTotal only.

Made with [Cursor](https://cursor.com)