### PR TITLE
fix: make vendor report filters reactive

### DIFF
--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.html
@@ -88,17 +88,11 @@
           [showClear]="true"
           styleClass="w-full">
         </p-dropdown>
+        <small class="text-gray-500">Filtra facturas, comprobantes y bajas contabilizados o anulados.</small>
       </div>
 
       <div class="flex flex-col gap-2 md:col-span-2 lg:col-span-3">
         <div class="flex flex-wrap gap-2 justify-end mt-2">
-          <p-button
-            label="Generar reporte"
-            icon="pi pi-chart-bar"
-            severity="success"
-            [loading]="loading"
-            (onClick)="loadVendorReport()">
-          </p-button>
           <p-button
             label="Limpiar filtros"
             icon="pi pi-filter-slash"
@@ -294,6 +288,6 @@
   <div *ngIf="!loading && !vendorReport" class="text-center py-12">
     <i class="pi pi-info-circle text-6xl text-gray-400 mb-4"></i>
     <h3 class="text-xl font-semibold text-gray-600 mb-2">{{ emptyFiltersMessage }}</h3>
-    <p class="text-gray-500">Ajuste los filtros y pulse «Generar reporte»</p>
+    <p class="text-gray-500">Ajuste los filtros para actualizar el reporte automáticamente</p>
   </div>
 </div>

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.spec.ts
@@ -1,3 +1,6 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
 import { VendorReport, VendorReportTransaction } from '../../Models/VendorReport';
 import { VendorReportComponent } from './vendor-report.component';
 
@@ -47,6 +50,39 @@ describe('VendorReportComponent document status filter', () => {
     } satisfies VendorReport;
     component.visibleTransactions = [];
     return component;
+  }
+
+  function interactiveComponent(transactions: VendorReportTransaction[] = rows) {
+    const report = componentWith(transactions).vendorReport!;
+    const service = jasmine.createSpyObj('VendorReportService', [
+      'getVendorReport',
+      'getInvoiceOptions',
+      'exportToPdf',
+    ]);
+    service.getVendorReport.and.returnValue(of(report));
+    service.getInvoiceOptions.and.returnValue(of([]));
+    service.exportToPdf.and.returnValue(new Blob(['pdf'], { type: 'application/pdf' }));
+    const exportService = jasmine.createSpyObj('TreasuryExportService', [
+      'triggerBrowserDownload',
+      'downloadCsv',
+      'formatDate',
+    ]);
+    exportService.formatDate.and.callFake((value: Date) => value.toISOString());
+    const messageService = jasmine.createSpyObj('MessageService', ['add']);
+    const component = new VendorReportComponent(
+      new FormBuilder(),
+      {} as any,
+      jasmine.createSpyObj('Router', ['navigate']),
+      service,
+      messageService,
+      exportService,
+    );
+    component.vendorId = 4;
+    component.vendorName = 'Libardo Pantoja';
+    component.initializeDateRangeForm();
+    component.vendorReport = report;
+    component.visibleTransactions = [...transactions];
+    return { component, service, exportService };
   }
 
   const rows = [
@@ -126,5 +162,115 @@ describe('VendorReportComponent document status filter', () => {
       severity: 'danger',
       text: 'Factura (Anulada)',
     });
+  });
+
+  it('filters status immediately without requesting the backend', () => {
+    const { component, service } = interactiveComponent();
+
+    component.dateRangeForm.get('status')!.setValue('VOIDED');
+
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-VOIDED']);
+    expect(service.getVendorReport).not.toHaveBeenCalled();
+  });
+
+  it('does not request while either date is missing or the range is invalid', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+
+    component.dateRangeForm.get('startDate')!.setValue(null);
+    tick(400);
+    component.dateRangeForm.patchValue(
+      { startDate: new Date(2026, 7, 31), endDate: new Date(2026, 7, 1) },
+      { emitEvent: true },
+    );
+    tick(400);
+
+    expect(service.getVendorReport).not.toHaveBeenCalled();
+  }));
+
+  it('requests automatically when the complete date range is valid', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+    component.dateRangeForm.patchValue(
+      { startDate: new Date(2026, 7, 1), endDate: new Date(2026, 7, 31) },
+      { emitEvent: false },
+    );
+
+    component.dateRangeForm.get('endDate')!.setValue(new Date(2026, 7, 30));
+    tick(399);
+    expect(service.getVendorReport).not.toHaveBeenCalled();
+    tick(1);
+
+    expect(service.getVendorReport).toHaveBeenCalledTimes(1);
+  }));
+
+  it('debounces rapid invoice or text filter changes', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+
+    component.dateRangeForm.get('invoice')!.setValue('F');
+    tick(200);
+    component.dateRangeForm.get('invoice')!.setValue('FC');
+    tick(399);
+    expect(service.getVendorReport).not.toHaveBeenCalled();
+    tick(1);
+
+    expect(service.getVendorReport).toHaveBeenCalledTimes(1);
+    expect(service.getVendorReport.calls.mostRecent().args[3]).toBe('FC');
+  }));
+
+  it('combines the backend invoice filter with the local status filter', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+
+    component.dateRangeForm.get('status')!.setValue('VOIDED');
+    component.dateRangeForm.get('invoice')!.setValue('FC-VOIDED');
+    tick(400);
+
+    expect(service.getVendorReport).toHaveBeenCalledTimes(1);
+    expect(component.visibleTransactions.map((row) => row.reference)).toEqual(['FC-VOIDED']);
+  }));
+
+  it('clears every filter, restores all rows and performs only one request', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+    component.dateRangeForm.get('status')!.setValue('VOIDED');
+    component.dateRangeForm.get('invoice')!.setValue('FC-VOIDED');
+
+    component.clearFilters();
+    tick(400);
+
+    expect(component.dateRangeForm.get('status')!.value).toBe('');
+    expect(component.dateRangeForm.get('invoice')!.value).toBeNull();
+    expect(component.visibleTransactions).toEqual(rows);
+    expect(service.getVendorReport).toHaveBeenCalledTimes(1);
+  }));
+
+  it('coalesces multiple backend filter changes into one request', fakeAsync(() => {
+    const { component, service } = interactiveComponent();
+
+    component.dateRangeForm.get('startDate')!.setValue(new Date(2026, 7, 1));
+    component.dateRangeForm.get('endDate')!.setValue(new Date(2026, 7, 31));
+    component.dateRangeForm.get('invoice')!.setValue('FC-VOIDED');
+    tick(400);
+
+    expect(service.getVendorReport).toHaveBeenCalledTimes(1);
+  }));
+
+  it('exports exactly the currently visible transactions', () => {
+    const { component, service, exportService } = interactiveComponent();
+    component.dateRangeForm.get('status')!.setValue('VOIDED');
+
+    component.exportToPdf();
+
+    const exportedReport = service.exportToPdf.calls.mostRecent().args[0] as VendorReport;
+    expect(exportedReport.transactions.map((row) => row.reference)).toEqual(['FC-VOIDED']);
+    expect(exportService.triggerBrowserDownload).toHaveBeenCalled();
+  });
+
+  it('keeps CSV export aligned with the currently visible transactions', () => {
+    const { component, exportService } = interactiveComponent();
+    component.dateRangeForm.get('status')!.setValue('VOIDED');
+
+    component.exportToCsv();
+
+    const csv = exportService.downloadCsv.calls.mostRecent().args[0];
+    expect(csv.rows.length).toBe(1);
+    expect(csv.rows[0][2]).toBe('FC-VOIDED');
   });
 });

