### PR TITLE
fix: filter vendor report by document status

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -165,11 +165,11 @@
 
     <p-card header="Detalle de transacciones">
       <p-table
-        [value]="vendorReport.transactions"
+        [value]="visibleTransactions"
         styleClass="p-datatable-sm p-datatable-striped"
         [scrollable]="true"
         scrollHeight="400px"
-        [paginator]="vendorReport.transactions.length > 10"
+        [paginator]="visibleTransactions.length > 10"
         [rows]="10">
 
         <ng-template pTemplate="header">

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
@@ -1,21 +1,130 @@
+import { VendorReport, VendorReportTransaction } from '../../Models/VendorReport';
 import { VendorReportComponent } from './vendor-report.component';
 
-describe('VendorReportComponent document status labels', () => {
-  it('identifies a voided invoice with text and not only color', () => {
+describe('VendorReportComponent document status filter', () => {
+  function transaction(
+    documentStatus: string,
+    reference: string,
+    date = new Date(2026, 7, 10),
+  ): VendorReportTransaction {
+    return {
+      date,
+      reference,
+      type: 'Bill',
+      description: reference,
+      debits: 0,
+      credits: 100,
+      balance: 100,
+      documentStatus,
+      voided: documentStatus === 'VOIDED',
+    };
+  }
+
+  function componentWith(transactions: VendorReportTransaction[]): VendorReportComponent {
     const component = Object.create(VendorReportComponent.prototype) as VendorReportComponent;
+    component.vendorReport = {
+      vendor: { id: 4, name: 'Libardo Pantoja' },
+      dateRange: { startDate: new Date(2026, 7, 1), endDate: new Date(2026, 7, 31) },
+      transactions,
+      periodTotals: {
+        openingBalance: 0,
+        periodPayments: 0,
+        totalDebits: 0,
+        totalCredits: 0,
+        writeOffTotal: 0,
+        netBalance: 0,
+      },
+      totalDue: 0,
+      agingReport: {
+        prePaid: 0,
+        current: 0,
+        days0to30: 0,
+        days31to60: 0,
+        days61to90: 0,
+        days91Plus: 0,
+        total: 0,
+      },
+    } satisfies VendorReport;
+    component.visibleTransactions = [];
+    return component;
+  }
+
+  const rows = [
+    transaction('POSTED', 'FC-POSTED'),
+    transaction('VOIDED', 'FC-VOIDED'),
+    transaction('DRAFT', 'FC-DRAFT'),
+  ];
+
+  it('shows every row when no status is selected', () => {
+    const component = componentWith(rows);
+
+    component.applyDocumentStatusFilter('');
+
+    expect(component.visibleTransactions).toEqual(rows);
+    expect(component.visibleTransactions).not.toBe(rows);
+  });
+
+  it('shows only POSTED documents for Contabilizado', () => {
+    const component = componentWith(rows);
+
+    component.applyDocumentStatusFilter('POSTED');
+
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-POSTED']);
+  });
+
+  it('shows only VOIDED documents for Anulado', () => {
+    const component = componentWith(rows);
+
+    component.applyDocumentStatusFilter('VOIDED');
+
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-VOIDED']);
+  });
+
+  it('supports DRAFT when that canonical state is present in the report', () => {
+    const component = componentWith(rows);
+
+    component.applyDocumentStatusFilter('DRAFT');
+
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-DRAFT']);
+  });
+
+  it('restores the complete source collection when the status is cleared', () => {
+    const component = componentWith(rows);
+    component.applyDocumentStatusFilter('VOIDED');
+
+    component.applyDocumentStatusFilter(null);
+
+    expect(component.visibleTransactions).toEqual(rows);
+    expect(component.vendorReport?.transactions).toEqual(rows);
+  });
+
+  it('combines status with the rows already constrained by date and invoice filters', () => {
+    const dateAndInvoiceRows = rows.filter(
+      (row) => row.date >= new Date(2026, 7, 1)
+        && row.date <= new Date(2026, 7, 31)
+        && row.reference === 'FC-VOIDED',
+    );
+    const component = componentWith(dateAndInvoiceRows);
+
+    component.applyDocumentStatusFilter('VOIDED');
+
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-VOIDED']);
+  });
+
+  it('returns an empty collection for a status that is not present', () => {
+    const component = componentWith(rows);
+
+    component.applyDocumentStatusFilter('NOT_A_STATUS');
+
+    expect(component.visibleTransactions).toEqual([]);
+  });
+
+  it('identifies a voided invoice with text and not only color', () => {
+    const component = componentWith(rows);
 
     expect(component.getTransactionTypeTag('Bill', true)).toEqual({
       severity: 'danger',
       text: 'Factura (Anulada)',
     });
-  });
-
-  it('restores all document states when the status filter is cleared', () => {
-    const component = Object.create(VendorReportComponent.prototype) as VendorReportComponent;
-
-    expect(component.documentActiveFilter('ACTIVE')).toBeTrue();
-    expect(component.documentActiveFilter('VOIDED')).toBeFalse();
-    expect(component.documentActiveFilter(null)).toBeUndefined();
-    expect(component.documentActiveFilter('')).toBeUndefined();
   });
 });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -23,6 +23,7 @@ import {
   exportSuccessDetail,
   reportEmptyFiltersMessage,
   transactionTypeLabel,
+  voucherStatusLabel,
 } from '../../../../Shared/treasury-status-labels';
 import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
 
@@ -56,6 +57,7 @@ interface FilterOption {
 })
 export class VendorReportComponent implements OnInit {
   vendorReport: VendorReport | null = null;
+  visibleTransactions: VendorReportTransaction[] = [];
   loading = false;
   exportingPdf = false;
   exportingCsv = false;
@@ -68,8 +70,8 @@ export class VendorReportComponent implements OnInit {
 
   statusOptions: FilterOption[] = [
     { label: 'Todos los documentos', value: '' },
-    { label: 'Solo vigentes', value: 'ACTIVE' },
-    { label: 'Solo anulados', value: 'VOIDED' },
+    { label: 'Contabilizado', value: 'POSTED' },
+    { label: 'Anulado', value: 'VOIDED' },
   ];
 
   periodOptions: { label: string; value: string; days?: number }[] = [
@@ -182,12 +184,14 @@ export class VendorReportComponent implements OnInit {
         formValue.startDate,
         formValue.endDate,
         formValue.invoice || undefined,
-        this.documentActiveFilter(formValue.status),
+        undefined,
         this.vendorName,
       )
       .subscribe({
         next: (report) => {
           this.vendorReport = report;
+          this.updateStatusOptions(report.transactions);
+          this.applyDocumentStatusFilter(formValue.status);
           this.vendorName = report.vendor.name;
           this.loading = false;
           if (!this.invoiceOptions.length && report.transactions.length) {
@@ -221,10 +225,26 @@ export class VendorReportComponent implements OnInit {
     this.loadVendorReport();
   }
 
-  documentActiveFilter(status: string | null | undefined): boolean | undefined {
-    if (status === 'ACTIVE') return true;
-    if (status === 'VOIDED') return false;
-    return undefined;
+  applyDocumentStatusFilter(status: string | null | undefined): void {
+    const transactions = this.vendorReport?.transactions || [];
+    this.visibleTransactions = status
+      ? transactions.filter((transaction) => transaction.documentStatus === status)
+      : [...transactions];
+  }
+
+  private updateStatusOptions(transactions: VendorReportTransaction[]): void {
+    const statuses = [...new Set([
+      'POSTED',
+      'VOIDED',
+      ...transactions.map((transaction) => transaction.documentStatus).filter(Boolean),
+    ])];
+    this.statusOptions = [
+      { label: 'Todos los documentos', value: '' },
+      ...statuses.map((status) => {
+        const translated = voucherStatusLabel(status);
+        return { label: translated === 'Desconocido' ? status : translated, value: status };
+      }),
+    ];
   }
 
   goBack(): void {

--- a/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Models/VendorReport.ts
@@ -19,6 +19,7 @@ export interface VendorReportTransaction {
   debits: number;
   credits: number;
   balance: number;
+  documentStatus: string;
   voided?: boolean;
   informational?: boolean;
 }

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.spec.ts
@@ -321,6 +321,7 @@ describe('VendorReportService summaries', () => {
       );
       expect(report.transactions).toContain(jasmine.objectContaining({
         type: 'Bill',
+        documentStatus: 'VOIDED',
         voided: true,
         description: 'Factura de compra (Anulada)',
       }));
@@ -369,8 +370,12 @@ describe('VendorReportService summaries', () => {
     value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
       expect(report.periodTotals.periodPayments).toBe(0);
       expect(report.totalDue).toBe(357000);
-      expect(report.transactions.some((row) => row.type === 'Payment' && row.voided)).toBeTrue();
-      expect(report.transactions.some((row) => row.type === 'PaymentReversal')).toBeTrue();
+      expect(report.transactions.some((row) =>
+        row.type === 'Payment' && row.voided && row.documentStatus === 'VOIDED',
+      )).toBeTrue();
+      expect(report.transactions.some((row) =>
+        row.type === 'PaymentReversal' && row.documentStatus === 'VOIDED',
+      )).toBeTrue();
       expect(report.transactions.at(-1)?.balance).toBe(357000);
       expect(report.agingReport.total).toBe(357000);
       done();
@@ -417,6 +422,7 @@ describe('VendorReportService summaries', () => {
     value.getVendorReport(78, start, end, undefined, undefined, 'Proveedor').subscribe((report) => {
       const payment = report.transactions.find((row) => row.type === 'Payment');
       expect(payment?.debits).toBe(100000);
+      expect(payment?.documentStatus).toBe('POSTED');
       expect(report.periodTotals.periodPayments).toBe(100000);
       expect(report.transactions.at(-1)?.balance).toBe(257000);
       expect(report.totalDue).toBe(257000);

--- a/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Services/vendor-report.service.ts
@@ -151,6 +151,7 @@ export class VendorReportService {
             debits: 0,
             credits: Number(inv.originalAmount || 0),
             balance: 0,
+            documentStatus: inv.active === false ? 'VOIDED' : 'POSTED',
             voided: inv.active === false,
           }));
 
@@ -424,7 +425,7 @@ export class VendorReportService {
     endIso: string,
   ): VendorReportTransaction[] {
     return (vouchers || []).flatMap((voucher) => {
-      const status = String(voucher.status || '');
+      const status = String(voucher.status || '').toUpperCase();
       const isVoided = status === 'VOIDED';
       const issuedInPeriod = voucher.issueDate
         ? this.inIsoDateRange(this.toReportDate(voucher.issueDate), startIso, endIso)
@@ -446,6 +447,7 @@ export class VendorReportService {
             debits: amount,
             credits: 0,
             balance: 0,
+            documentStatus: status || 'POSTED',
             voided: isVoided,
             informational: paymentInformational,
           };
@@ -463,6 +465,7 @@ export class VendorReportService {
             debits: 0,
             credits: amount,
             balance: 0,
+            documentStatus: status || 'POSTED',
             voided: true,
             informational: paymentInformational,
           };
@@ -479,7 +482,7 @@ export class VendorReportService {
     endIso: string,
   ): VendorReportTransaction[] {
     return (writeOffs || []).flatMap((writeOff) => {
-      const status = String(writeOff.status || '');
+      const status = String(writeOff.status || '').toUpperCase();
       const isVoided = status === 'VOIDED';
       const createdInPeriod = writeOff.createdAt
         ? this.inIsoDateRange(this.toReportDate(writeOff.createdAt), startIso, endIso)
@@ -502,6 +505,7 @@ export class VendorReportService {
             debits: amount,
             credits: 0,
             balance: 0,
+            documentStatus: status || 'POSTED',
             voided: isVoided,
             informational: postedInformational,
           };
@@ -518,6 +522,7 @@ export class VendorReportService {
             debits: 0,
             credits: amount,
             balance: 0,
+            documentStatus: status || 'POSTED',
             voided: true,
             informational: postedInformational,
           };


### PR DESCRIPTION
## Causa ra?z

El estado de cada fila llegaba mediante contratos distintos (active para facturas y status para comprobantes y bajas), pero el mapper del vendor report descartaba esos valores y conservaba ?nicamente voided. El selector traduc?a la opci?n a un booleano enviado al endpoint y la tabla segu?a renderizando la colecci?n completa sin aplicar el estado can?nico.

## Correcci?n

- conserva un documentStatus can?nico en cada movimiento del reporte;
- normaliza facturas activas/anuladas como POSTED/VOIDED y preserva el status real de comprobantes y bajas;
- separa etiquetas visuales (Contabilizado, Anulado, Borrador) de los valores internos;
- filtra una colecci?n visible sin mutar las transacciones originales;
- mantiene la combinaci?n con rango de fechas y factura/referencia;
- restaura todas las filas al limpiar el filtro;
- permite estados adicionales si el endpoint los entrega.

## Validaci?n

- pruebas focales del componente: 8/8;
- componente + servicio/mapper: 21/22; el ?nico fallo es hist?rico y corresponde a un fixture con una diferencia aritm?tica de 20 pesos;
- suite Treasury Angular: 178/182;
- los cuatro fallos restantes son preexistentes: tres fixtures de ExpenseReceiptCreationComponent y la conciliaci?n hist?rica del vendor report;
- build Angular: correcto;
- git diff --check: correcto.

No se modificaron backend, gateway, l?gica contable, otros reportes ni estilos generales.
