### PR TITLE
fix: load paid invoice product lines

### DIFF
--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.spec.ts
@@ -1,0 +1,90 @@
+import { of, throwError } from 'rxjs';
+
+import { ExpenseReceiptDetailView } from '../../Model/ExpenseReceiptView';
+import { ExpenseReceiptDetailsComponent } from './expense-receipt-details.component';
+
+describe('ExpenseReceiptDetailsComponent product lines', () => {
+  function detail(): ExpenseReceiptDetailView {
+    return {
+      invoiceId: 11,
+      sourceInvoiceId: 501,
+      amountPaid: 90000,
+      invoiceCode: '678151694',
+      invoiceValue: 100000,
+      retentionsApplied: 10000,
+      payableAccountCode: '220501',
+      remainingBalance: 0,
+    };
+  }
+
+  function component(service: object): ExpenseReceiptDetailsComponent {
+    return new ExpenseReceiptDetailsComponent(
+      null as any,
+      null as any,
+      service as any,
+      null as any,
+      null as any,
+    );
+  }
+
+  it('uses the obligation id, preserves the resolved source id and renders returned products', () => {
+    const productLines = [{
+      productLabel: 'Mantenimiento',
+      quantity: 1,
+      unitPrice: 80000,
+      subtotal: 80000,
+      discountPercent: 0,
+      discountAmount: 0,
+      taxLabel: '19%',
+      taxAmount: 15200,
+      lineTotal: 95200,
+    }];
+    const service = {
+      getPaidInvoiceProductLinesForObligation: jasmine.createSpy().and.returnValue(of({
+        sourceInvoiceId: 777,
+        lines: productLines,
+      })),
+    };
+    const target = detail();
+
+    component(service).toggleProducts(target);
+
+    expect(service.getPaidInvoiceProductLinesForObligation).toHaveBeenCalledWith(11);
+    expect(target.sourceInvoiceId).toBe(777);
+    expect(target.productLines).toBe(productLines);
+  });
+
+  it('shows the explicit empty state when the invoice has no products', () => {
+    const service = {
+      getPaidInvoiceProductLinesForObligation: jasmine.createSpy().and.returnValue(of({
+        sourceInvoiceId: 501,
+        lines: [],
+      })),
+    };
+    const target = detail();
+    const subject = component(service);
+
+    subject.toggleProducts(target);
+
+    expect(subject.productsError(target)).toBe(
+      'La factura no tiene productos o servicios registrados.',
+    );
+  });
+
+  it('reports an HTTP failure separately from an empty product list', () => {
+    const service = {
+      getPaidInvoiceProductLinesForObligation: jasmine.createSpy().and.returnValue(
+        throwError(() => ({ status: 503 })),
+      ),
+    };
+    const target = detail();
+    const subject = component(service);
+
+    subject.toggleProducts(target);
+
+    expect(target.productLines).toBeUndefined();
+    expect(subject.productsError(target)).toBe(
+      'No fue posible consultar los productos de la factura.',
+    );
+  });
+});

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-details/expense-receipt-details.component.ts
@@ -261,19 +261,13 @@ export class ExpenseReceiptDetailsComponent implements OnInit {
     }
     this.expandedInvoiceIds.add(detail.invoiceId);
     this.productLineErrors.delete(detail.invoiceId);
-    if (!detail.sourceInvoiceId) {
-      this.productLineErrors.set(
-        detail.invoiceId,
-        'No se encontró la factura de origen en Facturación.',
-      );
-      return;
-    }
     if (detail.productLines) {
       return;
     }
     this.loadingProductLines.add(detail.invoiceId);
-    this.expenseReceiptService.getPaidInvoiceProductLines(detail.sourceInvoiceId).subscribe({
-      next: (lines) => {
+    this.expenseReceiptService.getPaidInvoiceProductLinesForObligation(detail.invoiceId).subscribe({
+      next: ({ sourceInvoiceId, lines }) => {
+        detail.sourceInvoiceId = sourceInvoiceId;
         detail.productLines = lines;
         this.loadingProductLines.delete(detail.invoiceId);
         if (!lines.length) {

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.spec.ts
@@ -245,4 +245,33 @@ describe('ExpenseReceiptService payable accounts', () => {
     expect(lines[0].productLabel).toBe('Mantenimiento');
     expect(lines[0].lineTotal).toBe(95200);
   });
+
+  it('resolves the canonical billing invoice from the treasury obligation', async () => {
+    const api = {
+      payable: jasmine.createSpy().and.returnValue(of({
+        id: 11,
+        sourceInvoiceId: 501,
+      })),
+    };
+    const skeleton = {
+      getFactureById: jasmine.createSpy().and.returnValue(of({ products: [] })),
+    };
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const service = new ExpenseReceiptService(
+      api as any,
+      null as any,
+      null as any,
+      null as any,
+      null as any,
+      storage as any,
+      skeleton as any,
+    );
+
+    const result = await firstValueFrom(service.getPaidInvoiceProductLinesForObligation(11));
+
+    expect(api.payable).toHaveBeenCalledWith(11, 'enterprise-a');
+    expect(skeleton.getFactureById).toHaveBeenCalledWith(501);
+    expect(skeleton.getFactureById).not.toHaveBeenCalledWith(11);
+    expect(result).toEqual({ sourceInvoiceId: 501, lines: [] });
+  });
 });

--- a/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Service/expense-receipt.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, forkJoin, map, of, timer } from 'rxjs';
+import { Observable, forkJoin, map, of, throwError, timer } from 'rxjs';
 import { catchError, last, switchMap, take, takeWhile } from 'rxjs/operators';
 import { PaymentMethodsServiceService } from '../../../../GeneralMasters/PaymentMethods/services/payment-methods-service.service';
 import { ChartAccountService } from '../../../../GeneralMasters/AccountCatalogue/services/chart-account.service';
@@ -318,6 +318,22 @@ export class ExpenseReceiptService {
       map((facture) => mapSkeletonProductsToLineViews(this.normalizeSkeletonProducts(facture as {
         products?: PurchaseInvoiceProductLine[] | Iterable<PurchaseInvoiceProductLine>;
       }))),
+    );
+  }
+
+  getPaidInvoiceProductLinesForObligation(
+    obligationId: number,
+  ): Observable<{ sourceInvoiceId: number; lines: PaidInvoiceLineView[] }> {
+    return this.api.payable(obligationId, this.enterpriseId()).pipe(
+      switchMap((payable) => {
+        const sourceInvoiceId = Number(payable.sourceInvoiceId);
+        if (!Number.isInteger(sourceInvoiceId) || sourceInvoiceId <= 0) {
+          return throwError(() => new Error('La obligación no tiene una factura de origen válida.'));
+        }
+        return this.getPaidInvoiceProductLines(sourceInvoiceId).pipe(
+          map((lines) => ({ sourceInvoiceId, lines })),
+        );
+      }),
     );
   }
 


### PR DESCRIPTION
## Causa raíz
La acción de productos dependía del `sourceInvoiceId` precargado al abrir el comprobante. Si la resolución previa de la obligación fallaba, el error se convertía en `null` y el botón no volvía a resolver la factura canónica.

## Corrección
- Al abrir productos, consulta la obligación mediante `detail.invoiceId`.
- Usa exclusivamente `Payable.sourceInvoiceId` para consultar `factures/skeleton/{id}`.
- Conserva el identificador resuelto y diferencia productos vacíos de errores HTTP.

## Pruebas
- Focales de componente y servicio: 9/9 exitosas.
- Build Angular: exitoso, con advertencias de presupuesto preexistentes.
- No incluye cambios contables ni otras funcionalidades.