### PR TITLE
fix(treasury): complete supplier statement trace and supplier name

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -188,6 +188,7 @@ export class VendorReportComponent implements OnInit {
       .subscribe({
         next: (report) => {
           this.vendorReport = report;
+          this.vendorName = report.vendor.name;
           this.loading = false;
           if (!this.invoiceOptions.length && report.transactions.length) {
             this.invoiceOptions = [...new Set(report.transactions.map((t) => t.reference).filter(Boolean))]
@@ -271,7 +272,7 @@ export class VendorReportComponent implements OnInit {
         transaction.reference || '-',
         transaction.documentNumber || '-',
         transaction.expenseReceiptNumber || '-',
-        transaction.type === 'Bill' ? 'Factura' : transaction.type === 'Payment' ? 'Pago' : 'Baja CxP',
+        transactionTypeLabel(transaction.type),
         transaction.description || '-',
         transaction.debits || 0,
         transaction.credits || 0,
@@ -316,14 +317,19 @@ export class VendorReportComponent implements OnInit {
     if (voided && type === 'WriteOff') {
       return { severity: 'danger', text: `${text} (Anulada)` };
     }
+    if (voided && type === 'Payment') {
+      return { severity: 'danger', text: `${text} (Anulado)` };
+    }
     const severity =
       type === 'Payment'
         ? 'success'
-        : type === 'WriteOffReversal'
+        : type === 'PaymentReversal'
           ? 'warn'
-          : type === 'WriteOff'
-            ? 'warning'
-            : 'info';
+          : type === 'WriteOffReversal'
+            ? 'warn'
+            : type === 'WriteOff'
+              ? 'warning'
+              : 'info';
     return { severity, text };
   }
 

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -14,7 +14,7 @@ export interface VendorReportTransaction {
   reference: string;
   documentNumber?: string;
   expenseReceiptNumber?: string;
-  type: 'Bill' | 'Payment' | 'WriteOff' | 'WriteOffReversal';
+  type: 'Bill' | 'Payment' | 'PaymentReversal' | 'WriteOff' | 'WriteOffReversal';
   description: string;
   debits: number;
   credits: number;

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -3,6 +3,12 @@ import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/e
 import { VendorReportService } from './vendor-report.service';
 
 describe('VendorReportService summaries', () => {
+  function emptyThirds() {
+    return {
+      getThirdsByType: jasmine.createSpy('getThirdsByType').and.returnValue(of({ content: [] })),
+    };
+  }
+
   function service() {
     const api = {
       statement: jasmine.createSpy('statement').and.returnValue(of({
@@ -77,7 +83,7 @@ describe('VendorReportService summaries', () => {
         writeOffs: [],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -142,7 +148,7 @@ describe('VendorReportService summaries', () => {
         }],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -188,7 +194,7 @@ describe('VendorReportService summaries', () => {
         }],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -232,7 +238,7 @@ describe('VendorReportService summaries', () => {
         writeOffs: [],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -266,7 +272,7 @@ describe('VendorReportService summaries', () => {
         writeOffs: [],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -277,6 +283,212 @@ describe('VendorReportService summaries', () => {
       expect(report.transactions[0].type).toBe('Bill');
       expect(report.totalDue).toBe(357000);
       expect(report.agingReport.total).toBe(357000);
+      expect(report.transactions.at(-1)?.balance).toBe(357000);
+      done();
+    });
+  });
+
+  it('shows voided payment history without affecting effective totals', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 357000,
+        }],
+        vouchers: [{
+          issueDate: '2026-08-10',
+          voucherNumber: 'CE-100',
+          status: 'VOIDED',
+          updatedAt: '2026-08-12T15:00:00Z',
+          accountingEntryId: 88,
+          observations: 'Pago',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amountPaid: 100000,
+          }],
+        }],
+        writeOffs: [],
+      })),
+    };
+    const thirds = emptyThirds();
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      expect(report.periodTotals.periodPayments).toBe(0);
+      expect(report.totalDue).toBe(357000);
+      expect(report.transactions.some((row) => row.type === 'Payment' && row.voided)).toBeTrue();
+      expect(report.transactions.some((row) => row.type === 'PaymentReversal')).toBeTrue();
+      expect(report.transactions.at(-1)?.balance).toBe(357000);
+      expect(report.agingReport.total).toBe(357000);
+      done();
+    });
+  });
+
+  it('reconciles posted payment running balance with pending', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 100000,
+        writeOffTotal: 0,
+        pending: 257000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 257000,
+        }],
+        vouchers: [{
+          issueDate: '2026-08-10',
+          voucherNumber: 'CE-100',
+          status: 'POSTED',
+          accountingEntryId: 88,
+          observations: 'Pago',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amountPaid: 100000,
+          }],
+        }],
+        writeOffs: [],
+      })),
+    };
+    const thirds = emptyThirds();
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      const payment = report.transactions.find((row) => row.type === 'Payment');
+      expect(payment?.debits).toBe(100000);
+      expect(report.periodTotals.periodPayments).toBe(100000);
+      expect(report.transactions.at(-1)?.balance).toBe(257000);
+      expect(report.totalDue).toBe(257000);
+      expect(report.agingReport.total).toBe(257000);
+      done();
+    });
+  });
+
+  it('restores running balance when voided write-off reversal is outside report period', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 357000,
+        }],
+        vouchers: [],
+        writeOffs: [{
+          id: 5,
+          status: 'VOIDED',
+          reason: 'Ajuste',
+          createdAt: '2026-08-10T12:00:00Z',
+          updatedAt: '2026-09-05T12:00:00Z',
+          accountingEntryId: 12,
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amount: 100000,
+          }],
+        }],
+      })),
+    };
+    const thirds = emptyThirds();
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      const writeOff = report.transactions.find((row) => row.type === 'WriteOff');
+      const reversal = report.transactions.find((row) => row.type === 'WriteOffReversal');
+      expect(writeOff?.balance).toBe(257000);
+      expect(reversal?.balance).toBe(357000);
+      expect(report.transactions.at(-1)?.balance).toBe(357000);
+      expect(report.totalDue).toBe(357000);
+      done();
+    });
+  });
+
+  it('restores running balance through combined payment and write-off voids', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-357',
+          originalAmount: 357000,
+          pendingAmount: 357000,
+        }],
+        vouchers: [{
+          issueDate: '2026-08-08',
+          voucherNumber: 'CE-001',
+          status: 'VOIDED',
+          updatedAt: '2026-08-20T12:00:00Z',
+          accountingEntryId: 20,
+          observations: 'Pago',
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amountPaid: 50000,
+          }],
+        }],
+        writeOffs: [{
+          id: 5,
+          status: 'VOIDED',
+          reason: 'Ajuste',
+          createdAt: '2026-08-10T12:00:00Z',
+          updatedAt: '2026-08-18T12:00:00Z',
+          accountingEntryId: 12,
+          details: [{
+            supplierId: 78,
+            invoiceReference: 'FC-357',
+            amount: 100000,
+          }],
+        }],
+      })),
+    };
+    const thirds = emptyThirds();
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
+      const balances = report.transactions.map((row) => row.balance);
+      expect(balances).toEqual([357000, 307000, 207000, 307000, 357000]);
+      expect(report.periodTotals.writeOffTotal).toBe(0);
+      expect(report.periodTotals.periodPayments).toBe(0);
       expect(report.transactions.at(-1)?.balance).toBe(357000);
       done();
     });
