### PR TITLE
fix(accounting): resolve account code and name in journal entry views

### DIFF
--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -29,8 +29,10 @@ import {
 } from '../../Shared/treasury-third-party.integration';
 import {
   AccountingEntryView,
+  AccountCatalogueNode,
   buildAccountCatalogueLookup,
   buildAccountingEntryView,
+  flattenAccountCatalogueRefs,
   mapAccountingMovementsForView,
 } from '../../Shared/treasury-accounting-display';
 import { PaymentVoucher, Payable, VoucherDetail } from '../../Shared/treasury-api.models';
@@ -484,7 +486,7 @@ export class ExpenseReceiptService {
     const enterpriseId = this.enterpriseId();
     return forkJoin({
       entry: this.api.accountingEntry(receiptId),
-      accounts: this.accounts.getListAuxiliaryAccounts(enterpriseId),
+      accounts: this.accounts.getListAccounts(enterpriseId).pipe(catchError(() => of([]))),
       voucher: this.api.voucher(receiptId, enterpriseId),
       thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000).pipe(
         catchError(() => of({ content: [] } as any)),
@@ -493,7 +495,9 @@ export class ExpenseReceiptService {
       map(({ entry, accounts, voucher, thirds }) => {
         const entryData = (entry as any)?.data ?? entry;
         const lookup = buildAccountCatalogueLookup(
-          accounts.filter((account) => account.status !== false),
+          flattenAccountCatalogueRefs(accounts as AccountCatalogueNode[]).filter(
+            (account) => account.status !== false,
+          ),
         );
         const movements = mapAccountingMovementsForView(entryData?.movements ?? [], lookup);
         const thirdNames = buildThirdPartyNameMap(thirds?.content || []);

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -60,6 +60,7 @@ import {
   accountingTotalsBalanced,
   buildAccountCatalogueLookup,
   buildAccountingEntryView,
+  flattenAccountCatalogueRefs,
   mapAccountingMovementsForView,
 } from '../Shared/treasury-accounting-display';
 import { ContextualHelpComponent } from '../../../Shared/Components/contextual-help/contextual-help.component';
@@ -137,6 +138,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   allPaymentMethodsCount = 0;
   banks: any[] = [];
   accounts: any[] = [];
+  accountingAccountLookup = new Map<number, { code: string; description: string }>();
   bankOptions: { id: number; label: string }[] = [];
   accountOptions: { id: number; label: string }[] = [];
   readonly paymentAmountOptions = [
@@ -382,7 +384,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     this.accountingMovements = [];
     this.accountingDebitTotal = 0;
     this.accountingCreditTotal = 0;
-    const accountLookup = buildAccountCatalogueLookup(this.accounts);
+    const accountLookup = this.accountingAccountLookup;
     const supplierIds = [...new Set((item.details ?? []).map((detail) => detail.supplierId))];
     const supplierLabel = supplierIds
       .map((id) => this.supplierNames.get(Number(id)) ?? '—')
@@ -562,6 +564,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
       banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
       accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
+      accountCatalogue: this.chart.getListAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
       thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(
         catchError(() => of({ content: [] } as any)),
       ),
@@ -580,6 +583,9 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           label: `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`
         }));
         this.accounts = data.accounts.filter((a: any) => a.status !== false);
+        this.accountingAccountLookup = buildAccountCatalogueLookup(
+          flattenAccountCatalogueRefs(data.accountCatalogue || []).filter((a: any) => a.status !== false),
+        );
         this.accountOptions = this.accounts.map((account: any) => ({
           id: account.id,
           label: `${account.code} - ${account.description}`
@@ -1460,7 +1466,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     this.accountingMovements = [];
     this.accountingDebitTotal = 0;
     this.accountingCreditTotal = 0;
-    const accountLookup = buildAccountCatalogueLookup(this.accounts);
+    const accountLookup = this.accountingAccountLookup;
     const supplierIds = [...new Set(voucher.details.map((detail) => detail.supplierId))];
     const supplierLabel = supplierIds.map((id) => this.supplierName(id)).join(', ');
 
@@ -1858,6 +1864,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
       banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
       accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
+      accountCatalogue: this.chart.getListAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
       thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
     }).pipe(
       switchMap((data) => {
@@ -1872,6 +1879,9 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           label: `${bank.bank?.name || 'Banco'} - ${bank.accountNumber}`,
         }));
         this.accounts = data.accounts.filter((a: any) => a.status !== false);
+        this.accountingAccountLookup = buildAccountCatalogueLookup(
+          flattenAccountCatalogueRefs(data.accountCatalogue || []).filter((a: any) => a.status !== false),
+        );
         this.accountOptions = this.accounts.map((account: any) => ({
           id: account.id,
           label: `${account.code} - ${account.description}`,

--- a/src/app/Financial/Treasury/Shared/treasury-accounting-display.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-accounting-display.spec.ts
@@ -1,0 +1,62 @@
+import {
+  buildAccountCatalogueLookup,
+  flattenAccountCatalogueRefs,
+  mapAccountingMovementsForView,
+  resolveAccountFromLookup,
+  resolveMovementAccountDisplay,
+} from './treasury-accounting-display';
+
+describe('treasury-accounting-display', () => {
+  const lookup = buildAccountCatalogueLookup([
+    { id: 21, code: '2105', description: 'Cuentas por pagar', status: true },
+    { id: 99, code: '11050101', description: 'Banco menor', status: true },
+  ]);
+
+  it('resolves known accountId from catalogue lookup', () => {
+    const resolved = resolveMovementAccountDisplay({ accountId: 21 }, lookup);
+    expect(resolved.accountCode).toBe('2105');
+    expect(resolved.accountName).toBe('Cuentas por pagar');
+  });
+
+  it('keeps explicit code and name when already provided', () => {
+    const resolved = resolveMovementAccountDisplay({
+      accountCode: '11050101',
+      accountName: 'Banco menor',
+    }, lookup);
+    expect(resolved.accountCode).toBe('11050101');
+    expect(resolved.accountName).toBe('Banco menor');
+  });
+
+  it('falls back when accountId is not resolvable', () => {
+    const resolved = resolveAccountFromLookup(404, lookup);
+    expect(resolved.accountCode).toBe('—');
+    expect(resolved.accountName).toBe('Cuenta 404');
+  });
+
+  it('maps each movement with its own resolved account', () => {
+    const rows = mapAccountingMovementsForView([
+      { accountId: 21, description: 'Pago factura 863170369', debit: 20000, credit: 0 },
+      { accountCode: '11050101', accountName: 'Banco menor', description: 'Pago', debit: 0, credit: 20000 },
+    ], lookup);
+
+    expect(rows[0].accountCode).toBe('2105');
+    expect(rows[0].accountName).toBe('Cuentas por pagar');
+    expect(rows[1].accountCode).toBe('11050101');
+    expect(rows[1].accountName).toBe('Banco menor');
+  });
+
+  it('flattens nested catalogue nodes for lookup', () => {
+    const flat = flattenAccountCatalogueRefs([
+      {
+        id: 1,
+        code: '2',
+        description: 'Pasivo',
+        children: [{ id: 21, code: '2105', description: 'Cuentas por pagar' }],
+      },
+    ]);
+    const nestedLookup = buildAccountCatalogueLookup(flat);
+    const resolved = resolveMovementAccountDisplay({ accountId: 21 }, nestedLookup);
+    expect(resolved.accountCode).toBe('2105');
+    expect(resolved.accountName).toBe('Cuentas por pagar');
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
@@ -30,6 +30,31 @@ export interface AccountCatalogueRef {
   status?: boolean;
 }
 
+export interface AccountCatalogueNode extends AccountCatalogueRef {
+  children?: AccountCatalogueNode[];
+}
+
+export function flattenAccountCatalogueRefs(accounts: AccountCatalogueNode[]): AccountCatalogueRef[] {
+  const flat: AccountCatalogueRef[] = [];
+  const walk = (nodes: AccountCatalogueNode[]) => {
+    nodes.forEach((node) => {
+      if (node.id != null) {
+        flat.push({
+          id: node.id,
+          code: node.code,
+          description: node.description,
+          status: node.status,
+        });
+      }
+      if (node.children?.length) {
+        walk(node.children);
+      }
+    });
+  };
+  walk(accounts);
+  return flat;
+}
+
 export function buildAccountCatalogueLookup(accounts: AccountCatalogueRef[]): Map<number, { code: string; description: string }> {
   const lookup = new Map<number, { code: string; description: string }>();
   accounts.forEach((account) => {
@@ -87,13 +112,53 @@ export function resolveAccountFromLookup(
   };
 }
 
+function hasExplicitAccountLabel(code: string, name: string): boolean {
+  if (!code || !name) {
+    return false;
+  }
+  const normalizedName = name.trim();
+  return normalizedName !== '—' && normalizedName !== `Cuenta ${code}`;
+}
+
+export function resolveMovementAccountDisplay(
+  movement: Record<string, unknown>,
+  accountLookup: Map<number, { code: string; description: string }>,
+): { accountId?: number; accountCode: string; accountName: string } {
+  const accountIdRaw = movement['accountId'];
+  const accountId = accountIdRaw != null && accountIdRaw !== ''
+    ? Number(accountIdRaw)
+    : undefined;
+  if (accountId != null && !Number.isNaN(accountId) && accountLookup.has(accountId)) {
+    const account = accountLookup.get(accountId)!;
+    return {
+      accountId,
+      accountCode: account.code,
+      accountName: account.description,
+    };
+  }
+
+  const explicitCode = String(movement['accountCode'] ?? '').trim();
+  const explicitName = String(
+    movement['accountName'] ?? movement['accountDescription'] ?? movement['accountLabel'] ?? '',
+  ).trim();
+  if (hasExplicitAccountLabel(explicitCode, explicitName)) {
+    return {
+      accountId: accountId != null && !Number.isNaN(accountId) ? accountId : undefined,
+      accountCode: explicitCode,
+      accountName: explicitName,
+    };
+  }
+
+  const accountRef = accountId ?? movement['accountCode'] ?? movement['account'];
+  return resolveAccountFromLookup(accountRef, accountLookup);
+}
+
 export function mapAccountingMovementsForView(
   movements: unknown[],
   accountLookup: Map<number, { code: string; description: string }>,
 ): AccountingMovementViewRow[] {
   return (movements as Record<string, unknown>[]).map((movement) => {
-    const accountRef = movement['accountCode'] ?? movement['account'] ?? movement['accountId'];
-    const resolved = resolveAccountFromLookup(accountRef, accountLookup);
+    const resolved = resolveMovementAccountDisplay(movement, accountLookup);
     const thirdPartyRaw = movement['thirdPartyId'];
     const thirdPartyId = thirdPartyRaw != null ? Number(thirdPartyRaw) : undefined;
     return {


### PR DESCRIPTION
﻿## Summary
- Resolve journal entry account code/name from full Account Catalogue (not only auxiliary accounts)
- Fix shared treasury accounting display helper to resolve by accountId before falling back to Cuenta {id}
- Apply fix across expense receipt details/list/accounting and treasury operations accounting modals

## Test plan
- [ ] Open CE-C1ECE17A expense receipt details and verify CxP line shows real code/name (not Cuenta 21)
- [ ] Verify bank line 11050101 / Banco menor still renders correctly
- [ ] Open accounting entry from treasury operations (payment, write-off, reversal if available)
- [ ] Confirm no Cuenta {id} for resolvable accounts in /expense-receipts/details/:id
- [x] ng build PASS
- [ ] Unit tests: Karma ChromeHeadless timeout (known environmental issue)
