### PR TITLE
fix: complete pending treasury review corrections

### DIFF
--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.html
@@ -51,8 +51,9 @@
         </div>
 
         <div class="flex flex-col">
-          <label class="field-label">Fecha de emisión</label>
-          <p-datepicker [(ngModel)]="currentDate" [disabled]="true" dateFormat="dd/mm/yy"
+          <label for="issueDate" class="field-label">Fecha de emisión</label>
+          <p-datepicker inputId="issueDate" [(ngModel)]="currentDate"
+            (ngModelChange)="onIssueDateChange($event)" dateFormat="dd/mm/yy" [showIcon]="true"
             styleClass="w-full" size="small"></p-datepicker>
         </div>
 

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-creation.component.ts
@@ -319,6 +319,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
       totalValue: this.total.toFixed(2),
       totalPay: (this.initialPayment || 0).toFixed(2),
       pendingValue: this.pendingTotal.toFixed(2),
+      issueDate: this.resolveIssueDate(),
       expirationDate,
       factureType: 'PURCHASE',
       inventoryConfigType: this.localStorageMethods.getInventoryConfigType() as 'PEPS' | 'WEIGHTED_AVERAGE',
@@ -373,6 +374,15 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
     this.paymentTermDays = Math.max(this.toAmount(this.paymentTermDays, 1), 1);
     this.dueDate = this.addDays(this.stripTime(this.currentDate), this.paymentTermDays);
     this.releasePaymentScheduleSync();
+  }
+
+  onIssueDateChange(selectedDate: Date | null): void {
+    if (!selectedDate) {
+      return;
+    }
+    this.currentDate = selectedDate;
+    this.minDueDate = this.addDays(this.stripTime(this.currentDate), 1);
+    this.syncDueDateFromPaymentTerm();
   }
 
   onDueDateChange(selectedDate: Date | null): void {
@@ -494,7 +504,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
   private validateDueDate(): string | null {
     const due = this.dueDate ?? this.addDays(this.currentDate, Math.max(this.paymentTermDays, 1));
     if (this.stripTime(due).getTime() < this.minDueDate.getTime()) {
-      return 'La fecha de vencimiento debe ser posterior a hoy (no puede ser hoy ni anterior).';
+      return 'La fecha de vencimiento debe ser posterior a la fecha de emisión.';
     }
     return null;
   }
@@ -510,7 +520,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
         this.messageService.add({
           severity: 'warn',
           summary: 'Vencimiento inválido',
-          detail: 'La fecha de vencimiento debe ser posterior a hoy.',
+          detail: 'La fecha de vencimiento debe ser posterior a la fecha de emisión.',
         });
       }
     }
@@ -639,6 +649,18 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
     return this.stripTime(due).toISOString().split('T')[0];
   }
 