@@ -313,7 +525,7 @@ describe('VendorReportService summaries', () => {
         }],
       })),
     };
-    const thirds = { getThirdsByType: jasmine.createSpy('getThirdsByType') };
+    const thirds = emptyThirds();
     const storage = { getIdEnterprise: () => 'enterprise-a' };
     const value = new VendorReportService(api as any, thirds as any, storage as any);
     const start = new Date(2026, 7, 1);
@@ -324,6 +536,50 @@ describe('VendorReportService summaries', () => {
       expect(writeOff?.debits).toBe(100000);
       expect(report.transactions.at(-1)?.balance).toBe(257000);
       expect(report.totalDue).toBe(257000);
+      done();
+    });
+  });
+
+  it('resolves canonical supplier name from thirds', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 357000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 357000,
+        invoices: [],
+        vouchers: [],
+        writeOffs: [],
+      })),
+    };
+    const thirds = {
+      getThirdsByType: jasmine.createSpy('getThirdsByType').and.returnValue(of({
+        content: [{
+          thId: 78,
+          entId: 'enterprise-a',
+          typeId: {} as any,
+          thirdTypes: [],
+          personType: ePersonType.juridica,
+          socialReason: 'PEPSI',
+          idNumber: 7,
+          state: true,
+          address: 'addr',
+          phoneNumber: '1',
+          email: 'a@b.com',
+        }],
+      })),
+      getThirdParties: jasmine.createSpy('getThirdParties'),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor 78').subscribe((report) => {
+      expect(thirds.getThirdsByType).toHaveBeenCalledWith('enterprise-a', 'Proveedor');
+      expect(report.vendor.name).toBe('PEPSI');
       done();
     });
   });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -10,7 +10,8 @@ import { Third } from '../../../../../GeneralMasters/ThirdParties/models/Third';
 import { ePersonType } from '../../../../../GeneralMasters/ThirdParties/models/ePersonType';
 import { eThirdType } from '../../../../../GeneralMasters/ThirdParties/models/eThirdType';
 import { TreasuryApiService } from '../../../Shared/treasury-api.service';
