### PR TITLE
feat(treasury): disable operations when payment schedule is active

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -101,6 +101,9 @@
                   label="Pagar"
                   icon="pi pi-wallet"
                   size="small"
+                  [disabled]="hasActivePaymentScheduleForPayable(payable)"
+                  [pTooltip]="activePaymentScheduleTooltip(payable)"
+                  tooltipPosition="top"
                   (onClick)="openPaymentDialog(payable)">
                 </p-button>
                 <p-button
@@ -109,8 +112,8 @@
                   size="small"
                   severity="secondary"
                   [outlined]="true"
-                  [disabled]="hasActiveFullSchedule(payable)"
-                  [pTooltip]="hasActiveFullSchedule(payable) ? 'Ya existe un pago programado por el saldo disponible. Cancele la programación para crear otra.' : undefined"
+                  [disabled]="hasActivePaymentScheduleForPayable(payable)"
+                  [pTooltip]="activePaymentScheduleTooltip(payable)"
                   tooltipPosition="top"
                   (onClick)="openScheduleDialog(payable)">
                 </p-button>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -156,6 +156,34 @@ describe('TreasuryOperationsComponent PP8', () => {
     expect((value as any).messageService.add).toHaveBeenCalled();
   });
 
+  it('blocks payment when selected method is no longer selectable', () => {
+    const { value, api } = component();
+    value.openPaymentDialog(value.payables[0]);
+    value.dialogLines[0].paymentMode = 'partial';
+    value.dialogLines[0].amount = 25;
+    value.dialogPaymentMethodId = 99;
+    value.dialogBankAccountId = 33;
+    value.confirmPayFromDialog();
+    expect(api.createVoucher).not.toHaveBeenCalled();
+    expect((value as any).messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: 'El método de pago seleccionado ya no está disponible.',
+    }));
+  });
+
+  it('blocks draft creation when selected method is no longer selectable', () => {
+    const { value, api } = component();
+    value.openPaymentDialog(value.payables[0]);
+    value.dialogLines[0].paymentMode = 'partial';
+    value.dialogLines[0].amount = 25;
+    value.dialogPaymentMethodId = 99;
+    value.dialogBankAccountId = 33;
+    value.confirmCreateFromDialog();
+    expect(api.createVoucher).not.toHaveBeenCalled();
+    expect((value as any).messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: 'El método de pago seleccionado ya no está disponible.',
+    }));
+  });
+
   it('creates draft from dialog when payment rules are satisfied', () => {
     const { value, api } = component();
     api.createVoucher.and.returnValue(of({
@@ -282,6 +310,28 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.confirmScheduleFromDialog();
     expect(api.createSchedule).toHaveBeenCalled();
     expect(api.createVoucher).not.toHaveBeenCalled();
+  });
+
+  it('disables pay write-off and schedule actions when payable has active schedule', () => {
+    const { value, api } = component();
+    const target = payable({ id: 11, availableAmount: 100, pendingAmount: 100 });
+    value.schedules = [{
+      id: 1,
+      executionDate: '2026-08-20',
+      status: 'SCHEDULED',
+      total: 50,
+      retryCount: 0,
+      paymentMethodId: 1,
+      enterpriseId: 'enterprise-a',
+      details: [{ supplierId: 7, invoiceId: 11, amount: 50 }],
+    }];
+    expect(value.hasActivePaymentScheduleForPayable(target)).toBeTrue();
+    expect(value.canWriteOffPayable(target)).toBeFalse();
+    value.openPaymentDialog(target);
+    expect(value.paymentDialogVisible).toBeFalse();
+    value.openScheduleDialog(target);
+    expect(value.scheduleDialogVisible).toBeFalse();
+    expect(api.createSchedule).not.toHaveBeenCalled();
   });
 
   it('enables write-off action when payable has available balance', () => {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -70,6 +70,9 @@ import {
   paymentMethodsAvailabilityMessage,
 } from '../Shared/treasury-payment-messages';
 import {
+  ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE,
+} from '../Shared/treasury-schedule-messages';
+import {
   WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
   WRITE_OFF_AMOUNT_INVALID_MESSAGE,
   WRITE_OFF_COUNTERPART_REQUIRED_MESSAGE,
@@ -655,12 +658,16 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   canWriteOffPayable(payable: Payable): boolean {
     return payable.active
       && Number(payable.availableAmount) > 0
-      && !this.hasActiveWriteOffForPayable(payable);
+      && !this.hasActiveWriteOffForPayable(payable)
+      && !this.hasActivePaymentScheduleForPayable(payable);
   }
 
   writeOffPayableTooltip(payable: Payable): string | undefined {
     if (!payable.active || Number(payable.availableAmount) <= 0) {
       return WRITE_OFF_NO_AVAILABLE_BALANCE_MESSAGE;
+    }
+    if (this.hasActivePaymentScheduleForPayable(payable)) {
+      return ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE;
     }
     if (this.hasActiveWriteOffForPayable(payable)) {
       return WRITE_OFF_PENDING_BLOCK_MESSAGE;
@@ -679,6 +686,15 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   openWriteOffDialog(payable: Payable) {
+    if (this.hasActivePaymentScheduleForPayable(payable)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Pago programado',
+        detail: ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
     if (this.hasActiveWriteOffForPayable(payable)) {
       this.messageService.add({
         severity: 'warn',
@@ -883,6 +899,15 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   openPaymentDialog(payable: Payable) {
+    if (this.hasActivePaymentScheduleForPayable(payable)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Pago programado',
+        detail: ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
     if (this.noActivePaymentMethods) {
       this.messageService.add({
         severity: 'warn',
@@ -926,6 +951,15 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   openScheduleDialog(payable: Payable) {
+    if (this.hasActivePaymentScheduleForPayable(payable)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Pago programado',
+        detail: ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE,
+        life: 6000,
+      });
+      return;
+    }
     if (this.noActivePaymentMethods) {
       this.messageService.add({
         severity: 'warn',
@@ -1211,15 +1245,15 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   scheduledAmountForPayable(payable: Payable): number {
-    return this.activeSchedules()
+    return this.blockingSchedules()
       .flatMap((schedule) => schedule.details ?? [])
-      .filter((detail) => detail.invoiceId === payable.id)
+      .filter((detail) => detail.invoiceId === payable.id && !detail.canceled)
       .reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
   }
 
   scheduledLabelForPayable(payable: Payable): string | null {
-    const linked = this.activeSchedules().filter((schedule) =>
-      (schedule.details ?? []).some((detail) => detail.invoiceId === payable.id),
+    const linked = this.blockingSchedules().filter((schedule) =>
+      (schedule.details ?? []).some((detail) => detail.invoiceId === payable.id && !detail.canceled),
     );
     if (!linked.length) {
       return null;
@@ -1229,9 +1263,16 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     return `${this.formatMoney(amount)} · ${dates}`;
   }
 
-  hasActiveFullSchedule(payable: Payable): boolean {
-    const scheduled = this.scheduledAmountForPayable(payable);
-    return scheduled > 0 && scheduled >= Number(payable.availableAmount);
+  hasActivePaymentScheduleForPayable(payable: Payable): boolean {
+    return this.blockingSchedules().some((schedule) =>
+      (schedule.details ?? []).some((detail) => detail.invoiceId === payable.id && !detail.canceled),
+    );
+  }
+
+  activePaymentScheduleTooltip(payable: Payable): string | undefined {
+    return this.hasActivePaymentScheduleForPayable(payable)
+      ? ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE
+      : undefined;
   }
 
   payableReference(invoiceId: number): string {
@@ -1239,8 +1280,8 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     return payable?.reference ?? `ID ${invoiceId}`;
   }
 
-  private activeSchedules(): PaymentSchedule[] {
-    return this.schedules.filter((schedule) => schedule.status === 'SCHEDULED');
+  private blockingSchedules(): PaymentSchedule[] {
+    return this.schedules.filter((schedule) => schedule.status === 'SCHEDULED' || schedule.status === 'FAILED');
   }
 
   private buildScheduleSuccessDetail(
@@ -1337,6 +1378,15 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         severity: 'warn',
         summary: 'Método requerido',
         detail: 'Seleccione un método de pago activo.',
+        life: 5000,
+      });
+      return false;
+    }
+    if (!selectedMethod) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Método de pago',
+        detail: 'El método de pago seleccionado ya no está disponible.',
         life: 5000,
       });
       return false;

--- a/src/app/Financial/Treasury/Shared/treasury-api.models.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-api.models.ts
@@ -37,6 +37,8 @@ export interface ScheduleDetail {
   supplierId: number;
   invoiceId: number;
   amount: number;
+  canceled?: boolean;
+  cancellationReason?: string;
 }
 export interface PaymentSchedule {
   id: number; enterpriseId: string; executionDate: string; status: ScheduleStatus;

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-display.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-display.spec.ts
@@ -1,0 +1,34 @@
+import { PaymentSchedule } from './treasury-api.models';
+import { scheduleActiveDetails, scheduleActiveTotal, scheduleInvoicesLabel, scheduleTotal } from './treasury-schedule-display';
+
+describe('treasury-schedule-display', () => {
+  const schedule: PaymentSchedule = {
+    id: 1,
+    enterpriseId: 'ent',
+    executionDate: '2026-08-20',
+    status: 'SCHEDULED',
+    paymentMethodId: 1,
+    retryCount: 0,
+    details: [
+      { supplierId: 10, invoiceId: 11, amount: 100000, canceled: true },
+      { supplierId: 20, invoiceId: 12, amount: 200000 },
+    ],
+  };
+
+  it('keeps original total while excluding canceled details from active total', () => {
+    expect(scheduleTotal(schedule)).toBe(300000);
+    expect(scheduleActiveTotal(schedule)).toBe(200000);
+    expect(scheduleActiveDetails(schedule).length).toBe(1);
+  });
+
+  it('marks canceled invoice lines in schedule label', () => {
+    const label = scheduleInvoicesLabel(
+      schedule,
+      new Map([[11, 'FC-A'], [12, 'FC-B']]),
+      (amount) => `$${amount}`,
+    );
+    expect(label).toContain('FC-A ($100000) · cancelado');
+    expect(label).toContain('FC-B ($200000)');
+    expect(label).not.toContain('FC-B ($200000) · cancelado');
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-display.ts
@@ -2,11 +2,19 @@ import { PaymentSchedule } from './treasury-api.models';
 import { translatePaymentMethodName } from './treasury-status-labels';
 import { resolveSupplierName } from './treasury-third-party.integration';
 
+export function scheduleActiveDetails(item: PaymentSchedule) {
+  return (item.details ?? []).filter((detail) => !detail.canceled);
+}
+
 export function scheduleTotal(item: PaymentSchedule): number {
   if (item.total != null && !Number.isNaN(Number(item.total))) {
     return Number(item.total);
   }
   return (item.details ?? []).reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
+}
+
+export function scheduleActiveTotal(item: PaymentSchedule): number {
+  return scheduleActiveDetails(item).reduce((sum, detail) => sum + Number(detail.amount ?? 0), 0);
 }
 
 export function scheduleSuppliersLabel(
@@ -35,7 +43,8 @@ export function scheduleInvoicesLabel(
   return details
     .map((detail) => {
       const reference = payableReferenceById.get(detail.invoiceId) ?? `ID ${detail.invoiceId}`;
-      return `${reference} (${formatMoney(Number(detail.amount ?? 0))})`;
+      const canceledSuffix = detail.canceled ? ' · cancelado' : '';
+      return `${reference} (${formatMoney(Number(detail.amount ?? 0))})${canceledSuffix}`;
     })
     .join(', ');
 }

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
@@ -1,0 +1,5 @@
+export const ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE =
+  'Esta obligación tiene un pago programado activo. Cancela la programación para realizar otra operación.';
+
+export const ACTIVE_PAYMENT_SCHEDULE_DUPLICATE_MESSAGE =
+  'La obligación ya tiene una programación de pago activa.';


### PR DESCRIPTION
## Summary
- Disable Pay, Baja CxP, and Programar actions when an obligation has an active payment schedule.
- Show clear tooltip/helper text guiding users to cancel the schedule first.
- Align frontend UX with backend balance-blocking rules.

## Test plan
- [x] ng test --include=**/treasury-operations.component.spec.ts (59 tests)
- [x] ng build
- [x] Verified disabled buttons and dialog guards for active schedules