+  private resolveIssueDate(): string {
+    return this.formatLocalDate(this.currentDate);
+  }
+
+  private formatLocalDate(date: Date): string {
+    const normalized = this.stripTime(date);
+    const year = normalized.getFullYear();
+    const month = String(normalized.getMonth() + 1).padStart(2, '0');
+    const day = String(normalized.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
   private addDays(date: Date, days: number): Date {
     const copy = new Date(date);
     copy.setDate(copy.getDate() + days);
@@ -668,6 +690,7 @@ export class PurchaseInvoiceCreationComponent implements OnInit, OnDestroy {
     this.lstProducts = [];
     this.initialPayment = 0;
     this.observations = '';
+    this.currentDate = new Date();
     this.paymentTermDays = 30;
     this.minDueDate = this.addDays(this.stripTime(this.currentDate), 1);
     this.syncDueDateFromPaymentTerm();

--- a/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-issue-date.component.spec.ts
+++ b/src/app/Commercial/PurchaseInvoice/components/purchase-invoice-creation/purchase-invoice-issue-date.component.spec.ts
@@ -1,0 +1,41 @@
+import { of } from 'rxjs';
+import { PurchaseInvoiceCreationComponent } from './purchase-invoice-creation.component';
+
+describe('PurchaseInvoiceCreationComponent issue date', () => {
+  it('sends the selected issue date and recalculates the due date', () => {
+    const component = Object.create(PurchaseInvoiceCreationComponent.prototype) as any;
+    const createPurchaseInvoice = jasmine.createSpy('createPurchaseInvoice').and.returnValue(of({}));
+    component.supplier = { thId: 7 };
+    component.lstProducts = [{
+      id: 10,
+      name: 'Producto',
+      amount: 1,
+      description: 'Producto de prueba',
+      cost: 100000,
+      IVA: 0,
+      descuentos: [0, 0],
+      maxQuantity: 10,
+    }];
+    component.currentDate = new Date(2026, 6, 15);
+    component.paymentTermDays = 30;
+    component.initialPayment = 0;
+    component.total = 100000;
+    component.pendingTotal = 100000;
+    component.impuestoCheck = true;
+    component.saving = false;
+    component.messageService = { add: jasmine.createSpy('add') };
+    component.purchaseInvoiceService = { createPurchaseInvoice };
+    component.localStorageMethods = {
+      loadEnterpriseData: () => ({ id: 'enterprise-a' }),
+      getInventoryConfigType: () => 'WEIGHTED_AVERAGE',
+    };
+
+    component.onIssueDateChange(component.currentDate);
+    component.saveInvoice();
+
+    expect(createPurchaseInvoice).toHaveBeenCalledWith(jasmine.objectContaining({
+      issueDate: '2026-07-15',
+      expirationDate: '2026-08-14',
+    }));
+  });
+});

--- a/src/app/Commercial/PurchaseInvoice/models/purchase-invoice-payload.ts
+++ b/src/app/Commercial/PurchaseInvoice/models/purchase-invoice-payload.ts
@@ -16,6 +16,7 @@ export interface PurchaseInvoicePayload {
   totalValue: string;
   totalPay: string;
   pendingValue: string;
+  issueDate: string;
   expirationDate?: string;
   factureType: 'PURCHASE';
   inventoryConfigType: 'PEPS' | 'WEIGHTED_AVERAGE';

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.html
@@ -37,7 +37,17 @@
     </div>
 
     <div class="bg-white rounded-lg shadow-md p-6 mb-6">
-        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">Asiento contable</h2>
+        <h2 class="text-xl font-semibold text-[var(--color-primary)] mb-4">
+            {{ accountingEntryIsVoided ? 'Movimientos históricos del asiento original' : 'Asiento contable' }}
+        </h2>
+
+        @if (accountingEntryIsVoided) {
+            <p-message
+                severity="warn"
+                text="Este comprobante está anulado. Los movimientos se conservan como trazabilidad histórica y su efecto contable fue revertido."
+                styleClass="mb-4 w-full">
+            </p-message>
+        }
 
         @if (accountingMovements.length && !accountingIsBalanced) {
             <p-message
@@ -73,7 +83,7 @@
                 </ng-template>
                 <ng-template pTemplate="summary">
                     <tr class="font-semibold bg-gray-50">
-                        <td colspan="3" class="text-right">Totales</td>
+                        <td colspan="3" class="text-right">{{ accountingEntryIsVoided ? 'Totales históricos' : 'Totales' }}</td>
                         <td class="text-right text-red-600">
                             {{ getTotalDebit() | currency:'COP':'code':'1.0-2':'es-CO' }}
                         </td>

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.spec.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.spec.ts
@@ -2,6 +2,7 @@ import { registerLocaleData } from '@angular/common';
 import localeEsCo from '@angular/common/locales/es-CO';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 
 import { ExpenseReceiptService } from '../../Service/expense-receipt.service';
@@ -53,6 +54,7 @@ describe('ExpenseReceiptAccountingComponent route view', () => {
         { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '21' } } } },
         { provide: Router, useValue: { navigate: jasmine.createSpy() } },
         { provide: ExpenseReceiptService, useValue: service },
+        provideNoopAnimations(),
       ],
     }).compileComponents();
 
@@ -90,5 +92,24 @@ describe('ExpenseReceiptAccountingComponent route view', () => {
     expect(component.getTotalDebit()).toBe(123000);
     expect(component.getTotalCredit()).toBe(123000);
     expect(component.accountingIsBalanced).toBeTrue();
+  });
+
+  it('labels a voided entry as reversed historical trace while preserving balanced movements', () => {
+    service.getAccountingEntryView.and.returnValue(of({
+      header: { entryCode: 'AE-PV-21', entryStatus: 'VOIDED' },
+      movements: [
+        { accountCode: '2205', accountName: 'Cuentas por pagar', detail: 'Pago factura FC-123', debit: 123000, credit: 0 },
+        { accountCode: '1105', accountName: 'Caja/Banco', detail: 'Pago factura FC-123', debit: 0, credit: 123000 },
+      ],
+    }));
+
+    fixture.componentInstance.loadAccountingEntries(21);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.accountingEntryIsVoided).toBeTrue();
+    expect(fixture.componentInstance.accountingIsBalanced).toBeTrue();
+    expect(fixture.nativeElement.textContent).toContain('Movimientos históricos del asiento original');
+    expect(fixture.nativeElement.textContent).toContain('su efecto contable fue revertido');
+    expect(fixture.nativeElement.querySelectorAll('tbody tr').length).toBe(2);
   });
 });

