### PR TITLE
feat(treasury): add contextual help for write-off counterpart account

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -971,7 +971,16 @@
       </p-inputNumber>
     </div>
     <div class="flex flex-col gap-2">
-      <label for="writeOffCounterpartAccount" class="font-semibold text-[var(--color-primary)]">Cuenta contrapartida *</label>
+      <label for="writeOffCounterpartAccount" class="font-semibold text-[var(--color-primary)] inline-flex items-center gap-1">
+        Cuenta contrapartida *
+        <app-contextual-help
+          class="inline-flex align-middle"
+          iconClass="text-base"
+          [title]="writeOffCounterpartHelp.title"
+          [summary]="writeOffCounterpartHelp.summary"
+          [helpCenterSlug]="writeOffCounterpartHelp.slug">
+        </app-contextual-help>
+      </label>
       <p-dropdown
         inputId="writeOffCounterpartAccount"
         [(ngModel)]="writeOffCounterpartAccountId"

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -203,6 +203,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   dueDateReason = '';
   minDueDate!: Date;
   readonly help = TREASURY_HELP.operations;
+  readonly writeOffCounterpartHelp = TREASURY_HELP.writeOffCounterpartAccount;
   readonly noAvailableBankAccountsMessage = NO_AVAILABLE_BANK_ACCOUNTS_MESSAGE;
   readonly voucherStatusOptions = voucherStatusFilterOptions();
   private supplierNames = new Map<number, string>();

--- a/src/app/Financial/Treasury/Shared/treasury-help-content.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-help-content.ts
@@ -43,6 +43,18 @@ export const TREASURY_HELP = {
       'El detalle muestra movimientos del período y antigüedad de saldos.',
     slug: 'tesoreria',
   },
+  writeOffCounterpartAccount: {
+    title: 'Cuenta contrapartida',
+    summary:
+      'Cuenta contable que explica el reconocimiento de la disminución de la deuda cuando esta no se cancela mediante un pago.\n\n' +
+      'En una Baja CxP se disminuye una obligación sin realizar un pago. La Cuenta por Pagar se debita para reducir la deuda y la cuenta contrapartida se acredita según el motivo contable de la baja.\n\n' +
+      'Ejemplo del asiento:\n' +
+      'CxP                  Débito   $40.000\n' +
+      'Cuenta contrapartida Crédito   $40.000\n\n' +
+      'La cuenta contrapartida debe seleccionarse de acuerdo con la razón contable de la baja y no representa automáticamente una cuenta bancaria o de caja.\n\n' +
+      'Ejemplo práctico: si una obligación de $100.000 se reduce en $40.000 mediante una Baja CxP, el saldo pendiente queda en $60.000 sin que exista salida de dinero.',
+    slug: 'tesoreria',
+  },
 } as const;
 
 export const ACCOUNT_CATALOGUE_HELP = {

--- a/src/app/Shared/Components/contextual-help/contextual-help.component.ts
+++ b/src/app/Shared/Components/contextual-help/contextual-help.component.ts
@@ -12,8 +12,15 @@ import { HelpCenterService } from '../../services/help-center.service';
   standalone: true,
   imports: [CommonModule, PopoverModule],
   template: `
-    <span class="text-primary cursor-pointer inline-flex items-center" (click)="popover.toggle($event)">
-      <i class="pi pi-question-circle" [ngClass]="iconClass"></i>
+    <span
+      class="text-primary cursor-pointer inline-flex items-center"
+      role="button"
+      tabindex="0"
+      [attr.aria-label]="'Ayuda: ' + title"
+      (click)="popover.toggle($event)"
+      (keydown.enter)="popover.toggle($event); $event.preventDefault()"
+      (keydown.space)="popover.toggle($event); $event.preventDefault()">
+      <i class="pi pi-question-circle" [ngClass]="iconClass" aria-hidden="true"></i>
     </span>
     <p-popover #popover>
       <div class="p-4" style="max-width: 420px">


### PR DESCRIPTION
﻿## Summary
- Add contextual help icon next to the write-off counterpart account selector in Treasury Operations
- Reuse existing app-contextual-help pattern with educational content about Baja CxP accounting
- Improve keyboard accessibility on the shared contextual help trigger

## Test plan
- [x] ng build PASS
- [ ] Open Baja CxP dialog and verify help icon appears next to Cuenta contrapartida
- [ ] Verify selector behavior unchanged
- [ ] Verify help text explains CxP reduction without payment
