### PR TITLE
fix: render treasury accounting entries correctly

### DIFF
--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
@@ -63,23 +63,11 @@
                         <td class="font-mono">{{ entry.accountCode }}</td>
                         <td>{{ entry.accountName }}</td>
                         <td>{{ entry.detail }}</td>
-                        <td class="text-right">
-                            @if (entry.debit > 0) {
-                                <span class="text-red-600 font-semibold">
-                                    {{ entry.debit | currency:'COP':'symbol':'1.0-2':'es-CO' }}
-                                </span>
-                            } @else {
-                                <span class="text-gray-400">-</span>
-                            }
+                        <td class="text-right text-red-600 font-semibold">
+                            {{ entry.debit | currency:'COP':'code':'1.0-2':'es-CO' }}
                         </td>
-                        <td class="text-right">
-                            @if (entry.credit > 0) {
-                                <span class="text-green-600 font-semibold">
-                                    {{ entry.credit | currency:'COP':'symbol':'1.0-2':'es-CO' }}
-                                </span>
-                            } @else {
-                                <span class="text-gray-400">-</span>
-                            }
+                        <td class="text-right text-green-600 font-semibold">
+                            {{ entry.credit | currency:'COP':'code':'1.0-2':'es-CO' }}
                         </td>
                     </tr>
                 </ng-template>
@@ -87,10 +75,10 @@
                     <tr class="font-semibold bg-gray-50">
                         <td colspan="3" class="text-right">Totales</td>
                         <td class="text-right text-red-600">
-                            {{ getTotalDebit() | currency:'COP':'symbol':'1.0-2':'es-CO' }}
+                            {{ getTotalDebit() | currency:'COP':'code':'1.0-2':'es-CO' }}
                         </td>
                         <td class="text-right text-green-600">
-                            {{ getTotalCredit() | currency:'COP':'symbol':'1.0-2':'es-CO' }}
+                            {{ getTotalCredit() | currency:'COP':'code':'1.0-2':'es-CO' }}
                         </td>
                     </tr>
                 </ng-template>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.spec.ts
@@ -1,0 +1,94 @@
+import { registerLocaleData } from '@angular/common';
+import localeEsCo from '@angular/common/locales/es-CO';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
+import { ExpenseReceiptAccountingComponent } from './expense-receipt-accounting.component';
+
+describe('ExpenseReceiptAccountingComponent route view', () => {
+  let fixture: ComponentFixture<ExpenseReceiptAccountingComponent>;
+  let service: {
+    getExpenseReceiptById: jasmine.Spy;
+    getAccountingEntryView: jasmine.Spy;
+  };
+
+  beforeAll(() => registerLocaleData(localeEsCo));
+
+  beforeEach(async () => {
+    service = {
+      getExpenseReceiptById: jasmine.createSpy().and.returnValue(of({
+        id: 21,
+        receiptCode: 'CE-21',
+        issueDate: new Date('2026-08-18'),
+        supplierName: 'Proveedor Demo',
+      })),
+      getAccountingEntryView: jasmine.createSpy().and.returnValue(of({
+        header: { entryCode: 'AE-PV-21', entryStatus: 'ACTIVE' },
+        movements: [
+          {
+            accountId: 2205,
+            accountCode: '2205',
+            accountName: 'Cuentas por pagar',
+            detail: 'Pago factura FC-123',
+            debit: 123000,
+            credit: 0,
+          },
+          {
+            accountId: 1105,
+            accountCode: '1105',
+            accountName: 'Caja/Banco',
+            detail: 'Pago factura FC-123',
+            debit: 0,
+            credit: 123000,
+          },
+        ],
+      })),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ExpenseReceiptAccountingComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '21' } } } },
+        { provide: Router, useValue: { navigate: jasmine.createSpy() } },
+        { provide: ExpenseReceiptService, useValue: service },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ExpenseReceiptAccountingComponent);
+    fixture.detectChanges();
+  });
+
+  it('requests the route receipt and renders every accounting movement with numeric debit and credit', () => {
+    expect(service.getExpenseReceiptById).toHaveBeenCalledWith(21);
+    expect(service.getAccountingEntryView).toHaveBeenCalledWith(21, {
+      voucherNumber: 'CE-21',
+      supplierLabel: 'Proveedor Demo',
+    });
+
+    const rows = fixture.nativeElement.querySelectorAll('tbody tr');
+    const firstRowText = rows[0].textContent.replace(/\s/g, '');
+    const secondRowText = rows[1].textContent.replace(/\s/g, '');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('2205');
+    expect(rows[0].textContent).toContain('Cuentas por pagar');
+    expect(rows[0].textContent).toContain('Pago factura FC-123');
+    expect(firstRowText).toContain('123.000');
+    expect(firstRowText).toContain('COP0');
+    expect(rows[1].textContent).toContain('1105');
+    expect(rows[1].textContent).toContain('Caja/Banco');
+    expect(secondRowText).toContain('COP0');
+    expect(secondRowText).toContain('123.000');
+    const amountCells = Array.from(rows).flatMap((row: any) => [row.cells[3], row.cells[4]]);
+    expect(amountCells.some((cell: HTMLTableCellElement) => cell.textContent?.trim() === '-')).toBeFalse();
+  });
+
+  it('keeps the two movements balanced', () => {
+    const component = fixture.componentInstance;
+    expect(component.accountingMovements.length).toBe(2);
+    expect(component.getTotalDebit()).toBe(123000);
+    expect(component.getTotalCredit()).toBe(123000);
+    expect(component.accountingIsBalanced).toBeTrue();
+  });
+});