--- a/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
+++ b/src/app/Financial/Treasury/ExpenseReceipts/Components/expense-receipt-accounting/expense-receipt-accounting.component.ts
@@ -104,4 +104,8 @@ export class ExpenseReceiptAccountingComponent implements OnInit {
   get accountingIsBalanced(): boolean {
     return accountingTotalsBalanced(this.getTotalDebit(), this.getTotalCredit());
   }
+
+  get accountingEntryIsVoided(): boolean {
+    return String(this.accountingEntryHeader.entryStatus || '').toUpperCase() === 'VOIDED';
+  }
 }

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.css
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.css
@@ -143,6 +143,14 @@
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-wrap: wrap;
+}
+
+.action-buttons ::ng-deep .treasury-icon-action {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  justify-content: center;
 }
 
 /* Pagination */
@@ -191,8 +199,9 @@
   }
 
   .action-buttons {
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.625rem;
   }
 }
 

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.html
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.html
@@ -81,7 +81,7 @@
             <th>Vence</th>
             <th class="text-right">Disponible</th>
             <th>En programación</th>
-            <th style="min-width: 14rem">Acciones</th>
+            <th style="min-width: 11rem">Acciones</th>
           </tr>
         </ng-template>
         <ng-template pTemplate="body" let-payable>
@@ -107,44 +107,50 @@
               <span *ngIf="!scheduledLabelForPayable(payable)" class="text-gray-500">—</span>
             </td>
             <td>
-              <div class="flex flex-wrap gap-2 items-center">
+              <div class="action-buttons">
                 <p-button
-                  label="Pagar"
                   icon="pi pi-wallet"
+                  ariaLabel="Pagar"
+                  styleClass="treasury-icon-action"
                   size="small"
                   [disabled]="hasActivePaymentScheduleForPayable(payable)"
-                  [pTooltip]="activePaymentScheduleTooltip(payable)"
+                  [pTooltip]="activePaymentScheduleTooltip(payable) || 'Pagar'"
                   tooltipPosition="top"
                   (onClick)="openPaymentDialog(payable)">
                 </p-button>
                 <p-button
-                  label="Programar pago"
                   icon="pi pi-clock"
+                  ariaLabel="Programar pago"
+                  styleClass="treasury-icon-action"
                   size="small"
                   severity="secondary"
                   [outlined]="true"
                   [disabled]="hasActivePaymentScheduleForPayable(payable)"
-                  [pTooltip]="activePaymentScheduleTooltip(payable)"
+                  [pTooltip]="activePaymentScheduleTooltip(payable) || 'Programar pago'"
                   tooltipPosition="top"
                   (onClick)="openScheduleDialog(payable)">
                 </p-button>
                 <p-button
-                  label="Baja CxP"
                   icon="pi pi-minus-circle"
+                  ariaLabel="Registrar baja de CxP"
+                  styleClass="treasury-icon-action"
                   size="small"
                   severity="danger"
                   [outlined]="true"
                   [disabled]="!canWriteOffPayable(payable)"
-                  [pTooltip]="writeOffPayableTooltip(payable)"
+                  [pTooltip]="writeOffPayableTooltip(payable) || 'Registrar baja de CxP'"
                   tooltipPosition="top"
                   (onClick)="openWriteOffDialog(payable)">
                 </p-button>
                 <p-button
-                  label="Vencimiento"
                   icon="pi pi-calendar"
