### PR TITLE
fix(treasury): polish posted write-off trace in supplier statement

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -261,7 +261,7 @@
             <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.periodPayments) }}</span>
           </div>
           <div class="flex justify-between items-center" *ngIf="vendorReport.periodTotals.writeOffTotal > 0">
-            <span>Total bajas CxP:</span>
+            <span>Bajas CxP efectivas:</span>
             <span class="font-mono text-green-700 font-bold">{{ formatCurrency(vendorReport.periodTotals.writeOffTotal) }}</span>
           </div>
           <p-divider></p-divider>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -245,4 +245,86 @@ describe('VendorReportService summaries', () => {
       done();
     });
   });
+
+  it('keeps invoice-only statement without write-off rows', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 357000,
+        }],
+        vouchers: [],
+        writeOffs: [],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.transactions.length).toBe(1);
+      expect(report.transactions[0].type).toBe('Bill');
+      expect(report.totalDue).toBe(357000);
+      expect(report.agingReport.total).toBe(357000);
+      expect(report.transactions.at(-1)?.balance).toBe(357000);
+      done();
+    });
+  });
+
+  it('reconciles posted write-off running balance with pending', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 100000,
+        pending: 257000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 257000,
+        }],
+        vouchers: [],
+        writeOffs: [{
+          id: 5,
+          status: 'POSTED',
+          reason: 'Ajuste',
+          createdAt: '2026-08-10T12:00:00Z',
+          accountingEntryId: 12,
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amount: 100000,
+          }],
+        }],
+      })),
+    };
+    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      const writeOff = report.transactions.find((row) => row.type === 'WriteOff');
+      expect(writeOff?.debits).toBe(100000);
+      expect(report.transactions.at(-1)?.balance).toBe(257000);
+      expect(report.totalDue).toBe(257000);
+      done();
+    });
+  });
 });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -275,7 +275,7 @@ export class VendorReportService {
           : []),
         ['Pagos del período', fmt(report.periodTotals.periodPayments)],
         ...(report.periodTotals.writeOffTotal > 0
-          ? [['Total bajas CxP', fmt(report.periodTotals.writeOffTotal)]]
+          ? [['Bajas CxP efectivas', fmt(report.periodTotals.writeOffTotal)]]
           : []),
         ['Facturas del período', fmt(report.periodTotals.totalCredits)],
         ['Saldo pendiente', fmt(report.totalDue)],
@@ -330,7 +330,7 @@ export class VendorReportService {
         : []),
       ['Pagos del período', report.periodTotals.periodPayments],
       ...(report.periodTotals.writeOffTotal > 0
-        ? [['Total bajas CxP', report.periodTotals.writeOffTotal]]
+        ? [['Bajas CxP efectivas', report.periodTotals.writeOffTotal]]
         : []),
       ['Facturas del período', report.periodTotals.totalCredits],
       ['Saldo pendiente', report.totalDue],
@@ -440,7 +440,9 @@ export class VendorReportService {
             date: new Date(writeOff.createdAt!),
             reference,
             type: 'WriteOff',
-            description: reason || 'Baja de cuenta por pagar',
+            description: isVoided
+              ? `${reason || 'Baja de cuenta por pagar'} (Anulada)`
+              : reason || 'Baja de cuenta por pagar',
             debits: amount,
             credits: 0,
             balance: 0,


### PR DESCRIPTION
Label effective write-offs, mark voided baja rows, add reconciliation tests for invoice-only and posted write-off running balance. PDF/Excel use same trace rows.

Made with [Cursor](https://cursor.com)