--- a/src/app/Financial/Treasury/Shared/treasury-accounting-display.spec.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-accounting-display.spec.ts
@@ -1,4 +1,5 @@
 import {
+  buildAccountingEntryView,
   buildAccountCatalogueLookup,
   flattenAccountCatalogueRefs,
   mapAccountingMovementsForView,
@@ -43,6 +44,54 @@ describe('treasury-accounting-display', () => {
     expect(rows[0].accountName).toBe('Cuentas por pagar');
     expect(rows[1].accountCode).toBe('11050101');
     expect(rows[1].accountName).toBe('Banco menor');
+  });
+
+  it('maps the persisted Accounting API account field without treating its id as a code', () => {
+    const rows = mapAccountingMovementsForView([
+      { account: 21, description: 'Pago factura FC-501', debit: 100000, credit: 0 },
+      { account: 99, description: 'Salida de banco', debit: 0, credit: 100000 },
+    ], lookup);
+
+    expect(rows).toEqual([
+      jasmine.objectContaining({
+        accountId: 21,
+        accountCode: '2105',
+        accountName: 'Cuentas por pagar',
+        debit: 100000,
+        credit: 0,
+      }),
+      jasmine.objectContaining({
+        accountId: 99,
+        accountCode: '11050101',
+        accountName: 'Banco menor',
+        debit: 0,
+        credit: 100000,
+      }),
+    ]);
+  });
+
+  it('prefers the persisted account id over stale explicit labels', () => {
+    const resolved = resolveMovementAccountDisplay({
+      account: 21,
+      accountCode: '1105',
+      accountName: 'Caja',
+    }, lookup);
+
+    expect(resolved.accountCode).toBe('2105');
+    expect(resolved.accountName).toBe('Cuentas por pagar');
+  });
+
+  it('keeps historical movements and the voided status in the entry view', () => {
+    const movements = mapAccountingMovementsForView([
+      { account: 21, description: 'Baja de obligación 501', debit: 100000, credit: 0 },
+      { account: 99, description: 'Contrapartida', debit: 0, credit: 100000 },
+    ], lookup);
+    const view = buildAccountingEntryView({ code: 'AE-PWO-58', status: 'VOIDED' }, movements);
+
+    expect(view.header.entryStatus).toBe('VOIDED');
+    expect(view.movements.map((movement) => movement.accountCode)).toEqual(['2105', '11050101']);
+    expect(view.movements.reduce((total, movement) => total + movement.debit, 0)).toBe(100000);
+    expect(view.movements.reduce((total, movement) => total + movement.credit, 0)).toBe(100000);
   });
 
   it('flattens nested catalogue nodes for lookup', () => {

--- a/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-accounting-display.ts
@@ -124,7 +124,9 @@ export function resolveMovementAccountDisplay(
   movement: Record<string, unknown>,
   accountLookup: Map<number, { code: string; description: string }>,
 ): { accountId?: number; accountCode: string; accountName: string } {
-  const accountIdRaw = movement['accountId'];
+  // Accounting currently exposes the persisted internal account id as `account`.
+  // Prefer that authoritative reference (or `accountId`) over optional display labels.
+  const accountIdRaw = movement['accountId'] ?? movement['account'];
   const accountId = accountIdRaw != null && accountIdRaw !== ''
     ? Number(accountIdRaw)
     : undefined;
@@ -149,7 +151,7 @@ export function resolveMovementAccountDisplay(
     };
   }
 
-  const accountRef = accountId ?? movement['accountCode'] ?? movement['account'];
+  const accountRef = accountId ?? movement['accountCode'];
   return resolveAccountFromLookup(accountRef, accountLookup);
 }
 


### PR DESCRIPTION
## Causa raíz
La API contable expone el identificador persistido en `movement.account`, pero la vista priorizaba etiquetas opcionales y la pantalla de asiento reemplazaba los importes cero por guiones.

## Corrección
- Resuelve `account`/`accountId` contra el catálogo y conserva todos los movimientos.
- Renderiza débito, crédito y totales como valores COP, incluido `COP 0`.
- Añade una regresión de ruta con CxP débito y Caja/Banco crédito por 123000.

## Pruebas
- Focales locales actuales de mapper/ruta: 10/10 exitosas.
- Referencia completa: Angular Treasury 145/156; los 11 fallos restantes son preexistentes y no relacionados.
- Build Angular correcto.