+                  ariaLabel="Cambiar vencimiento"
+                  styleClass="treasury-icon-action"
                   size="small"
                   severity="secondary"
                   [outlined]="true"
+                  pTooltip="Cambiar vencimiento"
+                  tooltipPosition="top"
                   (onClick)="openDueDateDialog(payable)">
                 </p-button>
               </div>
@@ -263,7 +269,7 @@
           <th>Estado</th>
           <th class="text-right">Total</th>
           <th>Asiento contable</th>
-          <th style="min-width: 14rem">Acciones</th>
+          <th style="min-width: 10rem">Acciones</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-voucher>
@@ -277,11 +283,14 @@
           <td class="text-right font-semibold">{{ voucher.total | currency:'COP' }}</td>
           <td>{{ voucherAccountingEntryLabel(voucher) }}</td>
           <td>
-            <div class="action-buttons flex flex-wrap gap-1">
+            <div class="action-buttons">
               <p-button
                 *ngIf="voucher.status === 'DRAFT' || voucher.status === 'FAILED'"
-                [label]="voucher.status === 'FAILED' ? 'Reintentar' : 'Contabilizar'"
                 icon="pi pi-check"
+                [ariaLabel]="voucher.status === 'FAILED' ? 'Reintentar contabilización' : 'Contabilizar'"
+                styleClass="treasury-icon-action"
+                [pTooltip]="voucher.status === 'FAILED' ? 'Reintentar contabilización' : 'Contabilizar'"
+                tooltipPosition="top"
                 size="small"
                 [loading]="postingVoucherId === voucher.id"
                 [disabled]="busy && postingVoucherId !== voucher.id"
@@ -289,8 +298,11 @@
               </p-button>
               <p-button
                 *ngIf="voucher.status === 'DRAFT'"
-                label="Editar"
                 icon="pi pi-pencil"
+                ariaLabel="Editar comprobante"
+                styleClass="treasury-icon-action"
+                pTooltip="Editar comprobante"
+                tooltipPosition="top"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
@@ -298,8 +310,11 @@
               </p-button>
               <p-button
                 *ngIf="voucher.status === 'DRAFT'"
-                label="Eliminar"
                 icon="pi pi-trash"
+                ariaLabel="Eliminar comprobante"
+                styleClass="treasury-icon-action"
+                pTooltip="Eliminar comprobante"
+                tooltipPosition="top"
                 size="small"
                 severity="danger"
                 [text]="true"
@@ -307,8 +322,11 @@
               </p-button>
               <p-button
                 *ngIf="voucher.status === 'POSTED' || voucher.status === 'VOID_FAILED'"
-                [label]="voucher.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular'"
                 icon="pi pi-times"
+                [ariaLabel]="voucher.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular comprobante'"
+                styleClass="treasury-icon-action"
+                [pTooltip]="voucher.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular comprobante'"
+                tooltipPosition="top"
                 size="small"
                 severity="danger"
                 [outlined]="true"
@@ -316,8 +334,11 @@
               </p-button>
               <p-button
                 *ngIf="voucher.accountingEntryId"
-                label="Ver asiento"
                 icon="pi pi-eye"
+                ariaLabel="Ver asiento contable"
+                styleClass="treasury-icon-action"
+                pTooltip="Ver asiento contable"
+                tooltipPosition="top"
                 size="small"
                 severity="info"
                 [text]="true"
@@ -405,7 +426,7 @@
           <th class="text-right">Total</th>
           <th>Reintentos</th>
           <th>Comprobante</th>
-          <th style="min-width: 10rem">Acciones</th>
+          <th style="min-width: 9rem">Acciones</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-item>
@@ -430,10 +451,13 @@
             <span *ngIf="!canViewScheduleVoucher(item)">—</span>
           </td>
           <td>
-            <div class="action-buttons flex flex-wrap gap-1">
+            <div class="action-buttons">
               <p-button
-                label="Ver detalle"
                 icon="pi pi-eye"
+                ariaLabel="Ver detalle de programación"
+                styleClass="treasury-icon-action"
+                pTooltip="Ver detalle"
+                tooltipPosition="top"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
@@ -441,24 +465,33 @@
               </p-button>
               <p-button
                 *ngIf="canCancelSchedule(item)"
-                label="Cancelar"
                 icon="pi pi-ban"