-import { PayableWriteOff } from '../../../Shared/treasury-api.models';
+import { PayableWriteOff, PaymentVoucher } from '../../../Shared/treasury-api.models';
+import { resolveSupplierName } from '../../../Shared/treasury-third-party.integration';
 import { educationalDescription, transactionTypeLabel } from '../../../Shared/treasury-status-labels';
 import { VendorListFilter, VendorReport, VendorReportSummary, VendorReportTransaction } from '../Models/VendorReport';
 
@@ -113,17 +114,24 @@ export class VendorReportService {
     active?: boolean,
     vendorName?: string,
   ): Observable<VendorReport> {
-    return this.api
-      .statement(
-        this.enterpriseId(),
-        vendorId,
-        startDate.toISOString().slice(0, 10),
-        endDate.toISOString().slice(0, 10),
-        invoice,
-        active,
-      )
-      .pipe(
-        map((statement) => {
+    return this.getProveedores().pipe(
+      switchMap((suppliers) => {
+        const supplierNameMap = new Map(
+          suppliers.map((supplier) => [Number(supplier.thId), supplier.displayName] as const),
+        );
+        const resolvedName = resolveSupplierName(supplierNameMap, vendorId);
+
+        return this.api
+          .statement(
+            this.enterpriseId(),
+            vendorId,
+            startDate.toISOString().slice(0, 10),
+            endDate.toISOString().slice(0, 10),
+            invoice,
+            active,
+          )
+          .pipe(
+            map((statement) => {
           const openingBalance = Number(statement.openingBalance || 0);
           const writeOffTotal = Number(statement.writeOffTotal || 0);
           const totalCredits = Number(statement.invoiced || 0);
@@ -145,19 +153,11 @@ export class VendorReportService {
             balance: 0,
           }));
 
-          const payments: VendorReportTransaction[] = (statement.vouchers || []).flatMap((voucher: any) =>
-            (voucher.details || [])
-              .filter((detail: any) => detail.supplierId === vendorId)
-              .map((detail: any) => ({
-                date: new Date(voucher.issueDate),
-                reference: detail.invoiceReference,
-                expenseReceiptNumber: voucher.voucherNumber,
-                type: 'Payment' as const,
-                description: this.paymentDescription(voucher.observations, voucher.voucherNumber),
-                debits: Number(detail.amountPaid ?? detail.amount ?? 0),
-                credits: 0,
-                balance: 0,
-              })),
+          const paymentRows = this.buildPaymentTransactions(
+            statement.vouchers,
+            vendorId,
+            startIso,
+            endIso,
           );
 
           const writeOffRows = this.buildWriteOffTransactions(
@@ -170,14 +170,14 @@ export class VendorReportService {
           const transactions = this.applyRunningBalance(
             [
               ...bills.filter((row) => this.inIsoDateRange(row.date, startIso, endIso)),
-              ...payments.filter((row) => this.inIsoDateRange(row.date, startIso, endIso)),
+              ...paymentRows,
               ...writeOffRows,
             ].sort((a, b) => a.date.getTime() - b.date.getTime()),
             openingBalance,
           );
 
           return {
-            vendor: { id: vendorId, name: vendorName || `Proveedor ${vendorId}` },
+            vendor: { id: vendorId, name: resolvedName },
             dateRange: { startDate, endDate },
             transactions,
             periodTotals: {
@@ -199,8 +199,10 @@ export class VendorReportService {
               total: closingBalance,
             },
           };
-        }),
-      );
+            }),
+          );
+      }),
+    );
   }
 
   buildPdf(report: VendorReport): Blob {
@@ -249,7 +251,7 @@ export class VendorReportService {
         t.reference || '-',
         t.documentNumber || '-',
         t.expenseReceiptNumber || '-',
-        t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : transactionTypeLabel(t.type),
+        t.type === 'Bill' ? 'Factura' : transactionTypeLabel(t.type),
         t.description || '-',
         t.debits > 0 ? fmt(t.debits) : '-',
         t.credits > 0 ? fmt(t.credits) : '-',
@@ -360,7 +362,7 @@ export class VendorReportService {
       t.reference || '',
       t.documentNumber || '',
       t.expenseReceiptNumber || '',
-      t.type === 'Bill' ? 'Factura' : t.type === 'Payment' ? 'Pago' : transactionTypeLabel(t.type),
+      t.type === 'Bill' ? 'Factura' : transactionTypeLabel(t.type),
       t.description || '',
       t.debits || 0,
       t.credits || 0,
@@ -414,6 +416,61 @@ export class VendorReportService {
     return this.buildExcel(report);
   }
 
+  private buildPaymentTransactions(
+    vouchers: PaymentVoucher[] | undefined,
+    vendorId: number,
+    startIso: string,
+    endIso: string,
+  ): VendorReportTransaction[] {
+    return (vouchers || []).flatMap((voucher) => {
+      const status = String(voucher.status || '');
+      const isVoided = status === 'VOIDED';
+      const issuedInPeriod = voucher.issueDate
+        ? this.inIsoDateRange(new Date(voucher.issueDate), startIso, endIso)
+        : false;
+
+      return (voucher.details || [])
+        .filter((detail) => Number(detail.supplierId) === vendorId)
+        .flatMap((detail) => {
+          const amount = Number(detail.amountPaid ?? detail.amount ?? 0);
+          const reference = detail.invoiceReference || '';
+          const description = this.paymentDescription(voucher.observations, voucher.voucherNumber);
+          const paymentInformational = !issuedInPeriod;
+          const paymentRow: VendorReportTransaction = {
+            date: new Date(voucher.issueDate),
+            reference,
+            expenseReceiptNumber: voucher.voucherNumber,
+            type: 'Payment',
+            description: isVoided ? `${description} (Anulado)` : description,
+            debits: amount,
+            credits: 0,
+            balance: 0,
+            voided: isVoided,
+            informational: paymentInformational,
+          };
+
+          if (!isVoided) {
+            return [paymentRow];
+          }
+
+          const reversalRow: VendorReportTransaction = {
+            date: new Date(voucher.updatedAt || voucher.issueDate),
+            reference,
+            expenseReceiptNumber: voucher.voucherNumber,
+            type: 'PaymentReversal',
+            description: `Reversión pago${voucher.voucherNumber ? ` comprobante ${voucher.voucherNumber}` : ''} (Anulado)`,
+            debits: 0,
+            credits: amount,
+            balance: 0,
+            voided: true,
+            informational: paymentInformational,
+          };
+
+          return [paymentRow, reversalRow];
+        });
+    });
+  }
+
   private buildWriteOffTransactions(
     writeOffs: PayableWriteOff[] | undefined,
     vendorId: number,
@@ -426,9 +483,6 @@ export class VendorReportService {
       const createdInPeriod = writeOff.createdAt
         ? this.inIsoDateRange(new Date(writeOff.createdAt), startIso, endIso)
         : false;
-      const voidedInPeriod = isVoided && writeOff.updatedAt
-        ? this.inIsoDateRange(new Date(writeOff.updatedAt), startIso, endIso)
-        : false;
       const reason = (writeOff.reason || '').trim();
 
       return (writeOff.details || [])
@@ -436,6 +490,7 @@ export class VendorReportService {
         .flatMap((detail) => {
           const amount = Number(detail.amount || 0);
           const reference = detail.invoiceReference || '';
+          const postedInformational = !createdInPeriod;
           const postedRow: VendorReportTransaction = {
             date: new Date(writeOff.createdAt!),
             reference,
@@ -447,11 +502,11 @@ export class VendorReportService {
             credits: 0,
             balance: 0,
             voided: isVoided,
-            informational: isVoided && !createdInPeriod,
+            informational: postedInformational,
           };
 
           if (!isVoided) {
-            return [{ ...postedRow, informational: !createdInPeriod }];
+            return [postedRow];
           }
 
           const reversalRow: VendorReportTransaction = {
@@ -463,7 +518,7 @@ export class VendorReportService {
             credits: amount,
             balance: 0,
             voided: true,
-            informational: !(createdInPeriod && voidedInPeriod),
+            informational: postedInformational,
           };
 
           return [postedRow, reversalRow];

--- a/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-status-labels.ts
@@ -29,6 +29,7 @@ const PAYABLE_LABELS: Record<string, string> = {
 const TRANSACTION_TYPE_LABELS: Record<string, string> = {
   Bill: 'Factura de compra',
   Payment: 'Pago a proveedor',
+  PaymentReversal: 'Reversión pago',
   WriteOff: 'Baja CxP',
   WriteOffReversal: 'Reversión Baja CxP',
 };


### PR DESCRIPTION
## Summary
- Show voided payment history with reversal rows in supplier statement detail.
- Restore running balance when voided write-off reversals are shown.
- Resolve canonical supplier names from Thirds instead of Proveedor {id} fallback.

## Test plan
- [x] vendor-report.service.spec extended
- [x] ng build PASS locally
- [ ] Karma (ChromeHeadless timeout in local env)

## Impact
Vendor statement report UI and service only.

Made with [Cursor](https://cursor.com)