--- a/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
+++ b/src/app/Financial/Treasury/Reports/VendorReports/Components/vendor-report/vendor-report.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -26,6 +26,7 @@ import {
   voucherStatusLabel,
 } from '../../../../Shared/treasury-status-labels';
 import { TreasuryExportService } from '../../../../Shared/treasury-export.service';
+import { debounceTime, merge, Subject, takeUntil } from 'rxjs';
 
 interface FilterOption {
   label: string;
@@ -55,7 +56,7 @@ interface FilterOption {
   styleUrls: ['./vendor-report.component.css'],
   providers: [MessageService],
 })
-export class VendorReportComponent implements OnInit {
+export class VendorReportComponent implements OnInit, OnDestroy {
   vendorReport: VendorReport | null = null;
   visibleTransactions: VendorReportTransaction[] = [];
   loading = false;
@@ -67,6 +68,8 @@ export class VendorReportComponent implements OnInit {
 
   dateRangeForm!: FormGroup;
   invoiceOptions: FilterOption[] = [];
+  private readonly backendFilterChanges$ = new Subject<void>();
+  private readonly destroy$ = new Subject<void>();
 
   statusOptions: FilterOption[] = [
     { label: 'Todos los documentos', value: '' },
@@ -97,6 +100,11 @@ export class VendorReportComponent implements OnInit {
     this.getRouteParams();
   }
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   initializeDateRangeForm(): void {
     const today = new Date();
     const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -109,9 +117,31 @@ export class VendorReportComponent implements OnInit {
       status: [''],
     });
 
-    this.dateRangeForm.get('periodPreset')?.valueChanges.subscribe((preset) => {
-      if (preset) this.applyPeriodPreset(preset);
-    });
+    this.backendFilterChanges$
+      .pipe(debounceTime(400), takeUntil(this.destroy$))
+      .subscribe(() => {
+        if (this.hasCompleteValidDateRange()) this.loadVendorReport();
+      });
+
+    this.dateRangeForm.get('periodPreset')?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((preset) => {
+        if (!preset) return;
+        this.applyPeriodPreset(preset);
+        this.queueBackendReload();
+      });
+
+    merge(
+      this.dateRangeForm.get('startDate')!.valueChanges,
+      this.dateRangeForm.get('endDate')!.valueChanges,
+      this.dateRangeForm.get('invoice')!.valueChanges,
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.queueBackendReload());
+
+    this.dateRangeForm.get('status')?.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((status) => this.applyDocumentStatusFilter(status));
   }
 
   getRouteParams(): void {
@@ -166,14 +196,7 @@ export class VendorReportComponent implements OnInit {
   }
 
   loadVendorReport(): void {
-    if (!this.dateRangeForm.valid || !this.vendorId) {
-      this.messageService.add({
-        severity: 'warn',
-        summary: 'Advertencia',
-        detail: 'Seleccione un rango de fechas válido',
-      });
-      return;
-    }
+    if (!this.hasCompleteValidDateRange() || !this.vendorId) return;
 
     const formValue = this.dateRangeForm.value;
     this.loading = true;
@@ -215,14 +238,18 @@ export class VendorReportComponent implements OnInit {
   clearFilters(): void {
     const today = new Date();
     const firstDayOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
-    this.dateRangeForm.reset({
-      periodPreset: 'THIS_MONTH',
-      startDate: firstDayOfMonth,
-      endDate: today,
-      invoice: null,
-      status: '',
-    });
-    this.loadVendorReport();
+    this.dateRangeForm.reset(
+      {
+        periodPreset: 'THIS_MONTH',
+        startDate: firstDayOfMonth,
+        endDate: today,
+        invoice: null,
+        status: '',
+      },
+      { emitEvent: false },
+    );
+    this.applyDocumentStatusFilter('');
+    this.queueBackendReload();
   }
 
   applyDocumentStatusFilter(status: string | null | undefined): void {
@@ -252,11 +279,12 @@ export class VendorReportComponent implements OnInit {
   }
 
   exportToPdf(): void {
-    if (!this.vendorReport) return;
+    const report = this.currentReportForExport();
+    if (!report) return;
     this.exportingPdf = true;
     try {
       this.exportService.triggerBrowserDownload(
-        this.vendorReportService.exportToPdf(this.vendorReport),
+        this.vendorReportService.exportToPdf(report),
         this.exportFileName('pdf'),
       );
       this.messageService.add({
@@ -292,7 +320,7 @@ export class VendorReportComponent implements OnInit {
         'Créditos',
         'Saldo',
       ];
-      const rows = this.vendorReport.transactions.map((transaction) => [
+      const rows = this.visibleTransactions.map((transaction) => [
         this.formatDate(transaction.date),
         transaction.dueDate ? this.formatDate(transaction.dueDate) : '-',
         transaction.reference || '-',
@@ -333,6 +361,26 @@ export class VendorReportComponent implements OnInit {
   private exportFileName(ext: string): string {
     const safeName = this.vendorName.replace(/[^a-zA-Z0-9_-]/g, '_');
     return `estado_cuenta_${safeName}_${new Date().toISOString().slice(0, 10)}.${ext}`;
+  }
+
+  private queueBackendReload(): void {
+    this.backendFilterChanges$.next();
+  }
+
+  private hasCompleteValidDateRange(): boolean {
+    const startDate = this.dateRangeForm?.get('startDate')?.value;
+    const endDate = this.dateRangeForm?.get('endDate')?.value;
+    return startDate instanceof Date
+      && endDate instanceof Date
+      && !Number.isNaN(startDate.getTime())
+      && !Number.isNaN(endDate.getTime())
+      && startDate <= endDate;
+  }
+
+  private currentReportForExport(): VendorReport | null {
+    return this.vendorReport
+      ? { ...this.vendorReport, transactions: [...this.visibleTransactions] }
+      : null;
   }
 
   getTransactionTypeTag(type: VendorReportTransaction['type'], voided?: boolean): {


### PR DESCRIPTION
## Causa ra?z

Los filtros del estado de cuenta depend?an del bot?n Generar reporte. En particular, Estado documento solo se aplicaba despu?s de una recarga y no reaccionaba al cambio del selector, aunque el filtrado ya pod?a hacerse sobre las filas cargadas.

## Correcci?n

- Estado documento filtra localmente e inmediatamente, sin petici?n HTTP adicional.
- Periodo, fechas y factura/referencia recargan autom?ticamente con debounce de 400 ms.
- No se consulta con fechas incompletas, inv?lidas o invertidas.
- Los cambios agrupados y Limpiar filtros se consolidan en una sola petici?n.
- Se elimin? el bot?n Generar reporte y su texto residual.
- Limpiar filtros restaura valores iniciales y todos los movimientos.
- PDF y CSV exportan exactamente las transacciones visibles.
- El cambio se limita a financial/treasury/reports/vendor-report/:id.

## Validaci?n

- pruebas focales del componente: 17/17;
- componente + servicio/mapper: 30/31; el ?nico fallo es el fixture hist?rico con diferencia aritm?tica de 20 pesos;
- suite Treasury Angular: 187/191;
- los cuatro fallos restantes son preexistentes: tres fixtures de ExpenseReceiptCreationComponent y la conciliaci?n hist?rica del vendor report;
- build Angular: correcto;
- git diff --check: correcto.

No se modificaron backend, Gateway, otros reportes ni estilos generales.