+                ariaLabel="Desprogramar pago"
+                styleClass="treasury-icon-action"
+                pTooltip="Desprogramar pago"
+                tooltipPosition="top"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
-                (onClick)="cancel(item)">
+                (onClick)="deschedule(item)">
               </p-button>
               <p-button
                 *ngIf="canViewScheduleVoucher(item)"
-                label="Ver comprobante"
                 icon="pi pi-file"
+                ariaLabel="Ver comprobante"
+                styleClass="treasury-icon-action"
+                pTooltip="Ver comprobante"
+                tooltipPosition="top"
                 size="small"
                 (onClick)="openScheduleVoucher(item)">
               </p-button>
               <p-button
                 *ngIf="item.status === 'FAILED'"
-                label="Reintentar"
                 icon="pi pi-refresh"
+                ariaLabel="Reintentar programación"
+                styleClass="treasury-icon-action"
+                pTooltip="Reintentar programación"
+                tooltipPosition="top"
                 size="small"
                 (onClick)="retry(item)">
               </p-button>
@@ -498,7 +531,7 @@
           <th scope="col" class="text-right">Total</th>
           <th scope="col">Cuenta contrapartida</th>
           <th scope="col">Estado</th>
-          <th scope="col" style="min-width: 12rem">Acciones</th>
+          <th scope="col" style="min-width: 10rem">Acciones</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-item>
@@ -513,10 +546,13 @@
             <p-tag [value]="writeOffLabel(item.status)" [severity]="getStatusSeverity(item.status)"></p-tag>
           </td>
           <td>
-            <div class="action-buttons flex flex-wrap gap-1">
+            <div class="action-buttons">
               <p-button
-                label="Ver detalle"
                 icon="pi pi-eye"
+                ariaLabel="Ver detalle de baja"
+                styleClass="treasury-icon-action"
+                pTooltip="Ver detalle"
+                tooltipPosition="top"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
@@ -524,15 +560,19 @@
               </p-button>
               <p-button
                 *ngIf="canPostWriteOff(item)"
-                [label]="item.status === 'FAILED' ? 'Reintentar' : 'Contabilizar'"
                 icon="pi pi-check"
+                [ariaLabel]="item.status === 'FAILED' ? 'Reintentar contabilización' : 'Contabilizar baja'"
+                styleClass="treasury-icon-action"
+                [pTooltip]="item.status === 'FAILED' ? 'Reintentar contabilización' : 'Contabilizar baja'"
+                tooltipPosition="top"
                 size="small"
                 (onClick)="confirmWriteOff(item)">
               </p-button>
               <p-button
                 *ngIf="canDiscardWriteOff(item)"
-                label="Descartar borrador"
                 icon="pi pi-trash"
+                ariaLabel="Descartar borrador"
+                styleClass="treasury-icon-action"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
@@ -542,8 +582,11 @@
               </p-button>
               <p-button
                 *ngIf="canShowWriteOffAccounting(item)"
-                label="Ver asiento"
                 icon="pi pi-book"
+                ariaLabel="Ver asiento contable"
+                styleClass="treasury-icon-action"
+                pTooltip="Ver asiento contable"
+                tooltipPosition="top"
                 size="small"
                 severity="secondary"
                 [outlined]="true"
@@ -551,8 +594,9 @@
               </p-button>
               <p-button
                 *ngIf="canVoidWriteOff(item)"
-                [label]="item.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular'"
                 icon="pi pi-times"
+                [ariaLabel]="item.status === 'VOID_FAILED' ? 'Reintentar anulación' : 'Anular baja'"
+                styleClass="treasury-icon-action"
                 size="small"
                 severity="danger"
                 [outlined]="true"
@@ -1191,11 +1235,11 @@
       </p-button>
       <p-button
         *ngIf="scheduleDetailTarget && canCancelSchedule(scheduleDetailTarget)"
-        label="Cancelar"
+        label="Desprogramar"
         icon="pi pi-ban"
         severity="danger"
         [outlined]="true"
