### PR TITLE
fix(treasury): distinguish load errors from empty data

### DIFF
--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -41,6 +41,17 @@
     </div>
   </div>
 
+  <div *ngIf="loadError" class="flex flex-wrap items-center gap-3 mb-4">
+    <p-message severity="error" [text]="loadError" styleClass="w-full"></p-message>
+    <p-button
+      label="Reintentar"
+      icon="pi pi-refresh"
+      severity="secondary"
+      [outlined]="true"
+      [loading]="loading"
+      (onClick)="reload()">
+    </p-button>
+  </div>
   <p-message *ngIf="error" severity="error" [text]="error" styleClass="mb-4 w-full"></p-message>
   <p-message
     *ngIf="noActivePaymentMethods && paymentMethodsHelpMessage"
@@ -49,7 +60,7 @@
     styleClass="mb-4 w-full">
   </p-message>
 
-  <div class="treasury-sections">
+  <div *ngIf="loaded" class="treasury-sections">
   <fieldset [disabled]="busy" class="treasury-fieldset">
     <p-card header="Obligaciones pendientes">
       <p-table

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { NEVER, of } from 'rxjs';
+import { NEVER, of, throwError } from 'rxjs';
 import { TreasuryOperationsComponent } from './treasury-operations.component';
 import {
   WRITE_OFF_AMOUNT_EXCEEDS_MESSAGE,
@@ -18,7 +18,7 @@ import {
 } from '../Shared/treasury-writeoff-messages';
 
 describe('TreasuryOperationsComponent PP8', () => {
-  function component() {
+  function component(enterpriseId = 'enterprise-a') {
     const api = {
       createVoucher: jasmine.createSpy('createVoucher').and.returnValue(NEVER),
       createSchedule: jasmine.createSpy('createSchedule').and.returnValue(NEVER),
@@ -35,17 +35,28 @@ describe('TreasuryOperationsComponent PP8', () => {
       writeOff: jasmine.createSpy('writeOff').and.returnValue(of({ id: 1, status: 'POSTED', total: 100 })),
       accountingEntry: jasmine.createSpy('accountingEntry').and.returnValue(of({ code: 'AE-PWO-12', movements: [] })),
     };
-    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const storage = {
+      getIdEnterprise: jasmine.createSpy('getIdEnterprise').and.returnValue(enterpriseId),
+    };
     const exportService = {
       datedFilename: (_prefix: string, ext: string) => `test.${ext}`,
       downloadCsvSections: jasmine.createSpy('downloadCsvSections'),
       downloadPdfSections: jasmine.createSpy('downloadPdfSections'),
     };
     const messageService = { add: jasmine.createSpy('add') };
-    const paymentMethods = { findAllActive: () => of({ content: [] }) };
-    const chart = { getListAuxiliaryAccounts: () => of([]) };
-    const bankAccountsService = { findAllActive: () => of({ content: [] }) };
-    const thirds = { getThirdParties: () => of({ content: [] }) };
+    const paymentMethods = {
+      findAllActive: jasmine.createSpy('findAllActive').and.returnValue(of({ content: [] })),
+    };
+    const chart = {
+      getListAuxiliaryAccounts: jasmine.createSpy('getListAuxiliaryAccounts').and.returnValue(of([])),
+      getListAccounts: jasmine.createSpy('getListAccounts').and.returnValue(of([])),
+    };
+    const bankAccountsService = {
+      findAllActive: jasmine.createSpy('findAllActive').and.returnValue(of({ content: [] })),
+    };
+    const thirds = {
+      getThirdParties: jasmine.createSpy('getThirdParties').and.returnValue(of({ content: [] })),
+    };
     const expenseReceiptService = {
       getSuppliers: jasmine.createSpy('getSuppliers').and.returnValue(of([])),
     };
@@ -84,7 +95,16 @@ describe('TreasuryOperationsComponent PP8', () => {
       label: `${account.code} - ${account.description}`,
     }));
     (value as any).supplierNames = new Map<number, string>([[7, 'Proveedor Demo']]);
-    return { value, api, expenseReceiptService };
+    return {
+      value,
+      api,
+      storage,
+      paymentMethods,
+      chart,
+      bankAccountsService,
+      thirds,
+      expenseReceiptService,
+    };
   }
 
   function payable(overrides: Partial<any> = {}) {
@@ -109,6 +129,98 @@ describe('TreasuryOperationsComponent PP8', () => {
       ...overrides,
     };
   }
+
+  it('loads Treasury data from successful API responses', () => {
+    const { value, api } = component();
+    const expectedPayable = payable({ id: 91 });
+    const expectedVoucher = { id: 12, voucherNumber: 'CE-12', status: 'DRAFT', details: [] };
+    api.pending.and.returnValue(of([expectedPayable]));
+    api.vouchers.and.returnValue(of({ content: [expectedVoucher] }));
+
+    value.reload();
+
+    expect(value.payables).toEqual([expectedPayable]);
+    expect(value.allVouchers).toEqual([expectedVoucher] as any);
+    expect(value.vouchers).toEqual([expectedVoucher] as any);
+    expect(value.loaded).toBeTrue();
+    expect(value.loading).toBeFalse();
+    expect(value.loadError).toBe('');
+  });
+
+  it('treats a successful empty response as a legitimate empty state', () => {
+    const { value } = component();
+
+    value.reload();
+
+    expect(value.payables).toEqual([]);
+    expect(value.vouchers).toEqual([]);
+    expect(value.schedules).toEqual([]);
+    expect(value.writeOffs).toEqual([]);
+    expect(value.loaded).toBeTrue();
+    expect(value.loadError).toBe('');
+  });
+
+  it('exposes a load error instead of presenting a first-load HTTP failure as empty data', () => {
+    const { value, api } = component();
+    value.payables = [];
+    api.pending.and.returnValue(throwError(() => ({ status: 500 })));
+
+    value.reload();
+
+    expect(value.loaded).toBeFalse();
+    expect(value.loading).toBeFalse();
+    expect(value.loadError).toBe('No fue posible cargar la información de Tesorería.');
+  });
+
+  it('keeps the last valid data when a later reload fails', () => {
+    const { value, api } = component();
+    const lastValidPayables = [payable({ id: 77 })];
+    api.pending.and.returnValue(of(lastValidPayables));
+    value.reload();
+    expect(value.loaded).toBeTrue();
+
+    api.pending.and.returnValue(throwError(() => ({ status: 500 })));
+    value.reload();
+
+    expect(value.payables).toEqual(lastValidPayables);
+    expect(value.loaded).toBeTrue();
+    expect(value.loadError).toBe('No fue posible cargar la información de Tesorería.');
+  });
+
+  it('reads the active enterprise again on every reload', () => {
+    const { value, api, storage } = component();
+    storage.getIdEnterprise.and.returnValues('enterprise-a', 'enterprise-b');
+
+    value.reload();
+    value.reload();
+
+    expect(api.pending.calls.allArgs()).toEqual([
+      ['enterprise-a'],
+      ['enterprise-b'],
+    ]);
+    expect(api.vouchers.calls.allArgs()).toEqual([
+      ['enterprise-a', { size: 1000 }],
+      ['enterprise-b', { size: 1000 }],
+    ]);
+  });
+
+  it('does not call Treasury APIs when there is no active enterprise', () => {
+    const { value, api, paymentMethods, chart, bankAccountsService, thirds } = component('');
+
+    value.reload();
+
+    expect(api.pending).not.toHaveBeenCalled();
+    expect(api.vouchers).not.toHaveBeenCalled();
+    expect(api.schedules).not.toHaveBeenCalled();
+    expect(api.writeOffs).not.toHaveBeenCalled();
+    expect(paymentMethods.findAllActive).not.toHaveBeenCalled();
+    expect(bankAccountsService.findAllActive).not.toHaveBeenCalled();
+    expect(chart.getListAuxiliaryAccounts).not.toHaveBeenCalled();
+    expect(chart.getListAccounts).not.toHaveBeenCalled();
+    expect(thirds.getThirdParties).not.toHaveBeenCalled();
+    expect(value.loaded).toBeFalse();
+    expect(value.loadError).toBe('Seleccione una empresa activa.');
+  });
 
   it('blocks payment dialog when no active payment methods are available', () => {
     const { value } = component();

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -127,6 +127,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   private static readonly POST_POLL_INTERVAL_MS = 2_000;
   private static readonly POST_POLL_MAX_ATTEMPTS = 15;
   private static readonly VOUCHER_FILTER_DEBOUNCE_MS = 300;
+  private static readonly LOAD_ERROR_MESSAGE = 'No fue posible cargar la información de Tesorería.';
   private readonly destroy$ = new Subject<void>();
   private readonly voucherNumberFilter$ = new Subject<string>();
 
@@ -143,6 +144,9 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   banks: any[] = [];
   accounts: any[] = [];
   accountingAccountLookup = new Map<number, { code: string; description: string }>();
+  loading = false;
+  loaded = false;
+  loadError = '';
   bankOptions: { id: number; label: string }[] = [];
   accountOptions: { id: number; label: string }[] = [];
   readonly paymentAmountOptions = [
@@ -428,7 +432,11 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   accountingStatusLabel = accountingEntryStatusLabel;
   supplierName = (supplierId: number) => resolveSupplierName(this.supplierNames, supplierId);
 
-  private readonly enterpriseId: string;
+  private loadedEnterpriseId = '';
+
+  private get enterpriseId(): string {
+    return this.loadedEnterpriseId || this.storage.getIdEnterprise();
+  }
 
   constructor(
     private readonly api: TreasuryApiService,
@@ -441,9 +449,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     private readonly messageService: MessageService,
     private readonly expenseReceiptService: ExpenseReceiptService,
     private readonly router: Router,
-  ) {
-    this.enterpriseId = this.storage.getIdEnterprise();
-  }
+  ) {}
 
   ngOnInit() {
     const today = this.stripTime(new Date());
@@ -555,24 +561,33 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
   }
 
   reload() {
-    if (!this.enterpriseId) {
-      this.error = 'Seleccione una empresa activa.';
+    const enterpriseId = this.storage.getIdEnterprise();
+    this.error = '';
+    this.loadError = '';
+
+    if (!enterpriseId) {
+      this.loading = false;
+      this.loaded = false;
+      this.busy = false;
+      this.loadError = 'Seleccione una empresa activa.';
       return;
     }
+
+    if (this.loadedEnterpriseId && this.loadedEnterpriseId !== enterpriseId) {
+      this.loaded = false;
+    }
+    this.loading = true;
     this.busy = true;
-    this.error = '';
     forkJoin({
-      payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
-      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }).pipe(catchError(() => of({ content: this.allVouchers } as any))),
-      schedules: this.api.schedules(this.enterpriseId).pipe(catchError(() => of(this.schedules))),
-      writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
-      methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
-      banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
-      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
-      accountCatalogue: this.chart.getListAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
-      thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(
-        catchError(() => of({ content: [] } as any)),
-      ),
+      payables: this.api.pending(enterpriseId),
+      vouchers: this.api.vouchers(enterpriseId, { size: 1000 }),
+      schedules: this.api.schedules(enterpriseId),
+      writeOffs: this.api.writeOffs(enterpriseId),
+      methods: this.paymentMethods.findAllActive(enterpriseId),
+      banks: this.bankAccounts.findAllActive(enterpriseId),
+      accounts: this.chart.getListAuxiliaryAccounts(enterpriseId),
+      accountCatalogue: this.chart.getListAccounts(enterpriseId),
+      thirds: this.thirds.getThirdParties(enterpriseId, 0, 1000),
     }).subscribe({
       next: data => {
         this.payables = data.payables;
@@ -606,10 +621,14 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           id: method.id,
           label: translatePaymentMethodName(method.name),
         }));
+        this.loadedEnterpriseId = enterpriseId;
+        this.loaded = true;
+        this.loading = false;
         this.busy = false;
       },
-      error: err => {
-        this.error = err?.error?.message ?? 'No fue posible cargar Tesorería.';
+      error: () => {
+        this.loadError = TreasuryOperationsComponent.LOAD_ERROR_MESSAGE;
+        this.loading = false;
         this.busy = false;
       }
     });
@@ -1572,8 +1591,12 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
       timeout(TreasuryOperationsComponent.OPERATION_TIMEOUT_MS),
       switchMap((confirmed) => this.waitForWriteOffPosting(confirmed.id ?? item.id)),
       switchMap((updated) => forkJoin({
-        payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
-        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
+        payables: this.api.pending(this.enterpriseId).pipe(
+          catchError(() => this.preserveDataAfterRefreshError(this.payables)),
+        ),
+        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(
+          catchError(() => this.preserveDataAfterRefreshError(this.writeOffs)),
+        ),
       }).pipe(map((data) => ({ updated, ...data })))),
       finalize(() => {
         this.busy = false;
@@ -1651,8 +1674,12 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         return of(voided);
       }),
       switchMap((updated) => forkJoin({
-        payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
-        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(catchError(() => of(this.writeOffs))),
+        payables: this.api.pending(this.enterpriseId).pipe(
+          catchError(() => this.preserveDataAfterRefreshError(this.payables)),
+        ),
+        writeOffs: this.api.writeOffs(this.enterpriseId).pipe(
+          catchError(() => this.preserveDataAfterRefreshError(this.writeOffs)),
+        ),
       }).pipe(map((data) => ({ updated, ...data })))),
       finalize(() => {
         this.busy = false;
@@ -1905,7 +1932,7 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
           });
         }
         return this.api.writeOffs(this.enterpriseId).pipe(
-          catchError(() => of(this.writeOffs)),
+          catchError(() => this.preserveDataAfterRefreshError(this.writeOffs)),
           switchMap((writeOffs) => {
             this.writeOffs = this.normalizeWriteOffList(writeOffs);
             return this.reloadCoreData();
@@ -1923,14 +1950,14 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
 
   private reloadCoreData(): Observable<void> {
     return forkJoin({
-      payables: this.api.pending(this.enterpriseId).pipe(catchError(() => of(this.payables))),
-      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }).pipe(catchError(() => of({ content: this.allVouchers } as any))),
-      schedules: this.api.schedules(this.enterpriseId).pipe(catchError(() => of(this.schedules))),
-      methods: this.paymentMethods.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
-      banks: this.bankAccounts.findAllActive(this.enterpriseId).pipe(catchError(() => of({ content: [] }))),
-      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
-      accountCatalogue: this.chart.getListAccounts(this.enterpriseId).pipe(catchError(() => of([]))),
-      thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000).pipe(catchError(() => of({ content: [] } as any))),
+      payables: this.api.pending(this.enterpriseId),
+      vouchers: this.api.vouchers(this.enterpriseId, { size: 1000 }),
+      schedules: this.api.schedules(this.enterpriseId),
+      methods: this.paymentMethods.findAllActive(this.enterpriseId),
+      banks: this.bankAccounts.findAllActive(this.enterpriseId),
+      accounts: this.chart.getListAuxiliaryAccounts(this.enterpriseId),
+      accountCatalogue: this.chart.getListAccounts(this.enterpriseId),
+      thirds: this.thirds.getThirdParties(this.enterpriseId, 0, 1000),
     }).pipe(
       switchMap((data) => {
         this.payables = data.payables;
@@ -1964,7 +1991,13 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
         }));
         return of(undefined);
       }),
+      catchError(() => this.preserveDataAfterRefreshError(undefined)),
     );
+  }
+
+  private preserveDataAfterRefreshError<T>(currentData: T): Observable<T> {
+    this.loadError = TreasuryOperationsComponent.LOAD_ERROR_MESSAGE;
+    return of(currentData);
   }
 
   private handleOperationError(err: unknown, action: string): void {


### PR DESCRIPTION
- Treasury Operations ya no transforma errores HTTP en colecciones vacías.
- Una respuesta 200 + [] continúa representando correctamente ausencia de registros.
- Los errores de carga muestran un estado explícito y permiten reintentar.
- Un refresh fallido conserva los últimos datos válidos.
- enterpriseId se vuelve a obtener en cada reload para respetar cambios de empresa activa.
- No modifica backend, Gateway, PostgreSQL, manifests ni lógica contable.

Validaciones:
- Treasury Operations tests: 67/67 PASS
- npm run build: PASS
- git diff --check: PASS