### PR TITLE
feat(purchase-invoice): add purchase invoice listing

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -19,7 +19,7 @@
       <div class="flex flex-wrap gap-2 lg:justify-end shrink-0">
         <p-button label="Guardar factura" icon="pi pi-save" (click)="saveInvoice()"
           [disabled]="lstProducts.length === 0 || !supplier" [loading]="saving"></p-button>
-        <p-button label="Cancelar" icon="pi pi-times" severity="secondary" [outlined]="true"
+        <p-button label="Volver al listado" icon="pi pi-arrow-left" severity="secondary" [outlined]="true"
           (click)="cancel()"></p-button>
       </div>
     </div>

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.spec.ts
@@ -9,7 +9,7 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
       {} as any,
       {} as any,
       {} as any,
-      {} as any,
+      { add: jasmine.createSpy() } as any,
       {} as any,
       {} as any,
     );
@@ -90,7 +90,7 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
     expect(value.paymentTermDays).toBe(1);
   });
 
-  it('keeps payment term and due date in sync', () => {
+  it('keeps payment term and due date in sync', fakeAsync(() => {
     const value = component();
     value.currentDate = new Date('2026-08-13T12:00:00');
     value.minDueDate = new Date('2026-08-14T00:00:00');
@@ -99,14 +99,17 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
 
     expect(value.paymentTermDays).toBe(30);
     expect(value.dueDate?.toISOString().slice(0, 10)).toBe('2026-09-12');
+    tick();
 
     value.paymentTermDays = 10;
     value.onPaymentTermChange();
     expect(value.dueDate?.toISOString().slice(0, 10)).toBe('2026-08-23');
+    tick();
 
     value.onDueDateChange(new Date('2026-08-20T12:00:00'));
     expect(value.paymentTermDays).toBe(7);
-  });
+    tick();
+  }));
 
   it('recalculates line and invoice totals after editing a product', () => {
     const value = component();
@@ -117,6 +120,7 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
       IvaValor: 0,
       totalValue: 0,
       descuentos: [0, 0],
+      maxQuantity: 10,
     } as any;
     value.lstProducts = [product];
 
@@ -130,6 +134,15 @@ describe('PurchaseInvoiceCreationComponent totals', () => {
 });
 
 describe('PurchaseInvoiceCreationComponent save state', () => {
+  it('returns to the purchase invoice list', () => {
+    const component = Object.create(PurchaseInvoiceCreationComponent.prototype) as any;
+    component.router = { navigate: jasmine.createSpy() };
+
+    component.cancel();
+
+    expect(component.router.navigate).toHaveBeenCalledOnceWith(['/commercial/purchase-invoice']);
+  });
+
   it('releases the loading button when the server does not respond', fakeAsync(() => {
     const component = Object.create(PurchaseInvoiceCreationComponent.prototype) as any;
     component.supplier = { thId: 1 };
@@ -140,11 +153,14 @@ describe('PurchaseInvoiceCreationComponent save state', () => {
       cost: 100,
       IVA: 0,
       descuentos: [0, 0],
+      maxQuantity: 10,
     }];
     component.initialPayment = 0;
     component.total = 100;
     component.pendingTotal = 100;
     component.currentDate = new Date('2026-08-13T12:00:00');
+    component.minDueDate = new Date('2026-08-14T00:00:00');
+    component.dueDate = new Date('2026-09-12T00:00:00');
     component.paymentTermDays = 30;
     component.impuestoCheck = true;
     component.localStorageMethods = {

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -354,7 +354,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   }
 
   cancel(): void {
-    this.router.navigate(['/enterprise/list']);
+    this.router.navigate(['/commercial/purchase-invoice']);
   }
 
   private purchaseSaveErrorDetail(error: unknown): string {

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.css
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.css
@@ -1,0 +1,109 @@
+:host {
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
+.purchase-page {
+  color: #1f2937;
+}
+
+.purchase-shell {
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 6%);
+}
+
+.invoice-list {
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 1rem;
+  background: #fff;
+}
+
+.list-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.list-heading h2 {
+  margin: 0;
+  color: #111a68;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.list-heading p {
+  margin: 0.15rem 0 0;
+  color: #64748b;
+  font-family: sans-serif;
+  font-size: 0.8rem;
+}
+
+.load-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid #fecaca;
+  border-radius: 0.85rem;
+  color: #991b1b;
+  background: #fef2f2;
+}
+
+.load-error strong,
+.load-error span {
+  display: block;
+}
+
+.load-error span {
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+}
+
+.empty-state {
+  display: flex;
+  min-height: 13rem;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.empty-state .pi {
+  color: #94a3b8;
+  font-size: 2rem;
+}
+
+.empty-state strong {
+  color: #334155;
+  font-size: 1rem;
+}
+
+.empty-state span {
+  max-width: 30rem;
+  font-family: sans-serif;
+  font-size: 0.82rem;
+}
+
+:host ::ng-deep .p-datatable-table-container {
+  overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+  .purchase-shell {
+    margin: 0.5rem;
+    padding: 1rem;
+  }
+
+  .load-error {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.html
@@ -1,0 +1,97 @@
+<div class="purchase-page flex w-full min-h-full font-titillium bg-gray-50">
+  <div class="purchase-shell flex-1 min-w-0 m-2 md:m-6 bg-white rounded-2xl p-4 md:p-8">
+    <header class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-7">
+      <div>
+        <h1 class="font-bold text-2xl md:text-3xl text-primary border-b-4 border-secondary inline-block pb-1">
+          Facturas de compra
+        </h1>
+        <p class="mt-2 text-sm text-gray-600">
+          Consulte las compras registradas y el saldo pendiente que se sincroniza con Tesorería.
+        </p>
+      </div>
+      <p-button
+        label="Nueva factura de compra"
+        icon="pi pi-plus"
+        (onClick)="createInvoice()">
+      </p-button>
+    </header>
+
+    @if (loadError) {
+      <div class="load-error" role="alert">
+        <div>
+          <strong>No fue posible consultar las facturas</strong>
+          <span>{{ loadError }}</span>
+        </div>
+        <p-button
+          label="Reintentar"
+          icon="pi pi-refresh"
+          severity="secondary"
+          [outlined]="true"
+          (onClick)="loadInvoices()">
+        </p-button>
+      </div>
+    } @else {
+      <section class="invoice-list" aria-labelledby="purchase-list-title">
+        <div class="list-heading">
+          <div>
+            <h2 id="purchase-list-title">Compras registradas</h2>
+            <p>{{ invoices.length }} factura{{ invoices.length === 1 ? '' : 's' }} de compra</p>
+          </div>
+        </div>
+
+        <p-table
+          [value]="invoices"
+          [loading]="loading"
+          [paginator]="invoices.length > 10"
+          [rows]="10"
+          [rowsPerPageOptions]="[10, 20, 50]"
+          [tableStyle]="{ 'min-width': '68rem' }"
+          styleClass="p-datatable-striped">
+          <ng-template pTemplate="header">
+            <tr>
+              <th scope="col">Número / referencia</th>
+              <th scope="col">Proveedor</th>
+              <th scope="col">Fecha</th>
+              <th scope="col">Vencimiento</th>
+              <th scope="col" class="text-right">Total</th>
+              <th scope="col" class="text-right">Valor pagado</th>
+              <th scope="col" class="text-right">Saldo pendiente</th>
+              <th scope="col">Estado</th>
+            </tr>
+          </ng-template>
+
+          <ng-template pTemplate="body" let-invoice>
+            <tr>
+              <td class="font-semibold text-primary">{{ invoice.reference }}</td>
+              <td>{{ invoice.supplier }}</td>
+              <td>{{ invoice.issueDate | date: 'dd/MM/yyyy' }}</td>
+              <td>{{ invoice.dueDate ? (invoice.dueDate | date: 'dd/MM/yyyy') : 'Sin definir' }}</td>
+              <td class="text-right">{{ formatCurrency(invoice.total) }}</td>
+              <td class="text-right">{{ formatCurrency(invoice.paid) }}</td>
+              <td class="text-right font-semibold">{{ formatCurrency(invoice.pending) }}</td>
+              <td><p-tag [value]="invoice.status" [severity]="statusSeverity(invoice.status)"></p-tag></td>
+            </tr>
+          </ng-template>
+
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="8">
+                <div class="empty-state">
+                  <i class="pi pi-file"></i>
+                  <strong>Aún no hay facturas de compra</strong>
+                  <span>Use “Nueva factura de compra” para registrar la primera compra de la empresa.</span>
+                </div>
+              </td>
+            </tr>
+          </ng-template>
+
+          <ng-template pTemplate="loadingbody">
+            <tr>
+              <td colspan="8" class="text-center py-8">Cargando facturas de compra...</td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </section>
+    }
+  </div>
+</div>

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.spec.ts
@@ -1,0 +1,90 @@
+import { of, throwError } from 'rxjs';
+import { PurchaseInvoiceListComponent } from './purchase-invoice-list.component';
+
+describe('PurchaseInvoiceListComponent', () => {
+  function createComponent(options?: { summaries?: any[]; details?: Record<number, any>; error?: boolean }) {
+    const factureService = {
+      getAllFactures: jasmine.createSpy().and.returnValue(
+        options?.error ? throwError(() => new Error('backend unavailable')) : of(options?.summaries ?? []),
+      ),
+      getFactureById: jasmine.createSpy().and.callFake((id: number) => of(options?.details?.[id])),
+    };
+    const thirdService = {
+      getThirdsByType: jasmine.createSpy().and.returnValue(of({
+        content: [{ thId: 7, personType: 'Juridica', socialReason: 'Proveedor PP8' }],
+      })),
+    };
+    const router = { navigate: jasmine.createSpy() };
+    const component = new PurchaseInvoiceListComponent(factureService as any, thirdService as any, router as any);
+    (component as any).localStorageMethods = { getIdEnterprise: () => 'enterprise-pp8' };
+    return { component, factureService, router };
+  }
+
+  it('lists PURCHASE invoices with supplier, balances, due date and status', () => {
+    const { component, factureService } = createComponent({
+      summaries: [
+        { id: 1, entId: 'enterprise-pp8', factureType: 'PURCHASE' },
+        { id: 2, entId: 'enterprise-pp8', factureType: 'SALE' },
+      ],
+      details: {
+        1: {
+          id: 1,
+          factCode: 103,
+          entId: 'enterprise-pp8',
+          factureType: 'PURCHASE',
+          thId: 7,
+          totalValue: '1250000.00',
+          totalPay: '250000.00',
+          pendingValue: '1000000.00',
+          createdAt: '2026-08-17T10:00:00',
+          expirationDate: '2099-09-16',
+          purchaseStatus: 'ACTIVE',
+        },
+      },
+    });
+
+    component.loadInvoices();
+
+    expect(factureService.getFactureById).toHaveBeenCalledOnceWith(1);
+    expect(component.invoices).toEqual([jasmine.objectContaining({
+      reference: '#103',
+      supplier: 'Proveedor PP8',
+      total: 1_250_000,
+      paid: 250_000,
+      pending: 1_000_000,
+      dueDate: '2099-09-16',
+      status: 'Pendiente',
+    })]);
+    expect(component.loadError).toBe('');
+  });
+
+  it('shows a normal empty result when there are no PURCHASE invoices', () => {
+    const { component, factureService } = createComponent({
+      summaries: [{ id: 2, entId: 'enterprise-pp8', factureType: 'SALE' }],
+    });
+
+    component.loadInvoices();
+
+    expect(component.invoices).toEqual([]);
+    expect(component.loadError).toBe('');
+    expect(factureService.getFactureById).not.toHaveBeenCalled();
+  });
+
+  it('exposes the real load error instead of replacing it with an empty list', () => {
+    const { component } = createComponent({ error: true });
+    component.invoices = [{ id: 99 } as any];
+
+    component.loadInvoices();
+
+    expect(component.loadError).toContain('No se pudieron cargar');
+    expect(component.invoices).toEqual([{ id: 99 } as any]);
+  });
+
+  it('navigates to the existing purchase creation form', () => {
+    const { component, router } = createComponent();
+
+    component.createInvoice();
+
+    expect(router.navigate).toHaveBeenCalledOnceWith(['/commercial/purchase-invoice/new']);
+  });
+});

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component.ts
@@ -1,0 +1,191 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { forkJoin, map, Observable, of, switchMap, catchError, finalize } from 'rxjs';
+import { ButtonModule } from 'primeng/button';
+import { TableModule } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { Third } from '../../../../GeneralMasters/ThirdParties/models/Third';
+import { ThirdService } from '../../../../GeneralMasters/ThirdParties/Services/third.service';
+import { eThirdType } from '../../../../GeneralMasters/ThirdParties/models/eThirdType';
+import { LocalStorageMethods } from '../../../../Shared/Methods/local-storage.method';
+import { SteletonService } from '../../../InvoiceTemplate/services/steleton.service';
+
+interface PurchaseFactureSummary {
+  id: number;
+  entId: string;
+  factureType: string;
+}
+
+interface PurchaseFactureDetail extends PurchaseFactureSummary {
+  factCode: number;
+  thId: number;
+  totalValue: string;
+  totalPay: string;
+  pendingValue: string;
+  expirationDate?: string;
+  createdAt: string;
+  purchaseStatus?: string;
+}
+
+interface PurchaseInvoiceRow {
+  id: number;
+  reference: string;
+  supplier: string;
+  issueDate: string;
+  dueDate?: string;
+  total: number;
+  paid: number;
+  pending: number;
+  status: 'Pendiente' | 'Vencida' | 'Pagada' | 'Anulada';
+}
+
+@Component({
+  selector: 'app-purchase-invoice-list',
+  standalone: true,
+  imports: [CommonModule, ButtonModule, TableModule, TagModule],
+  templateUrl: './purchase-invoice-list.component.html',
+  styleUrl: './purchase-invoice-list.component.css',
+})
+export class PurchaseInvoiceListComponent implements OnInit {
+  private readonly localStorageMethods = new LocalStorageMethods();
+
+  invoices: PurchaseInvoiceRow[] = [];
+  loading = false;
+  loadError = '';
+
+  constructor(
+    private readonly factureService: SteletonService,
+    private readonly thirdService: ThirdService,
+    private readonly router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadInvoices();
+  }
+
+  loadInvoices(): void {
+    const enterpriseId = this.localStorageMethods.getIdEnterprise();
+    if (!enterpriseId) {
+      this.loadError = 'Seleccione una empresa activa para consultar las facturas de compra.';
+      return;
+    }
+
+    this.loading = true;
+    this.loadError = '';
+
+    forkJoin({
+      summaries: this.factureService.getAllFactures() as Observable<PurchaseFactureSummary[]>,
+      suppliers: this.thirdService.getThirdsByType(enterpriseId, eThirdType.Proveedor).pipe(
+        catchError(() => of({ content: [] })),
+      ),
+    }).pipe(
+      switchMap(({ summaries, suppliers }) => {
+        const supplierNames = this.supplierNames(suppliers.content ?? []);
+        const purchases = (summaries ?? []).filter((facture) =>
+          facture.factureType === 'PURCHASE' && facture.entId === enterpriseId,
+        );
+
+        if (purchases.length === 0) {
+          return of([] as PurchaseInvoiceRow[]);
+        }
+
+        return forkJoin(purchases.map((facture) =>
+          (this.factureService.getFactureById(facture.id) as Observable<PurchaseFactureDetail>).pipe(
+            map((detail) => this.toRow(detail, supplierNames)),
+          ),
+        ));
+      }),
+      finalize(() => {
+        this.loading = false;
+      }),
+    ).subscribe({
+      next: (invoices) => {
+        this.invoices = [...invoices].sort((left, right) =>
+          right.issueDate.localeCompare(left.issueDate) || right.id - left.id,
+        );
+      },
+      error: () => {
+        this.loadError = 'No se pudieron cargar las facturas de compra. Intente nuevamente.';
+      },
+    });
+  }
+
+  createInvoice(): void {
+    this.router.navigate(['/commercial/purchase-invoice/new']);
+  }
+
+  formatCurrency(value: number): string {
+    return new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  statusSeverity(status: PurchaseInvoiceRow['status']): 'success' | 'warn' | 'danger' | 'secondary' {
+    if (status === 'Pagada') {
+      return 'success';
+    }
+    if (status === 'Vencida') {
+      return 'danger';
+    }
+    if (status === 'Anulada') {
+      return 'secondary';
+    }
+    return 'warn';
+  }
+
+  private toRow(detail: PurchaseFactureDetail, supplierNames: Map<number, string>): PurchaseInvoiceRow {
+    const pending = this.amount(detail.pendingValue);
+    return {
+      id: detail.id,
+      reference: `#${detail.factCode}`,
+      supplier: supplierNames.get(detail.thId) ?? `Proveedor #${detail.thId}`,
+      issueDate: detail.createdAt,
+      dueDate: detail.expirationDate,
+      total: this.amount(detail.totalValue),
+      paid: this.amount(detail.totalPay),
+      pending,
+      status: this.invoiceStatus(detail.purchaseStatus, pending, detail.expirationDate),
+    };
+  }
+
+  private invoiceStatus(purchaseStatus: string | undefined, pending: number, dueDate?: string): PurchaseInvoiceRow['status'] {
+    if (purchaseStatus === 'VOIDED') {
+      return 'Anulada';
+    }
+    if (pending <= 0) {
+      return 'Pagada';
+    }
+    if (dueDate && dueDate < this.today()) {
+      return 'Vencida';
+    }
+    return 'Pendiente';
+  }
+
+  private supplierNames(suppliers: Third[]): Map<number, string> {
+    return new Map(suppliers.map((supplier) => [supplier.thId, this.supplierName(supplier)]));
+  }
+
+  private supplierName(supplier: Third): string {
+    if (supplier.personType === 'Natural') {
+      return `${supplier.names ?? ''} ${supplier.lastNames ?? ''}`.trim() || `Proveedor #${supplier.thId}`;
+    }
+    return supplier.socialReason?.trim() || `Proveedor #${supplier.thId}`;
+  }
+
+  private amount(value: string): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private today(): string {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, '0');
+    const day = String(today.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/src/app/routes/commercial.routes.ts
+++ b/src/app/routes/commercial.routes.ts
@@ -40,13 +40,23 @@ export const COMMERCIAL_ROUTES: Routes = [
       ),
   },
   {
-    path: 'purchase-invoice',
+    path: 'purchase-invoice/new',
     data: {
-      breadcrumb: 'Factura de Compra',
+      breadcrumb: 'Nueva Factura de Compra',
     },
     loadComponent: () =>
       import('../Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component').then(
         (m) => m.PurchaseInvoiceCreationComponent
+      ),
+  },
+  {
+    path: 'purchase-invoice',
+    data: {
+      breadcrumb: 'Facturas de Compra',
+    },
+    loadComponent: () =>
+      import('../Commercial/PurchaseInvoice/components/purchase-invoice-list/purchase-invoice-list.component').then(
+        (m) => m.PurchaseInvoiceListComponent
       ),
   },
   {


### PR DESCRIPTION
Este cambio completa de forma m?nima la secci?n de Facturas de Compra para el flujo PP8.

- Agrega listado espec?fico de facturas PURCHASE.
- Muestra referencia, proveedor, emisi?n, vencimiento, total, pagado, pendiente y estado.
- Diferencia lista vac?a de error HTTP.
- Agrega reintento ante error.
- Agrega navegaci?n hacia "Nueva factura de compra".
- Mueve el formulario existente a `/commercial/purchase-invoice/new`.
- Reutiliza endpoints existentes.
- No modifica backend, Treasury, RabbitMQ ni l?gica contable.

Validaciones:
- Purchase Invoice tests: 13/13 PASS.
- `npm run build`: PASS.
- `git diff --check`: PASS.