-        (onClick)="cancel(scheduleDetailTarget!); cancelScheduleDetailDialog()">
+        (onClick)="deschedule(scheduleDetailTarget!); cancelScheduleDetailDialog()">
       </p-button>
     </div>
   </ng-template>

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.spec.ts
@@ -31,6 +31,7 @@ describe('TreasuryOperationsComponent PP8', () => {
       payable: jasmine.createSpy('payable').and.returnValue(of(null)),
       vouchers: jasmine.createSpy('vouchers').and.returnValue(of({ content: [] })),
       schedules: jasmine.createSpy('schedules').and.returnValue(of([])),
+      cancelSchedule: jasmine.createSpy('cancelSchedule').and.returnValue(NEVER),
       writeOffs: jasmine.createSpy('writeOffs').and.returnValue(of([])),
       writeOff: jasmine.createSpy('writeOff').and.returnValue(of({ id: 1, status: 'POSTED', total: 100 })),
       accountingEntry: jasmine.createSpy('accountingEntry').and.returnValue(of({ code: 'AE-PWO-12', movements: [] })),
@@ -450,6 +451,47 @@ describe('TreasuryOperationsComponent PP8', () => {
     value.scheduleExecutionDate = yesterday;
     value.confirmScheduleFromDialog();
     expect(api.createSchedule).not.toHaveBeenCalled();
+  });
+
+  it('rejects a scheduled amount of zero before calling the API', () => {
+    const { value, api } = component();
+    value.openScheduleDialog(value.payables[0]);
+    value.scheduleLines[0].amount = 0;
+    value.schedulePaymentMethodId = 1;
+    value.scheduleBankAccountId = 33;
+    value.scheduleExecutionDate = new Date(value.minExecutionDate);
+
+    value.confirmScheduleFromDialog();
+
+    expect(api.createSchedule).not.toHaveBeenCalled();
+    expect((value as any).messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      summary: 'Monto inválido',
+    }));
+  });
+
+  it('rejects a scheduled amount above the available balance before calling the API', () => {
+    const { value, api } = component();
+    value.openScheduleDialog(value.payables[0]);
+    value.scheduleLines[0].amount = 100.01;
+    value.schedulePaymentMethodId = 1;
+    value.scheduleBankAccountId = 33;
+    value.scheduleExecutionDate = new Date(value.minExecutionDate);
+
+    value.confirmScheduleFromDialog();
+
+    expect(api.createSchedule).not.toHaveBeenCalled();
+    expect((value as any).messageService.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      summary: 'Saldo insuficiente',
+    }));
+  });
+
+  it('uses deschedule terminology and calls the existing cancellation contract', () => {
+    const { value, api } = component();
+    const schedule = { id: 5 } as any;
+
+    value.deschedule(schedule);
+
+    expect(api.cancelSchedule).toHaveBeenCalledWith(5);
   });
 
   it('disables pay write-off and schedule actions when payable has active schedule', () => {

--- a/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
+++ b/src/app/Financial/Treasury/Operations/treasury-operations.component.ts
@@ -1580,7 +1580,12 @@ export class TreasuryOperationsComponent implements OnInit, OnDestroy {
     });
   }
 
