### PR TITLE
fix(treasury): block same-day dates in payment schedule dialog

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -70,6 +70,7 @@ describe('TreasuryOperationsComponent PP8', () => {
     }];
     value.minExecutionDate = new Date();
     value.minExecutionDate.setHours(0, 0, 0, 0);
+    value.minExecutionDate.setDate(value.minExecutionDate.getDate() + 1);
     value.methods = [{ id: 1, requiresBankAccount: true, accountingAccountId: 10 }];
     value.methodOptions = [{ id: 1, label: 'Transferencia' }];
     value.bankOptions = [{ id: 33, label: 'Banco - 123' }];
@@ -310,6 +311,33 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.confirmScheduleFromDialog();
     expect(api.createSchedule).toHaveBeenCalled();
     expect(api.createVoucher).not.toHaveBeenCalled();
+  });
+
+  it('rejects schedule submission when execution date is today', () => {
+    const { value, api } = component();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    value.openScheduleDialog(value.payables[0]);
+    value.scheduleLines[0].amount = 25;
+    value.schedulePaymentMethodId = 1;
+    value.scheduleBankAccountId = 33;
+    value.scheduleExecutionDate = today;
+    value.confirmScheduleFromDialog();
+    expect(api.createSchedule).not.toHaveBeenCalled();
+  });
+
+  it('rejects schedule submission when execution date is in the past', () => {
+    const { value, api } = component();
+    const yesterday = new Date();
+    yesterday.setHours(0, 0, 0, 0);
+    yesterday.setDate(yesterday.getDate() - 1);
+    value.openScheduleDialog(value.payables[0]);
+    value.scheduleLines[0].amount = 25;
+    value.schedulePaymentMethodId = 1;
+    value.scheduleBankAccountId = 33;
+    value.scheduleExecutionDate = yesterday;
+    value.confirmScheduleFromDialog();
+    expect(api.createSchedule).not.toHaveBeenCalled();
   });
 
   it('disables pay write-off and schedule actions when payable has active schedule', () => {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -71,6 +71,7 @@ import {
 } from '../Shared/treasury-payment-messages';
 import {
   ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE,
+  SCHEDULE_FUTURE_DATE_REQUIRED_MESSAGE,
 } from '../Shared/treasury-schedule-messages';
 import {
   WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
@@ -447,7 +448,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     const today = this.stripTime(new Date());
     this.minDueDate = this.addDays(today, 1);
-    this.minExecutionDate = today;
+    this.minExecutionDate = this.addDays(today, 1);
     this.setupVoucherFilterSubscriptions();
     this.reload();
   }
@@ -996,13 +997,14 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     if (!selectedDate) {
       return;
     }
-    if (this.stripTime(selectedDate).getTime() < this.minExecutionDate.getTime()) {
+    const today = this.stripTime(new Date());
+    if (this.stripTime(selectedDate).getTime() <= today.getTime()) {
       this.scheduleExecutionDate = new Date(this.minExecutionDate);
       this.messageService.add({
         severity: 'warn',
         summary: 'Fecha inválida',
-        detail: 'La fecha programada no puede ser anterior a hoy.',
-        life: 4000,
+        detail: SCHEDULE_FUTURE_DATE_REQUIRED_MESSAGE,
+        life: 5000,
       });
     }
   }
@@ -1427,6 +1429,18 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         life: 5000,
       });
       return false;
+    }
+    if (options?.requireScheduleDate && options.executionDate) {
+      const today = this.stripTime(new Date());
+      if (this.stripTime(options.executionDate).getTime() <= today.getTime()) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Fecha inválida',
+          detail: SCHEDULE_FUTURE_DATE_REQUIRED_MESSAGE,
+          life: 5000,
+        });
+        return false;
+      }
     }
     return true;
   }

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
@@ -3,3 +3,6 @@ export const ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE =
 
 export const ACTIVE_PAYMENT_SCHEDULE_DUPLICATE_MESSAGE =
   'La obligación ya tiene una programación de pago activa.';
+
+export const SCHEDULE_FUTURE_DATE_REQUIRED_MESSAGE =
+  'La fecha de programación debe ser posterior a hoy. Para realizar el pago ahora, utiliza la opción Pagar.';


### PR DESCRIPTION
## Summary
- Set schedule calendar minimum date to tomorrow.
- Block submit when execution date is today or in the past.
- Show message guiding users to use Pay for immediate payments.

## Test plan
- [x] treasury-operations.component.spec.ts: today and past dates rejected
- [x] Future date scheduling still works

Made with [Cursor](https://cursor.com)