-  cancel(schedule: PaymentSchedule) { this.run(this.api.cancelSchedule(schedule.id)); }
+  deschedule(schedule: PaymentSchedule) {
+    this.run(this.api.cancelSchedule(schedule.id), () => ({
+      summary: 'Pago desprogramado',
+      detail: 'La programación pendiente fue eliminada correctamente.',
+    }));
+  }
   retry(schedule: PaymentSchedule) { this.run(this.api.retrySchedule(schedule.id)); }
 
   confirmWriteOff(item: PayableWriteOff) {

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
@@ -1,0 +1,21 @@
+import { VendorReportComponent } from './vendor-report.component';
+
+describe('VendorReportComponent document status labels', () => {
+  it('identifies a voided invoice with text and not only color', () => {
+    const component = Object.create(VendorReportComponent.prototype) as VendorReportComponent;
+
+    expect(component.getTransactionTypeTag('Bill', true)).toEqual({
+      severity: 'danger',
+      text: 'Factura (Anulada)',
+    });
+  });
+
+  it('restores all document states when the status filter is cleared', () => {
+    const component = Object.create(VendorReportComponent.prototype) as VendorReportComponent;
+
+    expect(component.documentActiveFilter('ACTIVE')).toBeTrue();
+    expect(component.documentActiveFilter('VOIDED')).toBeFalse();
+    expect(component.documentActiveFilter(null)).toBeUndefined();
+    expect(component.documentActiveFilter('')).toBeUndefined();
+  });
+});

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -182,7 +182,7 @@ export class VendorReportComponent implements OnInit {
         formValue.startDate,
         formValue.endDate,
         formValue.invoice || undefined,
-        formValue.status === '' ? undefined : formValue.status === 'ACTIVE',
+        this.documentActiveFilter(formValue.status),
         this.vendorName,
       )
       .subscribe({
@@ -219,6 +219,12 @@ export class VendorReportComponent implements OnInit {
       status: '',
     });
     this.loadVendorReport();
+  }
+
+  documentActiveFilter(status: string | null | undefined): boolean | undefined {
+    if (status === 'ACTIVE') return true;
+    if (status === 'VOIDED') return false;
+    return undefined;
   }
 
   goBack(): void {
@@ -314,6 +320,9 @@ export class VendorReportComponent implements OnInit {
     text: string;
   } {
     const text = transactionTypeLabel(type);
+    if (voided && type === 'Bill') {
+      return { severity: 'danger', text: 'Factura (Anulada)' };
+    }
     if (voided && type === 'WriteOff') {
       return { severity: 'danger', text: `${text} (Anulada)` };
     }

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -288,6 +288,46 @@ describe('VendorReportService summaries', () => {
     });
   });
 
+  it('passes the voided document filter and marks voided invoices explicitly', (done) => {
+    const api = {
+      statement: jasmine.createSpy('statement').and.returnValue(of({
+        supplierId: 78,
+        openingBalance: 0,
+        invoiced: 100000,
+        paid: 0,
+        writeOffTotal: 0,
+        pending: 100000,
+        invoices: [{
+          issueDate: '2026-08-01',
+          dueDate: '2026-09-01',
+          reference: 'FC-VOID',
+          originalAmount: 100000,
+          pendingAmount: 100000,
+          active: false,
+        }],
+        vouchers: [],
+        writeOffs: [],
+      })),
+    };
+    const thirds = emptyThirds();
+    const storage = { getIdEnterprise: () => 'enterprise-a' };
+    const value = new VendorReportService(api as any, thirds as any, storage as any);
+    const start = new Date(2026, 7, 1);
+    const end = new Date(2026, 7, 31);
+
+    value.getVendorReport(78, start, end, undefined, false, 'Proveedor').subscribe((report) => {
+      expect(api.statement).toHaveBeenCalledWith(
+        'enterprise-a', 78, '2026-08-01', '2026-08-31', undefined, false,
+      );
+      expect(report.transactions).toContain(jasmine.objectContaining({
+        type: 'Bill',
+        voided: true,
+        description: 'Factura de compra (Anulada)',
+      }));
+      done();
+    });
+  });
+
   it('shows voided payment history without affecting effective totals', (done) => {
     const api = {
       statement: jasmine.createSpy('statement').and.returnValue(of({

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -142,15 +142,16 @@ export class VendorReportService {
           const endIso = this.toIsoDate(endDate);
 
           const bills: VendorReportTransaction[] = (statement.invoices || []).map((inv: any) => ({
-            date: new Date(inv.issueDate),
-            dueDate: new Date(inv.dueDate),
+            date: this.toReportDate(inv.issueDate),
+            dueDate: this.toReportDate(inv.dueDate),
             reference: inv.reference,
             documentNumber: inv.reference,
             type: 'Bill' as const,
-            description: 'Factura de compra',
+            description: inv.active === false ? 'Factura de compra (Anulada)' : 'Factura de compra',
             debits: 0,
             credits: Number(inv.originalAmount || 0),
             balance: 0,
+            voided: inv.active === false,
           }));
 
           const paymentRows = this.buildPaymentTransactions(
@@ -426,7 +427,7 @@ export class VendorReportService {
       const status = String(voucher.status || '');
       const isVoided = status === 'VOIDED';
       const issuedInPeriod = voucher.issueDate
-        ? this.inIsoDateRange(new Date(voucher.issueDate), startIso, endIso)
+        ? this.inIsoDateRange(this.toReportDate(voucher.issueDate), startIso, endIso)
         : false;
 
       return (voucher.details || [])
@@ -437,7 +438,7 @@ export class VendorReportService {
           const description = this.paymentDescription(voucher.observations, voucher.voucherNumber);
           const paymentInformational = !issuedInPeriod;
           const paymentRow: VendorReportTransaction = {
-            date: new Date(voucher.issueDate),
+            date: this.toReportDate(voucher.issueDate),
             reference,
             expenseReceiptNumber: voucher.voucherNumber,
             type: 'Payment',
@@ -481,7 +482,7 @@ export class VendorReportService {
       const status = String(writeOff.status || '');
       const isVoided = status === 'VOIDED';
       const createdInPeriod = writeOff.createdAt
-        ? this.inIsoDateRange(new Date(writeOff.createdAt), startIso, endIso)
+        ? this.inIsoDateRange(this.toReportDate(writeOff.createdAt), startIso, endIso)
         : false;
       const reason = (writeOff.reason || '').trim();
 
@@ -492,7 +493,7 @@ export class VendorReportService {
           const reference = detail.invoiceReference || '';
           const postedInformational = !createdInPeriod;
           const postedRow: VendorReportTransaction = {
-            date: new Date(writeOff.createdAt!),
+            date: this.toReportDate(writeOff.createdAt!),
             reference,
             type: 'WriteOff',
             description: isVoided
@@ -550,6 +551,14 @@ export class VendorReportService {
   private inIsoDateRange(date: Date, startIso: string, endIso: string): boolean {
     const value = this.toIsoDate(date);
     return value >= startIso && value <= endIso;
+  }
+
+  private toReportDate(value: Date | string): Date {
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      const [year, month, day] = value.split('-').map(Number);
+      return new Date(year, month - 1, day);
+    }
+    return new Date(value);
   }
 
   private formatMoney(amount: number): string {

--- a/src/app/Financial/Treasury/Shared/treasury-help-content.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-help-content.ts
@@ -26,7 +26,7 @@ export const TREASURY_HELP = {
     title: 'Programación de Pagos',
     summary:
       'Consulte y gestione los pagos de facturas que fueron programados previamente desde Operaciones de Tesorería. ' +
-      'Puede cancelar programaciones pendientes o reintentar las fallidas.',
+      'Puede desprogramar pagos pendientes o reintentar las programaciones fallidas.',
     slug: 'tesoreria',
   },
   agingReport: {

--- a/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
+++ b/src/app/Financial/Treasury/Shared/treasury-schedule-messages.ts
@@ -1,5 +1,5 @@
 export const ACTIVE_PAYMENT_SCHEDULE_BLOCK_MESSAGE =
-  'Esta obligación tiene un pago programado activo. Cancela la programación para realizar otra operación.';
+  'Esta obligación tiene un pago programado activo. Desprograme el pago para realizar otra operación.';
 
 export const ACTIVE_PAYMENT_SCHEDULE_DUPLICATE_MESSAGE =
   'La obligación ya tiene una programación de pago activa.';


### PR DESCRIPTION
## Causa raíz
La emisión estaba bloqueada y no se enviaba al backend; la terminología y las acciones de programaciones saturaban las filas; el asiento anulado conservaba movimientos pero se presentaba como vigente; y limpiar el filtro de estado podía convertir null en el filtro de anulados. Las facturas anuladas tampoco tenían marca textual.

## Corrección
- permite editar y enviar issueDate, sincronizando vencimiento
- anticipa límites de monto y cubre cero/exceso
- cambia la terminología visible a Desprogramar con mensaje de éxito
- compacta acciones con iconos, tooltips y etiquetas accesibles
- presenta movimientos anulados como trazabilidad histórica cuyo efecto fue revertido
- normaliza el filtro vigente/anulado/todos y marca Factura (Anulada)
- interpreta fechas YYYY-MM-DD sin desplazamiento de zona horaria

## Validación
- focales de los componentes modificados: 76/76
- suite Treasury: 172/176
- los 4 fallos restantes son preexistentes/no relacionados: 3 fixtures incompletos de expense-receipt-creation y 1 aserción aritmética histórica del vendor-report (el cálculo produce 4.626 y el test espera 4.646)
- suite global no inicia por la dependencia histórica faltante quill de PrimeNG Editor
- build Angular: correcto
- git diff --check: correcto

No se corrigieron fallos históricos ni se incluyeron cambios de Gateway, despliegue, Sonar o funcionalidades ajenas.